### PR TITLE
Fix Google Drive word counting and speed up file linking

### DIFF
--- a/src/integrations/google_drive/google_drive_auth/link_files.py
+++ b/src/integrations/google_drive/google_drive_auth/link_files.py
@@ -12,6 +12,7 @@ except ImportError:
 
 from .file_matcher import (
     _search_supported_files_by_names,
+    _list_supported_drive_files,
     find_maybe_matches,
     search_by_name,
 )
@@ -33,11 +34,19 @@ def find_and_link_files(service: Resource,project_name: str,zip_files: List[str]
     selected_files: Dict[str, Tuple[str, str, str]] = {}
     not_found_files: List[str] = []
     
+    full_drive_cache: Dict[str, List[Dict]] = {"files": None}
+
+    def _load_full_drive_files() -> List[Dict]:
+        if full_drive_cache["files"] is None:
+            full_drive_cache["files"] = _list_supported_drive_files(service)
+        return full_drive_cache["files"]
+
     # Fetch only candidates that roughly match local file names (avoids scanning entire Drive)
     print(f"\nLoading candidate files from Google Drive...")
     base_names = {os.path.splitext(name)[0].lower() for name in zip_files}
     all_drive_files = _search_supported_files_by_names(service, list(base_names))
     all_drive_files_list = [(f['id'], f['name'], f['mimeType']) for f in all_drive_files]
+    expanded_drive_loaded = False
     
     print(f"Matching files from '{project_name}' with Google Drive...")
     print("=" * 60)
@@ -46,16 +55,31 @@ def find_and_link_files(service: Resource,project_name: str,zip_files: List[str]
     for idx, local_file_name in enumerate(zip_files, 1):
         print(f"\n[{idx}/{len(zip_files)}] Looking for: {local_file_name}")
         
-        # Find maybe matches
+        # Find maybe matches with the current (possibly narrowed) list
         maybe_matches = find_maybe_matches(local_file_name, project_name, all_drive_files)
+
+        # If none found, lazily load the full Drive list to enable browsing/search
+        if not maybe_matches and not expanded_drive_loaded:
+            print("  No candidate matches found; loading full Drive file list for browsing...")
+            all_drive_files = _list_supported_drive_files(service)
+            all_drive_files_list = [(f['id'], f['name'], f['mimeType']) for f in all_drive_files]
+            expanded_drive_loaded = True
+            maybe_matches = find_maybe_matches(local_file_name, project_name, all_drive_files)
         
         if maybe_matches:
             selected = select_from_matches(
-                local_file_name, maybe_matches, all_drive_files_list, search_by_name
+                local_file_name,
+                maybe_matches,
+                all_drive_files_list,
+                search_by_name,
+                load_all_drive_files=_load_full_drive_files,
             )
         else:
             print("  Couldn't find any files that might match.")
-            selected = handle_no_matches(local_file_name, all_drive_files_list, search_by_name)
+            # Ensure browse/search sees the full Drive list
+            full_drive_files = _load_full_drive_files()
+            full_drive_files_list = [(f['id'], f['name'], f['mimeType']) for f in full_drive_files]
+            selected = handle_no_matches(local_file_name, full_drive_files_list, search_by_name)
         
         if selected:
             selected_files[local_file_name] = selected

--- a/tests/test_link_files.py
+++ b/tests/test_link_files.py
@@ -39,10 +39,10 @@ def test_find_and_link_files_successful_matching(monkeypatch, conn, mock_service
     user_id = get_or_create_user(conn, "TestUser")
     
     # Mock file_selector functions to simulate user selecting matches
-    def mock_select_from_matches(local_name, matches, all_files, search_func):
+    def mock_select_from_matches(local_name, matches, all_files, search_func, **kwargs):
         return matches[0] if matches else None
     
-    def mock_handle_no_matches(local_name, all_files, search_func):
+    def mock_handle_no_matches(local_name, all_files, search_func, **kwargs):
         return None
     
     monkeypatch.setattr(
@@ -78,14 +78,14 @@ def test_find_and_link_files_partial_matching(monkeypatch, conn, mock_service):
     
     # Mock select_from_matches - return match for first, None for second
     call_count = [0]
-    def mock_select_from_matches(local_name, matches, all_files, search_func):
+    def mock_select_from_matches(local_name, matches, all_files, search_func, **kwargs):
         call_count[0] += 1
         if call_count[0] == 1:
             return matches[0] if matches else None
         else:
             return None
     
-    def mock_handle_no_matches(local_name, all_files, search_func):
+    def mock_handle_no_matches(local_name, all_files, search_func, **kwargs):
         return None
     
     monkeypatch.setattr(
@@ -121,10 +121,10 @@ def test_no_duplicate_storage(monkeypatch, conn, mock_service):
     """Test that files are not stored multiple times."""
     user_id = get_or_create_user(conn, "TestUser")
     
-    def mock_select_from_matches(local_name, matches, all_files, search_func):
+    def mock_select_from_matches(local_name, matches, all_files, search_func, **kwargs):
         return matches[0] if matches else None
     
-    def mock_handle_no_matches(local_name, all_files, search_func):
+    def mock_handle_no_matches(local_name, all_files, search_func, **kwargs):
         return None
     
     monkeypatch.setattr(


### PR DESCRIPTION
## 📝 Description
Optimized file linking: we now query only candidate files by base name (with MIME filters) instead of scanning the whole Drive, making the “Loading files…” faster. Fixed Google Docs revision counting to count words via whitespace tokens (with a fallback to doc export) instead of raw character length. Kept the rest of the Drive/text analysis flow unchanged aside from these fixes.

**Closes:** #270 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [x] ⚡ Performance improvement

---

## 🧪 Testing

Manually tested by running the collaborative text flow and see the words added column in `text_contribution_revisions` table.
Manually tested by running the collaborative text flow and measure how long it takes to connect to google drive file. Expected behavior: less than a second.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

<img width="1077" height="123" alt="Screenshot 2025-11-28 at 2 10 46 PM" src="https://github.com/user-attachments/assets/21f8787f-148e-4848-8880-4c527c4551cc" />

</details>