### PR TITLE
Refactor/store text offline metrics

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -62,8 +62,6 @@ from .consent import (
 # Text metrics operations
 from .text_metrics import (
     store_text_offline_metrics,
-    store_text_llm_metrics,
-    get_text_llm_metrics,
     get_text_non_llm_metrics,
 )
 
@@ -139,8 +137,6 @@ __all__ = [
     "get_latest_consent",
     "get_latest_external_consent",
     "store_text_offline_metrics",
-    "store_text_llm_metrics",
-    "get_text_llm_metrics",
     "get_text_non_llm_metrics",
     "code_complexity_metrics_exists",
     "insert_code_complexity_metrics",

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -109,11 +109,11 @@ CREATE TABLE IF NOT EXISTS config_files (
 CREATE TABLE IF NOT EXISTS non_llm_text (
     metrics_id        INTEGER PRIMARY KEY AUTOINCREMENT,
     classification_id INTEGER UNIQUE NOT NULL,
-    doc_count         INTEGER,
-    total_words       INTEGER,
-    reading_level_avg REAL,
-    reading_level_label TEXT,
-    keywords_json     TEXT,
+    doc_count         INTEGER, -- always 1 (main file)
+    total_words       INTEGER, -- of main file
+    reading_level_avg REAL, -- of main file
+    reading_level_label TEXT, -- of main file
+    keywords_json     TEXT, -- currently empty in case we want to bring back TF IDF to determine user's "topics of interest"
     summary_json      TEXT,
     csv_metadata TEXT,
     generated_at      TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -115,27 +115,8 @@ CREATE TABLE IF NOT EXISTS non_llm_text (
     reading_level_label TEXT,
     keywords_json     TEXT,
     summary_json      TEXT,
+    csv_metadata TEXT,
     generated_at      TEXT NOT NULL DEFAULT (datetime('now')),
-    FOREIGN KEY (classification_id) REFERENCES project_classifications(classification_id) ON DELETE CASCADE
-);
-
-CREATE TABLE IF NOT EXISTS llm_text (
-    text_metric_id INTEGER PRIMARY KEY AUTOINCREMENT,
-    classification_id INTEGER NOT NULL,
-    file_path TEXT,
-    file_name TEXT,
-    project_name TEXT,
-    word_count INTEGER,
-    sentence_count INTEGER,
-    flesch_kincaid_grade REAL,
-    lexical_diversity REAL,
-    summary TEXT NOT NULL,
-    skills_json JSON,
-    strength_json JSON,
-    weaknesses_json JSON,
-    overall_score TEXT,
-    processed_at TEXT DEFAULT (datetime('now')),
-    UNIQUE(text_metric_id),
     FOREIGN KEY (classification_id) REFERENCES project_classifications(classification_id) ON DELETE CASCADE
 );
 

--- a/src/db/text_metrics.py
+++ b/src/db/text_metrics.py
@@ -72,8 +72,22 @@ def store_text_offline_metrics(
 
     # ---------- UPDATE ----------
     if existing:
-        if csv_metadata_json is None:
-            csv_metadata_json = existing[6]
+        existing_doc_count, existing_total_words, existing_rl_avg, existing_rl_label, \
+            existing_keywords_json, existing_summary_json, existing_csv_metadata = existing
+
+        # Preserve keywords if not provided
+        if "keywords" in project_metrics:
+            # use new value
+            keywords_json = json.dumps(
+                sanitize_for_json(keywords), ensure_ascii=False
+            )
+        else:
+            # keep old
+            keywords_json = existing_keywords_json
+
+        # Preserve csv_metadata if not provided
+        if csv_metadata is None:
+            csv_metadata_json = existing_csv_metadata
 
         conn.execute(
             """
@@ -90,10 +104,10 @@ def store_text_offline_metrics(
             WHERE classification_id = ?
             """,
             (
-                doc_count,
-                total_words,
-                reading_level_avg,
-                reading_level_label,
+                doc_count if doc_count is not None else existing_doc_count,
+                total_words if total_words is not None else existing_total_words,
+                reading_level_avg if reading_level_avg is not None else existing_rl_avg,
+                reading_level_label if reading_level_label is not None else existing_rl_label,
                 keywords_json,
                 summary_json,
                 csv_metadata_json,

--- a/src/db/text_metrics.py
+++ b/src/db/text_metrics.py
@@ -1,66 +1,91 @@
-"""
-src/db/text_metrics.py
-
-Handles metrics storage and retrieval for text analysis:
- - Storing offline (non-LLM) metrics
- - Storing and retrieving LLM-based metrics
-"""
-
 import sqlite3
 import json
-from typing import Optional, Dict, Any
+from typing import Optional
+
+import numpy as np
+
+def sanitize_for_json(obj):
+    """Recursively convert numpy types to python builtins."""
+    if isinstance(obj, dict):
+        return {k: sanitize_for_json(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [sanitize_for_json(i) for i in obj]
+    elif isinstance(obj, tuple):
+        return tuple(sanitize_for_json(i) for i in obj)
+    elif isinstance(obj, (np.integer, np.int64, np.int32)):
+        return int(obj)
+    elif isinstance(obj, (np.floating, np.float64, np.float32)):
+        return float(obj)
+    elif isinstance(obj, np.ndarray):
+        return obj.tolist()
+    else:
+        return obj
 
 
 def store_text_offline_metrics(
     conn: sqlite3.Connection,
     classification_id: int,
     project_metrics: dict | None,
+    csv_metadata: dict | list | None = None
 ) -> None:
+
     if not classification_id or not project_metrics:
         return
 
+    # Extract summary values
     summary_block = project_metrics.get("summary") or {}
-    keywords = project_metrics.get("keywords")
+    keywords = project_metrics.get("keywords") or []
 
     doc_count = summary_block.get("total_documents")
     total_words = summary_block.get("total_words")
     reading_level_avg = summary_block.get("reading_level_average")
     reading_level_label = summary_block.get("reading_level_label")
 
-    summary_json = json.dumps(project_metrics, ensure_ascii=False)
-    keywords_json = json.dumps(keywords, ensure_ascii=False) if keywords is not None else None
+    # Sanitize everything BEFORE serialization
+    clean_metrics = sanitize_for_json(project_metrics)
+    summary_json = json.dumps(clean_metrics, ensure_ascii=False)
 
+    keywords_json = json.dumps(
+        sanitize_for_json(keywords), ensure_ascii=False
+    )
+
+    csv_metadata_json = json.dumps(
+        sanitize_for_json(csv_metadata), ensure_ascii=False
+    ) if csv_metadata is not None else None
+
+    # Check existing row
     existing = conn.execute(
         """
-        SELECT doc_count,
-               total_words,
-               reading_level_avg,
-               reading_level_label,
-               keywords_json,
-               summary_json
+        SELECT 
+            doc_count,
+            total_words,
+            reading_level_avg,
+            reading_level_label,
+            keywords_json,
+            summary_json,
+            csv_metadata
         FROM non_llm_text
         WHERE classification_id = ?
         """,
-        (classification_id,),
+        (classification_id,)
     ).fetchone()
 
+    # ---------- UPDATE ----------
     if existing:
-        doc_count = doc_count if doc_count is not None else existing[0]
-        total_words = total_words if total_words is not None else existing[1]
-        reading_level_avg = reading_level_avg if reading_level_avg is not None else existing[2]
-        reading_level_label = reading_level_label if reading_level_label is not None else existing[3]
-        keywords_json = keywords_json if keywords_json is not None else existing[4]
-        summary_json = summary_json if summary_json is not None else existing[5]
+        if csv_metadata_json is None:
+            csv_metadata_json = existing[6]
 
         conn.execute(
             """
             UPDATE non_llm_text
-            SET doc_count = ?,
+            SET
+                doc_count = ?,
                 total_words = ?,
                 reading_level_avg = ?,
                 reading_level_label = ?,
                 keywords_json = ?,
                 summary_json = ?,
+                csv_metadata = ?,
                 generated_at = datetime('now')
             WHERE classification_id = ?
             """,
@@ -71,15 +96,13 @@ def store_text_offline_metrics(
                 reading_level_label,
                 keywords_json,
                 summary_json,
+                csv_metadata_json,
                 classification_id,
             ),
         )
-    else:
-        if keywords_json is None:
-            keywords_json = json.dumps([], ensure_ascii=False)
-        if summary_json is None:
-            summary_json = json.dumps({}, ensure_ascii=False)
 
+    # ---------- INSERT ----------
+    else:
         conn.execute(
             """
             INSERT INTO non_llm_text (
@@ -90,8 +113,10 @@ def store_text_offline_metrics(
                 reading_level_label,
                 keywords_json,
                 summary_json,
+                csv_metadata,
                 generated_at
-            ) VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, datetime('now'))
             """,
             (
                 classification_id,
@@ -101,59 +126,26 @@ def store_text_offline_metrics(
                 reading_level_label,
                 keywords_json,
                 summary_json,
+                csv_metadata_json,
             ),
         )
-    conn.commit()
-    
 
-def store_text_llm_metrics(conn: sqlite3.Connection, classification_id: int, project_name: str, file_name:str, file_path:str, linguistic:dict, summary: str, skills: list, success: dict )-> None:
-    skills_json=json.dumps(skills)
-    strength_json=json.dumps(success.get("strengths", []))
-    weaknesses_json=json.dumps(success.get("weaknesses", []))
-    conn.execute(
-        """
-        INSERT INTO llm_text(
-        classification_id, file_path, file_name, project_name, word_count, sentence_count, flesch_kincaid_grade, lexical_diversity, summary, skills_json, strength_json, weaknesses_json, overall_score)
-        VALUES(?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-        """,
-        (classification_id, file_path, file_name, project_name, linguistic.get("word_count"), linguistic.get("sentence_count"), linguistic.get("flesch_kincaid_grade"), linguistic.get("lexical_diversity"), summary, skills_json, strength_json, weaknesses_json, success.get("score"))
-        )
     conn.commit()
 
-
-def get_text_llm_metrics(conn: sqlite3.Connection, classification_id: int) -> Optional[dict]:
-    row = conn.execute("""
-        SELECT text_metric_id, classification_id, project_name, file_name, file_path, word_count, sentence_count, flesch_kincaid_grade, lexical_diversity,
-        summary, skills_json, strength_json, weaknesses_json, overall_score, processed_at
-        FROM llm_text
-        WHERE classification_id = ?
-    """, (classification_id,)).fetchone()
-
-    if not row:
-        return None
-
-    return {
-        "text_metric_id": row[0],
-        "classification_id": row[1],
-        "project_name": row[2],
-        "file_name": row[3],
-        "file_path": row[4],
-        "word_count": row[5],
-        "sentence_count": row[6],
-        "flesch_kincaid_grade": row[7],
-        "lexical_diversity": row[8],
-        "summary": row[9],
-        "skills_json": row[10],
-        "strength_json": row[11],
-        "weaknesses_json": row[12],
-        "overall_score": row[13],
-        "processed_at": row[14]
-    }
 
 
 def get_text_non_llm_metrics(conn: sqlite3.Connection, classification_id: int) -> Optional[dict]:
+    """Retrieve non-LLM metrics for a project classification."""
+
     row = conn.execute("""
-        SELECT doc_count, total_words, reading_level_avg, reading_level_label, keywords_json
+        SELECT 
+            doc_count,
+            total_words,
+            reading_level_avg,
+            reading_level_label,
+            keywords_json,
+            summary_json,
+            csv_metadata
         FROM non_llm_text
         WHERE classification_id = ?
     """, (classification_id,)).fetchone()
@@ -162,11 +154,15 @@ def get_text_non_llm_metrics(conn: sqlite3.Connection, classification_id: int) -
         return None
 
     keywords = json.loads(row[4]) if row[4] else []
-    
+    summary = json.loads(row[5]) if row[5] else {}
+    csv_metadata = json.loads(row[6]) if row[6] else None
+
     return {
         "doc_count": row[0],
         "total_words": row[1],
         "reading_level_avg": row[2],
         "reading_level_label": row[3],
-        "keywords": keywords
+        "keywords": keywords,
+        "summary": summary,
+        "csv_metadata": csv_metadata
     }

--- a/src/project_analysis.py
+++ b/src/project_analysis.py
@@ -7,10 +7,9 @@ import json
 # TEXT ANALYSIS imports
 from src.analysis.text_individual.text_analyze import run_text_pipeline
 from src.analysis.text_individual.csv_analyze import analyze_all_csv
-from src.db import get_classification_id, store_text_offline_metrics, store_text_llm_metrics, get_text_activity_contribution
+from src.db import get_classification_id, get_text_activity_contribution
 from src.analysis.text_collaborative.text_collab_analysis import analyze_collaborative_text_project
 from src.integrations.google_drive.google_drive_auth.text_project_setup import setup_text_project_drive_connection
-
 
 # CODE ANALYSIS imports
 from src.analysis.code_individual.code_llm_analyze import run_code_llm_analysis
@@ -20,7 +19,7 @@ from src.analysis.code_collaborative.code_collaborative_analysis import analyze_
 from src.integrations.google_drive.process_project_files import process_project_files
 from src.db.project_summaries import save_project_summary
 from src.db.skills import get_project_skills
-from src.db import get_text_llm_metrics, get_text_non_llm_metrics, get_classification_id
+from src.db import get_text_non_llm_metrics, get_classification_id
 from src.db.code_metrics import (
     insert_code_complexity_metrics,
     update_code_complexity_metrics,
@@ -548,13 +547,7 @@ def analyze_files(conn, user_id, project_name, external_consent, parsed_files, z
             summary.summary_text = text_results.get("project_summary")
             summary.skills = text_results.get("skills", [])
 
-#        if classification_id and text_results:
-#            store_text_offline_metrics(
-#                conn,
-#                classification_id,
-#                text_results.get("project_summary")
-#            )
-#commenting out to be fixed next pr
+
     else:
         # --- Run non-LLM code analysis (static + Git metrics) ---
         classification_id=get_classification_id(conn, user_id, project_name)
@@ -619,19 +612,6 @@ def _load_text_metrics_into_summary(conn, user_id, project_name, summary):
             "reading_level_avg": non_llm.get("reading_level_avg"),
             "reading_level_label": non_llm.get("reading_level_label"),
             "keywords": non_llm.get("keywords", [])
-        }
-    
-    # Load LLM metrics
-    llm = get_text_llm_metrics(conn, classification_id)
-    if llm:
-        text_metrics["llm"] = {
-            "word_count": llm.get("word_count"),
-            "sentence_count": llm.get("sentence_count"),
-            "flesch_kincaid_grade": llm.get("flesch_kincaid_grade"),
-            "lexical_diversity": llm.get("lexical_diversity"),
-            "overall_score": llm.get("overall_score"),
-            "strengths": json.loads(llm.get("strength_json")) if llm.get("strength_json") else [],
-            "weaknesses": json.loads(llm.get("weaknesses_json")) if llm.get("weaknesses_json") else []
         }
     
     if text_metrics:

--- a/src/project_analysis.py
+++ b/src/project_analysis.py
@@ -6,7 +6,8 @@ import sqlite3
 # TEXT ANALYSIS imports
 from src.analysis.text_individual.text_analyze import run_text_pipeline
 from src.analysis.text_individual.csv_analyze import analyze_all_csv
-from src.db import get_classification_id, store_text_offline_metrics, store_text_llm_metrics
+from src.db.text_metrics import store_text_offline_metrics, store_text_llm_metrics
+from src.db.projects import get_classification_id
 from src.analysis.text_collaborative.text_collab_analysis import analyze_collaborative_text_project
 from src.integrations.google_drive.google_drive_auth.text_project_setup import setup_text_project_drive_connection
 
@@ -17,7 +18,6 @@ from src.analysis.code_individual.code_non_llm_analysis import run_code_non_llm_
 from src.utils.helpers import _fetch_files
 from src.analysis.code_collaborative.code_collaborative_analysis import analyze_code_project, print_code_portfolio_summary
 from src.integrations.google_drive.process_project_files import process_project_files
-from src.db import get_classification_id, store_text_offline_metrics, store_text_llm_metrics
 from src.db.project_summaries import save_project_summary
 import json
 from src.analysis.code_collaborative.code_collaborative_analysis import analyze_code_project, print_code_portfolio_summary, set_manual_descs_store, prompt_collab_descriptions

--- a/tests/test_project_summary.py
+++ b/tests/test_project_summary.py
@@ -4,7 +4,7 @@ import pytest
 from src.models.project_summary import ProjectSummary
 from src.db import init_schema, get_or_create_user, record_project_classification, get_classification_id
 from src.db.skills import insert_project_skill
-from src.db.text_metrics import store_text_offline_metrics, store_text_llm_metrics
+from src.db.text_metrics import store_text_offline_metrics
 from src.project_analysis import _load_skills_into_summary, _load_text_metrics_into_summary
 
 
@@ -81,20 +81,11 @@ def test_load_text_metrics_into_summary(conn, test_user, test_classification):
         "keywords": [{"word": "test", "score": 0.5}],
     })
 
-    store_text_llm_metrics(
-        conn, test_classification, "TestProject", "doc.txt", "path/doc.txt",
-        {"word_count": 500, "sentence_count": 25, "flesch_kincaid_grade": 12.5, "lexical_diversity": 0.7},
-        "Summary text", [], {"strengths": ["clarity"], "weaknesses": ["depth"], "score": "B"}
-    )
-
     _load_text_metrics_into_summary(conn, test_user, "TestProject", summary)
 
     assert "text" in summary.metrics
     assert summary.metrics["text"]["non_llm"]["doc_count"] == 2
     assert summary.metrics["text"]["non_llm"]["total_words"] == 1000
-    assert summary.metrics["text"]["llm"]["word_count"] == 500
-    assert summary.metrics["text"]["llm"]["flesch_kincaid_grade"] == 12.5
-    assert summary.metrics["text"]["llm"]["strengths"] == ["clarity"]
 
 
 def test_load_text_metrics_into_summary_skips_code_projects(conn, test_user):

--- a/tests/test_project_type_analysis.py
+++ b/tests/test_project_type_analysis.py
@@ -60,26 +60,8 @@ def setup_in_memory_db():
             reading_level_label TEXT,
             keywords_json TEXT,
             summary_json TEXT,
+            csv_metadata TEXT,
             generated_at TEXT NOT NULL DEFAULT (datetime('now'))
-        );
-    """)
-    conn.execute("""
-        CREATE TABLE llm_text (
-            text_metric_id INTEGER PRIMARY KEY AUTOINCREMENT,
-            classification_id INTEGER NOT NULL,
-            file_path TEXT,
-            file_name TEXT,
-            project_name TEXT,
-            word_count INTEGER,
-            sentence_count INTEGER,
-            flesch_kincaid_grade REAL,
-            lexical_diversity REAL,
-            summary TEXT NOT NULL,
-            skills_json JSON,
-            strength_json JSON,
-            weaknesses_json JSON,
-            overall_score TEXT,
-            processed_at TEXT DEFAULT (datetime('now'))
         );
     """)
     conn.execute("""


### PR DESCRIPTION
## 📝 Description

This PR updates the storage and retrieval logic in `text_metrics.py` to align with the refactored text-analysis pipeline. The previous `store_text_offline_metrics()` implementation was commented out in `project_analysis.py` because it no longer matched the new architecture and would break at runtime. It is now fully fixed and correctly integrated into `extract_text_skills()`, which is where the non-LLM metrics are generated.

### **Key changes**

* Refactored `store_text_offline_metrics()` to support the new pipeline structure:

  * Stable upsert behavior
  * Field preservation when missing in subsequent updates
  * Full numpy → Python sanitation before JSON serialization
* Added support for storing **csv_metadata** in `non_llm_text` (previously unstored).
* Updated `get_text_non_llm_metrics()`
* Removed all dependencies on **llm_text** since we no longer call the LLM for strengths, weaknesses, skills, or success factors.
* Updated `extract_text_skills()` to pass linguistic metrics and csv_metadata directly into `store_text_offline_metrics()`.
* Fixed failing tests caused by the schema change

Now these are the fieldnames in non_llm_text:
    `metrics_id`
    `classification_id` 
    `doc_count` --> always 1 (main file)
    `total_words` (of main file)
    `reading_level_avg` (of main file)
    `reading_level_label` (of main file)
    `keywords_json` 
 --> currently empty in case we want to bring back TF IDF to determine user's "topics of interest" (maybe in milestone 2)
    `summary_json` 
    `csv_metadata`
    `generated_at`

**Closes:** #244 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] ran python -m pytest
- [x] manually test with text projects, and checking if table `non_llm_text` is filled

NOTE: please delete your db before running python -m src.main

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
<img width="1440" height="106" alt="Screenshot 2025-11-28 at 9 48 17 PM" src="https://github.com/user-attachments/assets/1fc2a8fb-4a17-4e03-98be-9a43afd2f17e" />