### PR TITLE
Store non llm text metrics

### DIFF
--- a/src/alt_analyze.py
+++ b/src/alt_analyze.py
@@ -296,9 +296,15 @@ def alternative_analysis(parsed_files, zip_path, project_name=None):
             print(f"  {user_summary}\n")
             print(f"{'─'*80}\n")
 
-        display_project_summary(calculate_project_metrics(all_document_metrics))
+        project_metrics = calculate_project_metrics(all_document_metrics)
+        display_project_summary(project_metrics)
+        return {
+            "project_summary": project_metrics,
+            "documents": all_document_metrics,
+        }
     else:
         print("\nNo files were successfully processed.")
+        return None
 
 def display_individual_results(filename: str, doc_metrics: dict):
     """Display analysis results for an individual file."""
@@ -378,6 +384,5 @@ def display_all_projects_summary(all_projects_results: List[Dict]):
         print(f"    Reading Level: {summary['reading_level_label']} (Grade {summary['reading_level_average']})")
 
     print(f"\n{'='*80}\n")
-
 
 

--- a/src/db.py
+++ b/src/db.py
@@ -386,13 +386,13 @@ def get_classification_id(conn: sqlite3.Connection, user_id: int, project_name: 
 def store_text_offline_metrics(
     conn: sqlite3.Connection,
     classification_id: int,
-    project_metrics: dict,
+    project_metrics: dict | None,
 ) -> None:
     if not classification_id or not project_metrics:
         return
 
-    summary_block = project_metrics.get("summary", {}) or {}
-    keywords = project_metrics.get("keywords", []) or []
+    summary_block = project_metrics.get("summary") or {}
+    keywords = project_metrics.get("keywords")
 
     doc_count = summary_block.get("total_documents")
     total_words = summary_block.get("total_words")
@@ -400,39 +400,81 @@ def store_text_offline_metrics(
     reading_level_label = summary_block.get("reading_level_label")
 
     summary_json = json.dumps(project_metrics, ensure_ascii=False)
-    keywords_json = json.dumps(keywords, ensure_ascii=False)
+    keywords_json = json.dumps(keywords, ensure_ascii=False) if keywords is not None else None
 
-    conn.execute(
+    existing = conn.execute(
         """
-        INSERT INTO text_offline_metrics (
-            classification_id,
-            doc_count,
-            total_words,
-            reading_level_avg,
-            reading_level_label,
-            keywords_json,
-            summary_json,
-            generated_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
-        ON CONFLICT(classification_id) DO UPDATE SET
-            doc_count = excluded.doc_count,
-            total_words = excluded.total_words,
-            reading_level_avg = excluded.reading_level_avg,
-            reading_level_label = excluded.reading_level_label,
-            keywords_json = excluded.keywords_json,
-            summary_json = excluded.summary_json,
-            generated_at = excluded.generated_at
+        SELECT doc_count,
+               total_words,
+               reading_level_avg,
+               reading_level_label,
+               keywords_json,
+               summary_json
+        FROM text_offline_metrics
+        WHERE classification_id = ?
         """,
-        (
-            classification_id,
-            doc_count,
-            total_words,
-            reading_level_avg,
-            reading_level_label,
-            keywords_json,
-            summary_json,
-        ),
-    )
+        (classification_id,),
+    ).fetchone()
+
+    if existing:
+        doc_count = doc_count if doc_count is not None else existing[0]
+        total_words = total_words if total_words is not None else existing[1]
+        reading_level_avg = reading_level_avg if reading_level_avg is not None else existing[2]
+        reading_level_label = reading_level_label if reading_level_label is not None else existing[3]
+        keywords_json = keywords_json if keywords_json is not None else existing[4]
+        summary_json = summary_json if summary_json is not None else existing[5]
+
+        conn.execute(
+            """
+            UPDATE text_offline_metrics
+            SET doc_count = ?,
+                total_words = ?,
+                reading_level_avg = ?,
+                reading_level_label = ?,
+                keywords_json = ?,
+                summary_json = ?,
+                generated_at = datetime('now')
+            WHERE classification_id = ?
+            """,
+            (
+                doc_count,
+                total_words,
+                reading_level_avg,
+                reading_level_label,
+                keywords_json,
+                summary_json,
+                classification_id,
+            ),
+        )
+    else:
+        if keywords_json is None:
+            keywords_json = json.dumps([], ensure_ascii=False)
+        if summary_json is None:
+            summary_json = json.dumps({}, ensure_ascii=False)
+
+        conn.execute(
+            """
+            INSERT INTO text_offline_metrics (
+                classification_id,
+                doc_count,
+                total_words,
+                reading_level_avg,
+                reading_level_label,
+                keywords_json,
+                summary_json,
+                generated_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            """,
+            (
+                classification_id,
+                doc_count,
+                total_words,
+                reading_level_avg,
+                reading_level_label,
+                keywords_json,
+                summary_json,
+            ),
+        )
     conn.commit()
     
 def save_token_placeholder(conn: sqlite3.Connection, user_id: int):

--- a/src/db.py
+++ b/src/db.py
@@ -140,7 +140,7 @@ def init_schema(conn: sqlite3.Connection) -> None:
     """)
 
     cur.execute("""
-    CREATE TABLE IF NOT EXISTS text_offline_metrics (
+    CREATE TABLE IF NOT EXISTS non_llm_text (
         metrics_id        INTEGER PRIMARY KEY AUTOINCREMENT,
         classification_id INTEGER UNIQUE NOT NULL,
         doc_count         INTEGER,
@@ -410,7 +410,7 @@ def store_text_offline_metrics(
                reading_level_label,
                keywords_json,
                summary_json
-        FROM text_offline_metrics
+        FROM non_llm_text
         WHERE classification_id = ?
         """,
         (classification_id,),
@@ -426,7 +426,7 @@ def store_text_offline_metrics(
 
         conn.execute(
             """
-            UPDATE text_offline_metrics
+            UPDATE non_llm_text
             SET doc_count = ?,
                 total_words = ?,
                 reading_level_avg = ?,
@@ -454,7 +454,7 @@ def store_text_offline_metrics(
 
         conn.execute(
             """
-            INSERT INTO text_offline_metrics (
+            INSERT INTO non_llm_text (
                 classification_id,
                 doc_count,
                 total_words,

--- a/tests/test_text_offline_metrics.py
+++ b/tests/test_text_offline_metrics.py
@@ -16,6 +16,21 @@ def _create_classification(conn, user_id, project_name="OfflineText"):
     return db.get_classification_id(conn, user_id, project_name)
 
 
+def _fetch_metrics(conn, classification_id):
+    return conn.execute(
+        """
+        SELECT doc_count,
+               total_words,
+               reading_level_avg,
+               reading_level_label,
+               keywords_json
+        FROM text_offline_metrics
+        WHERE classification_id = ?
+        """,
+        (classification_id,),
+    ).fetchone()
+
+
 def test_store_text_offline_metrics_upserts(shared_db):
     conn = db.connect()
     user_id = db.get_or_create_user(conn, "metrics-user")
@@ -36,15 +51,7 @@ def test_store_text_offline_metrics_upserts(shared_db):
 
     db.store_text_offline_metrics(conn, classification_id, metrics_payload)
 
-    row = conn.execute(
-        """
-        SELECT doc_count, total_words, reading_level_avg, reading_level_label, keywords_json
-        FROM text_offline_metrics
-        WHERE classification_id = ?
-        """,
-        (classification_id,),
-    ).fetchone()
-
+    row = _fetch_metrics(conn, classification_id)
     assert row[0] == 3
     assert row[1] == 1500
     assert row[2] == 10.2
@@ -55,8 +62,52 @@ def test_store_text_offline_metrics_upserts(shared_db):
     metrics_payload["summary"]["total_documents"] = 4
     db.store_text_offline_metrics(conn, classification_id, metrics_payload)
 
-    updated = conn.execute(
-        "SELECT doc_count FROM text_offline_metrics WHERE classification_id = ?",
-        (classification_id,),
-    ).fetchone()
+    updated = _fetch_metrics(conn, classification_id)
     assert updated[0] == 4
+
+
+def test_store_text_offline_metrics_preserves_existing_fields(shared_db):
+    conn = db.connect()
+    user_id = db.get_or_create_user(conn, "metrics-preserve-user")
+    classification_id = _create_classification(conn, user_id)
+
+    original_keywords = [{"word": "analysis", "score": 0.9}]
+    db.store_text_offline_metrics(
+        conn,
+        classification_id,
+        {
+            "summary": {"total_documents": 2},
+            "keywords": original_keywords,
+        },
+    )
+
+    # Second call omits keywords; existing ones should remain.
+    db.store_text_offline_metrics(
+        conn,
+        classification_id,
+        {
+            "summary": {"total_documents": 3},
+        },
+    )
+
+    row = _fetch_metrics(conn, classification_id)
+    assert row[0] == 3  # doc_count updated
+    assert json.loads(row[4]) == original_keywords  # keywords preserved
+
+
+def test_store_text_offline_metrics_requires_classification(shared_db):
+    conn = db.connect()
+    payload = {"summary": {"total_documents": 1}}
+    db.store_text_offline_metrics(conn, None, payload)
+
+    count = conn.execute("SELECT COUNT(*) FROM text_offline_metrics").fetchone()[0]
+    assert count == 0
+
+
+def test_store_text_offline_metrics_handles_missing_payload(shared_db):
+    conn = db.connect()
+    user_id = db.get_or_create_user(conn, "metrics-empty-user")
+    classification_id = _create_classification(conn, user_id)
+
+    db.store_text_offline_metrics(conn, classification_id, None)
+    assert _fetch_metrics(conn, classification_id) is None

--- a/tests/test_text_offline_metrics.py
+++ b/tests/test_text_offline_metrics.py
@@ -1,0 +1,62 @@
+import json
+import db
+
+
+def _create_classification(conn, user_id, project_name="OfflineText"):
+    zip_path = "/tmp/sample.zip"
+    zip_name = "sample"
+    db.record_project_classification(
+        conn=conn,
+        user_id=user_id,
+        zip_path=zip_path,
+        zip_name=zip_name,
+        project_name=project_name,
+        classification="individual",
+    )
+    return db.get_classification_id(conn, user_id, project_name)
+
+
+def test_store_text_offline_metrics_upserts(shared_db):
+    conn = db.connect()
+    user_id = db.get_or_create_user(conn, "metrics-user")
+    classification_id = _create_classification(conn, user_id)
+
+    metrics_payload = {
+        "summary": {
+            "total_documents": 3,
+            "total_words": 1500,
+            "reading_level_average": 10.2,
+            "reading_level_label": "College",
+        },
+        "keywords": [
+            {"word": "analysis", "score": 0.6},
+            {"word": "pipeline", "score": 0.4},
+        ],
+    }
+
+    db.store_text_offline_metrics(conn, classification_id, metrics_payload)
+
+    row = conn.execute(
+        """
+        SELECT doc_count, total_words, reading_level_avg, reading_level_label, keywords_json
+        FROM text_offline_metrics
+        WHERE classification_id = ?
+        """,
+        (classification_id,),
+    ).fetchone()
+
+    assert row[0] == 3
+    assert row[1] == 1500
+    assert row[2] == 10.2
+    assert row[3] == "College"
+    assert json.loads(row[4]) == metrics_payload["keywords"]
+
+    # Update to ensure upsert path works
+    metrics_payload["summary"]["total_documents"] = 4
+    db.store_text_offline_metrics(conn, classification_id, metrics_payload)
+
+    updated = conn.execute(
+        "SELECT doc_count FROM text_offline_metrics WHERE classification_id = ?",
+        (classification_id,),
+    ).fetchone()
+    assert updated[0] == 4

--- a/tests/test_text_offline_metrics.py
+++ b/tests/test_text_offline_metrics.py
@@ -24,7 +24,7 @@ def _fetch_metrics(conn, classification_id):
                reading_level_avg,
                reading_level_label,
                keywords_json
-        FROM text_offline_metrics
+        FROM non_llm_text
         WHERE classification_id = ?
         """,
         (classification_id,),
@@ -100,7 +100,7 @@ def test_store_text_offline_metrics_requires_classification(shared_db):
     payload = {"summary": {"total_documents": 1}}
     db.store_text_offline_metrics(conn, None, payload)
 
-    count = conn.execute("SELECT COUNT(*) FROM text_offline_metrics").fetchone()[0]
+    count = conn.execute("SELECT COUNT(*) FROM non_llm_text").fetchone()[0]
     assert count == 0
 
 


### PR DESCRIPTION
## 📝 Description

Stored offline text-analysis metrics so we can reuse results later. Added:
- `text_offline_metrics` table keyed to `project_classifications`
- DB helpers (`get_classification_id`, `store_text_offline_metrics`)
- `alternative_analysis` now returns its summary so `analyze_files` can persist it
- Unit test covering the helper

**Closes:** #187 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- `pytest`
- Manual CLI run (text project, no external consent) to confirm metrics rows are created.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works (pending `radon` install to execute)
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Not applicable (no UI changes)

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

<img width="691" height="130" alt="Screenshot 2025-11-08 at 9 09 54 PM" src="https://github.com/user-attachments/assets/c05d169e-9ff4-41b9-95cd-5ffd6194cd64" />

</details>
