### PR TITLE
Fix Framework Detection

### DIFF
--- a/src/utils/framework_detector.py
+++ b/src/utils/framework_detector.py
@@ -186,16 +186,15 @@ FRAMEWORK_KEYWORDS = {
     "Prettier": ["prettier"],
 }
 
-def detect_frameworks(conn, project_name, user_id,zip_path):
+def detect_frameworks(conn, project_name, user_id, zip_path):
     """
     Detect frameworks used in a project by scanning config files.
     Returns a set of framework names.
     """
-    #path for accessing files
-    REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    ZIP_DATA_DIR = os.path.join(REPO_ROOT, "zip_data")
+    # Use the same extraction path as parsing.py (analysis/zip_data/<zip_name>)
+    repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     zip_name = os.path.splitext(os.path.basename(zip_path))[0]
-    base_path = os.path.join(ZIP_DATA_DIR, zip_name)
+    base_path = os.path.join(repo_root, "analysis", "zip_data", zip_name)
 
     cur = conn.cursor()
     frameworks = set()

--- a/src/utils/framework_detector.py
+++ b/src/utils/framework_detector.py
@@ -191,13 +191,10 @@ def detect_frameworks(conn, project_name, user_id, zip_path):
     Detect frameworks used in a project by scanning config files.
     Returns a set of framework names.
     """
-    # Prefer the analysis/zip_data path (used in parsing.py); fall back to ./zip_data for tests/legacy
+    # Use the analysis/zip_data path (used in parsing.py)
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     zip_name = os.path.splitext(os.path.basename(zip_path))[0]
-    candidate_paths = [
-        os.path.join(repo_root, "analysis", "zip_data", zip_name),
-        os.path.join(repo_root, "zip_data", zip_name),
-    ]
+    base_path = os.path.join(repo_root, "analysis", "zip_data", zip_name)
 
     cur = conn.cursor()
     frameworks = set()
@@ -214,14 +211,9 @@ def detect_frameworks(conn, project_name, user_id, zip_path):
         return frameworks  # empty set
 
     for (file_path,) in files:
-        full_path = None
-        for base_path in candidate_paths:
-            test_path = os.path.join(base_path, file_path)
-            if os.path.isfile(test_path):
-                full_path = test_path
-                break
+        full_path = os.path.join(base_path, file_path)
 
-        if not full_path:
+        if not os.path.isfile(full_path):
             continue
 
         try:

--- a/tests/test_framework_detector.py
+++ b/tests/test_framework_detector.py
@@ -33,7 +33,7 @@ def conn():
 def _repo_zip_base(zip_name):
     """Return the expected base path used by framework_detector for a given zip_name."""
     repo_root = os.path.dirname(os.path.dirname(os.path.abspath(fd.__file__)))
-    base = os.path.join(repo_root, "zip_data", zip_name)
+    base = os.path.join(repo_root, "analysis", "zip_data", zip_name)
     return repo_root, base
 
 


### PR DESCRIPTION
## 📝 Description
This PR fixes the file path for the framework detection to work. It was currently looking at the wrong path and thus unable to detect any frameworks. This will fix the issue brought up in Salma's PR: #269 which related to storing collaborative code metrics. This will also help with the ranking module, resume and portfolio creation. The test cases have been updated as they too were using the wrong path. 

**Closes:** #277 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual:
Run a code analysis (individual or collaborative) and check if the frameworks are stored in table project_summaries in the summary_json.

Tests:
Run pytest and ensure all pass. 

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>
In terminal:
<img width="882" height="84" alt="Screenshot 2025-11-29 at 2 50 12 PM" src="https://github.com/user-attachments/assets/c1eccb27-6048-490e-9a61-dd3de4341faa" />
In the database (project_summaries table > summary_json )
<img width="555" height="291" alt="Screenshot 2025-11-29 at 2 49 42 PM" src="https://github.com/user-attachments/assets/347fc6b6-d867-46dd-83a1-768054b07228" />


</details>