### PR TITLE
Expand Framework Detection

### DIFF
--- a/src/framework_detector.py
+++ b/src/framework_detector.py
@@ -1,20 +1,189 @@
 import os
 
 FRAMEWORK_KEYWORDS = {
+    # Python Web Frameworks
     "Django": ["django"],
     "Flask": ["flask"],
     "FastAPI": ["fastapi"],
     "Pyramid": ["pyramid"],
+    "Tornado": ["tornado"],
+    "Bottle": ["bottle"],
+    "CherryPy": ["cherrypy"],
+    "Sanic": ["sanic"],
+    "Starlette": ["starlette"],
+    "Quart": ["quart"],
+    "aiohttp": ["aiohttp"],
+
+    # Python Data/ML/Visualization Frameworks
+    "Streamlit": ["streamlit"],
+    "Dash": ["dash"],
+    "Gradio": ["gradio"],
+    "Reflex": ["reflex"],
+    "Plotly": ["plotly"],
+    "Bokeh": ["bokeh"],
+
+    # Python Testing
+    "Pytest": ["pytest"],
+    "Unittest": ["unittest"],
+    "Nose": ["nose", "nose2"],
+    "Behave": ["behave"],
+    "Robot Framework": ["robotframework"],
+
+    # Python ORM/Database
+    "SQLAlchemy": ["sqlalchemy"],
+    "Django ORM": ["django.db"],
+    "Peewee": ["peewee"],
+    "Tortoise ORM": ["tortoise-orm"],
+    "Pony ORM": ["ponyorm"],
+
+    # Java/Spring Frameworks
     "Spring": ["spring-boot", "springframework"],
+    "Spring Boot": ["spring-boot"],
     "Hibernate": ["hibernate"],
-    "React": ["react", "react-dom", "react-scripts", "next", "gatsby", "remix"],
-    "Angular": ["@angular/core"],
-    "Vue": ["vue", "vite", "nuxt"],
+    "Struts": ["struts"],
+    "Play Framework": ["play-framework"],
+    "Micronaut": ["micronaut"],
+    "Quarkus": ["quarkus"],
+
+    # JavaScript/TypeScript Frontend Frameworks
+    "React": ["react", "react-dom", "react-scripts"],
     "Next.js": ["next"],
+    "Gatsby": ["gatsby"],
+    "Remix": ["@remix-run"],
+    "Angular": ["@angular/core"],
+    "Vue": ["vue"],
+    "Nuxt": ["nuxt"],
+    "Svelte": ["svelte"],
+    "SvelteKit": ["@sveltejs/kit"],
+    "SolidJS": ["solid-js"],
+    "Preact": ["preact"],
+    "Astro": ["astro"],
+    "Qwik": ["@builder.io/qwik"],
+    "Lit": ["lit"],
+    "Alpine.js": ["alpinejs"],
+    "Ember": ["ember"],
+    "Backbone": ["backbone"],
+
+    # JavaScript/TypeScript Backend Frameworks
     "Express": ["express"],
     "NestJS": ["@nestjs/core"],
-    "Tailwind CSS": ["tailwindcss", "tailwind.config.js", "tailwind.config.cjs"],
+    "Koa": ["koa"],
+    "Hapi": ["@hapi/hapi"],
+    "Fastify": ["fastify"],
+    "Adonis": ["@adonisjs/core"],
+    "Meteor": ["meteor"],
+    "Sails": ["sails"],
+    "LoopBack": ["loopback"],
+
+    # Mobile Frameworks
+    "React Native": ["react-native"],
+    "Expo": ["expo"],
+    "Flutter": ["flutter"],
+    "Ionic": ["@ionic/angular", "@ionic/react", "@ionic/vue"],
+    "Capacitor": ["@capacitor/core"],
+    "Cordova": ["cordova"],
+    "NativeScript": ["nativescript"],
+
+    # CSS Frameworks & Preprocessors
+    "Tailwind CSS": ["tailwindcss"],
     "Bootstrap": ["bootstrap"],
+    "Material-UI": ["@mui/material", "@material-ui/core"],
+    "Ant Design": ["antd"],
+    "Chakra UI": ["@chakra-ui/react"],
+    "Bulma": ["bulma"],
+    "Foundation": ["foundation-sites"],
+    "Semantic UI": ["semantic-ui"],
+    "Sass": ["sass", "node-sass"],
+    "Less": ["less"],
+    "Styled Components": ["styled-components"],
+    "Emotion": ["@emotion/react"],
+
+    # JavaScript Testing Frameworks
+    "Jest": ["jest"],
+    "Mocha": ["mocha"],
+    "Jasmine": ["jasmine"],
+    "Karma": ["karma"],
+    "Cypress": ["cypress"],
+    "Playwright": ["@playwright/test"],
+    "Puppeteer": ["puppeteer"],
+    "TestCafe": ["testcafe"],
+    "Vitest": ["vitest"],
+    "AVA": ["ava"],
+
+    # Java Testing
+    "JUnit": ["junit"],
+    "TestNG": ["testng"],
+    "Mockito": ["mockito"],
+
+    # Build Tools & Bundlers
+    "Webpack": ["webpack"],
+    "Vite": ["vite"],
+    "Rollup": ["rollup"],
+    "Parcel": ["parcel"],
+    "esbuild": ["esbuild"],
+    "Turbopack": ["turbopack"],
+    "Snowpack": ["snowpack"],
+    "Gulp": ["gulp"],
+    "Grunt": ["grunt"],
+    "Browserify": ["browserify"],
+
+    # State Management
+    "Redux": ["redux", "@reduxjs/toolkit"],
+    "MobX": ["mobx"],
+    "Zustand": ["zustand"],
+    "Recoil": ["recoil"],
+    "Jotai": ["jotai"],
+    "XState": ["xstate"],
+    "Pinia": ["pinia"],
+    "Vuex": ["vuex"],
+    "NgRx": ["@ngrx/store"],
+
+    # ORM/Database Libraries (JS/TS)
+    "Prisma": ["prisma", "@prisma/client"],
+    "TypeORM": ["typeorm"],
+    "Sequelize": ["sequelize"],
+    "Mongoose": ["mongoose"],
+    "Knex": ["knex"],
+    "Drizzle": ["drizzle-orm"],
+
+    # API & GraphQL
+    "GraphQL": ["graphql"],
+    "Apollo": ["@apollo/client", "apollo-server"],
+    "tRPC": ["@trpc/server"],
+    "Axios": ["axios"],
+    "React Query": ["@tanstack/react-query"],
+    "SWR": ["swr"],
+
+    # PHP Frameworks
+    "Laravel": ["laravel/framework"],
+    "Symfony": ["symfony"],
+    "CodeIgniter": ["codeigniter"],
+    "Yii": ["yiisoft/yii2"],
+    "CakePHP": ["cakephp"],
+
+    # Ruby Frameworks
+    "Ruby on Rails": ["rails"],
+    "Sinatra": ["sinatra"],
+    "Hanami": ["hanami"],
+
+    # .NET Frameworks
+    "ASP.NET": ["microsoft.aspnetcore"],
+    "Entity Framework": ["entityframework"],
+
+    # Other Popular Tools
+    "Electron": ["electron"],
+    "Tauri": ["tauri"],
+    "Three.js": ["three"],
+    "D3.js": ["d3"],
+    "Chart.js": ["chart.js"],
+    "Socket.io": ["socket.io"],
+    "Lodash": ["lodash"],
+    "Moment.js": ["moment"],
+    "Date-fns": ["date-fns"],
+    "Babel": ["@babel/core"],
+    "TypeScript": ["typescript"],
+    "ESLint": ["eslint"],
+    "Prettier": ["prettier"],
 }
 
 def detect_frameworks(conn, project_name, user_id,zip_path):

--- a/tests/test_framework_detector.py
+++ b/tests/test_framework_detector.py
@@ -60,6 +60,26 @@ def _cleanup_zip_data(zip_name):
         except OSError:
             pass
 
+def _test_framework_detection(conn, zip_name, file_path, file_content, project_name, user_id, expected_frameworks):
+    """Helper function to reduce test boilerplate."""
+    try:
+        _make_zip_data_file(zip_name, file_path, file_content)
+        cur = conn.cursor()
+        cur.execute(
+            "INSERT INTO config_files (file_name, file_path, user_id, project_name) VALUES (?, ?, ?, ?)",
+            (os.path.basename(file_path), file_path, user_id, project_name),
+        )
+        conn.commit()
+
+        frameworks = fd.detect_frameworks(conn, project_name, user_id, zip_name + ".zip")
+
+        for fw in expected_frameworks:
+            assert fw in frameworks, f"Expected {fw} but got {frameworks}"
+
+        return frameworks
+    finally:
+        _cleanup_zip_data(zip_name)
+
 # Test cases
 def test_missing_config_file_is_skipped(conn):
     """Handles cases where a config file listed in DB is missing on disk."""
@@ -103,56 +123,70 @@ def test_unreadable_config_entry_is_handled_gracefully(conn):
 
 def test_detects_single_framework(conn):
     """Detects Flask from requirements.txt"""
-    zip_name = "flask_version_zip"
-    try:
-        _make_zip_data_file(zip_name, "requirements.txt", "Flask==2.2.5\n")
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO config_files (file_name, file_path, user_id, project_name) VALUES (?, ?, ?, ?)",
-            ("requirements.txt", "requirements.txt", 10, "basicProj"),
-        )
-        conn.commit()
-
-        frameworks = fd.detect_frameworks(conn, "basicProj", 10, zip_name + ".zip")
-        assert "Flask" in frameworks
-        # ensure no unrelated frameworks detected
-        assert "Django" not in frameworks
-    finally:
-        _cleanup_zip_data(zip_name)
+    frameworks = _test_framework_detection(
+        conn, "flask_version_zip", "requirements.txt", "Flask==2.2.5\n",
+        "basicProj", 10, ["Flask"]
+    )
+    assert "Django" not in frameworks
 
 def test_detects_multiple_frameworks_in_one_project(conn):
     """Detects both Flask and Django from requirements.txt"""
-    zip_name = "multi_frameworks_zip"
-    try:
-        # requirements containing both Flask and Django
-        _make_zip_data_file(zip_name, "requirements.txt", "Flask==2.2.5\nDjango>=3.2\n")
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO config_files (file_name, file_path, user_id, project_name) VALUES (?, ?, ?, ?)",
-            ("requirements.txt", "requirements.txt", 11, "multiProj"),
-        )
-        conn.commit()
-
-        frameworks = fd.detect_frameworks(conn, "multiProj", 11, zip_name + ".zip")
-        assert "Flask" in frameworks
-        assert "Django" in frameworks
-    finally:
-        _cleanup_zip_data(zip_name)
+    _test_framework_detection(
+        conn, "multi_frameworks_zip", "requirements.txt", "Flask==2.2.5\nDjango>=3.2\n",
+        "multiProj", 11, ["Flask", "Django"]
+    )
 
 def test_no_frameworks_present_returns_empty(conn):
     """Returns empty set when no known frameworks are detected."""
-    zip_name = "no_frameworks_zip"
-    try:
-        # requirements with unrelated packages
-        _make_zip_data_file(zip_name, "requirements.txt", "requests==2.31.0\nnumpy==1.24.0\n")
-        cur = conn.cursor()
-        cur.execute(
-            "INSERT INTO config_files (file_name, file_path, user_id, project_name) VALUES (?, ?, ?, ?)",
-            ("requirements.txt", "requirements.txt", 12, "emptyProj"),
-        )
-        conn.commit()
+    frameworks = _test_framework_detection(
+        conn, "no_frameworks_zip", "requirements.txt", "requests==2.31.0\nnumpy==1.24.0\n",
+        "emptyProj", 12, []
+    )
+    assert frameworks == set()
 
-        frameworks = fd.detect_frameworks(conn, "emptyProj", 12, zip_name + ".zip")
-        assert frameworks == set()
-    finally:
-        _cleanup_zip_data(zip_name)
+def test_detects_python_web_frameworks(conn):
+    """Detects multiple Python web frameworks from requirements.txt"""
+    _test_framework_detection(
+        conn, "python_web_zip", "requirements.txt", "FastAPI==0.100.0\nstreamlit==1.24.0\ntornado>=6.0\n",
+        "pyWebProj", 20, ["FastAPI", "Streamlit", "Tornado"]
+    )
+
+def test_detects_javascript_frameworks_from_package_json(conn):
+    """Detects JavaScript frameworks from package.json"""
+    _test_framework_detection(
+        conn, "js_frameworks_zip", "package.json",
+        '{"dependencies": {"react": "^18.2.0", "next": "^13.0.0", "axios": "^1.4.0"}, "devDependencies": {"jest": "^29.0.0", "cypress": "^12.0.0"}}',
+        "jsProj", 21, ["React", "Next.js", "Axios", "Jest", "Cypress"]
+    )
+
+def test_detects_orm_and_state_management(conn):
+    """Detects ORM and state management libraries"""
+    _test_framework_detection(
+        conn, "orm_state_zip", "package.json",
+        '{"dependencies": {"prisma": "^5.0.0", "@prisma/client": "^5.0.0", "redux": "^4.2.0", "zustand": "^4.3.0"}}',
+        "ormProj", 22, ["Prisma", "Redux", "Zustand"]
+    )
+
+def test_detects_mobile_frameworks(conn):
+    """Detects mobile frameworks"""
+    _test_framework_detection(
+        conn, "mobile_zip", "package.json",
+        '{"dependencies": {"react-native": "^0.72.0", "expo": "^49.0.0"}}',
+        "mobileProj", 23, ["React Native", "Expo"]
+    )
+
+def test_detects_css_frameworks(conn):
+    """Detects CSS frameworks and preprocessors"""
+    _test_framework_detection(
+        conn, "css_zip", "package.json",
+        '{"dependencies": {"@mui/material": "^5.14.0", "styled-components": "^6.0.0"}, "devDependencies": {"sass": "^1.64.0"}}',
+        "cssProj", 24, ["Material-UI", "Styled Components", "Sass"]
+    )
+
+def test_detects_build_tools(conn):
+    """Detects build tools and bundlers"""
+    _test_framework_detection(
+        conn, "build_tools_zip", "package.json",
+        '{"devDependencies": {"vite": "^4.4.0", "webpack": "^5.88.0", "esbuild": "^0.18.0"}}',
+        "buildProj", 25, ["Vite", "Webpack", "esbuild"]
+    )


### PR DESCRIPTION
<!--
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR significantly expands the framework detection capabilities of our project analysis system, increasing coverage from 14 frameworks to over 100 frameworks and tools across multiple ecosystems.

### What Changed

**Framework Detection Expansion** (`src/framework_detector.py`):
- Expanded `FRAMEWORK_KEYWORDS` dictionary from 14 to 100+ frameworks
- Added support for 19 framework categories including:
  - Python web frameworks (Django, Flask, FastAPI, Tornado, Sanic, etc.)
  - Python data/ML frameworks (Streamlit, Dash, Gradio, Plotly, etc.)
  - JavaScript/TypeScript frontend (React, Vue, Svelte, SolidJS, Astro, Qwik, etc.)
  - JavaScript/TypeScript backend (Express, NestJS, Fastify, Koa, Hapi, etc.)
  - and lots more....

**Test Cases** (`tests/test_framework_detector.py`):
- Created reusable helper function `_test_framework_detection()` to eliminate boilerplate
- Added 6 new test cases covering newly added frameworks

### Limitations & Expected Behavior

**What This Detects:**
- Frameworks and tools listed in **config files** (requirements.txt, package.json, pom.xml, etc.)
- Focus is on frameworks, build tools, testing libraries, and development dependencies

**What This Does NOT Detect:**
- Programming languages (use language_detector.py for that - e.g., "Python", "JavaScript")
- Markup languages (HTML, CSS, Markdown are not frameworks)
- Frameworks loaded via CDN links in HTML files (barebones HTML/CSS projects won't show frameworks)
- Frameworks not listed in config files

**Closes:** #131

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests
All existing and new tests pass:
- [x] **192/192 total project tests passing**
- [x] Tests cover: single framework detection, multiple frameworks, Python/JS frameworks, mobile, CSS, build tools, ORM, state management
- [x] Edge cases: missing config files, unreadable entries, no frameworks present

### Manual Testing Instructions

**Download Sample Test Data:**
A sample ZIP file is available [here](https://drive.google.com/file/d/1LGDK3PHj8vm9CF9w-uHVrm8as6VQpg4c/view?usp=sharing)

This contains 3 test projects:
1. **python_flask_project** - Flask + SQLAlchemy + Pytest
2. **react_nextjs_project** - React + Next.js + Material-UI + Zustand + Jest + Cypress + ESLint + Prettier
3. **mixed_frameworks_project** - Django + FastAPI + Streamlit + Vue + Vite + Tailwind + Prisma + Vitest + Playwright

**Steps to Test:**

```
# 1. Accept consent prompts
# User consent: yes
# External consent: no (or yes, doesn't matter for this feature)

# 2. Select the sample ZIP

# 3. Observe framework detection output
# Look for lines like:
# "Frameworks detected in python_flask_project: {'Flask', 'SQLAlchemy', 'Pytest'}"
# "Frameworks detected in react_nextjs_project: {'React', 'Next.js', 'Axios', ...}"
```

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile (N/A - CLI only)

---

## 📸 Screenshots

<details>
<summary>Click to expand output</summary>

Project 1:
<img width="604" height="211" alt="Screenshot 2025-11-05 at 12 44 32 PM" src="https://github.com/user-attachments/assets/8357369a-48f7-4902-b621-b68c87dbd846" />

Project 2:
<img width="759" height="69" alt="Screenshot 2025-11-05 at 12 44 48 PM" src="https://github.com/user-attachments/assets/1912d64d-3c95-433a-a42e-cfa95089f7f2" />

Project 3:
<img width="768" height="65" alt="Screenshot 2025-11-05 at 12 44 58 PM" src="https://github.com/user-attachments/assets/fd8dd397-7107-4781-b72a-f88198f8514a" />

</details>
