### PR TITLE
Refactor/non llm code summary

### DIFF
--- a/src/analysis/code_collaborative/code_collaborative_analysis.py
+++ b/src/analysis/code_collaborative/code_collaborative_analysis.py
@@ -168,6 +168,9 @@ def analyze_code_project(conn: sqlite3.Connection,
             summary.metrics["collaborative_git"] = {
                 "last_commit_date": history["last"]
             }
+        # store non llm contribution summary    
+        if desc and "llm_contribution_summary" not in summary.contributions:
+            summary.contributions["non_llm_contribution_summary"] = desc.strip()
 
     # 7.5) save file contributions to database for skill extraction filtering
     file_contributions_data = metrics.get("file_contributions", {})

--- a/src/analysis/code_collaborative/code_collaborative_analysis_helper.py
+++ b/src/analysis/code_collaborative/code_collaborative_analysis_helper.py
@@ -698,38 +698,23 @@ Top files: {top_files}
 """.rstrip())
     
 def prompt_collab_descriptions(projects: list[tuple[str, str]], consent: str) -> dict[str, str]:
-    """
-    Ask once for project descriptions if LLM consent is not accepted.
-    Returns {project_name: description}.
-    """
     if consent == "accepted" or not projects:
         return {}
 
-    print(
-        "\nSince you’ve opted out of LLM analysis, we’ll use your manual descriptions "
-        "to summarize your focus and contributions. Evidence (e.g., commits, code structure, "
-        "languages, and algorithms) will still be extracted automatically to support your summary.\n\n"
-        "Include:\n"
-        " - What the project does\n"
-        " - Languages/frameworks used\n"
-        " - Technical focus (e.g., architecture, data structures, optimization)\n"
-        " - Your main contributions\n\n"
-        "Example: "
-        '"Movie recommendation system built with Python and Flask. '
-        "Focused on implementing collaborative filtering using hash maps for faster lookups "
-        "and optimizing SQL queries with indexing. "
-        "Developed the recommendation module and integrated it into the web interface.\""
-    )
+    print("\n[NON-LLM] CONTRIBUTION SUMMARIES")
+    print("Describe only your personal contributions to the collaborative project.")
+    print("Write 1–3 sentences.\n")
 
     descs = {}
     for project_name, _ in projects:
-        print()
         try:
-            user_input = input(f"> {project_name}:\n> ").strip()
+            user_input = input(f"Your contribution to '{project_name}': ").strip()
         except EOFError:
             user_input = ""
-        descs[project_name] = user_input
+        descs[project_name] = user_input or "[No manual contribution summary provided]"
+
     return descs
+
 
 
 # ------------------------------------------------------------

--- a/src/analysis/code_individual/code_non_llm_analysis.py
+++ b/src/analysis/code_individual/code_non_llm_analysis.py
@@ -23,19 +23,14 @@ def run_code_non_llm_analysis(conn, user_id, project_name, zip_path, summary=Non
     }
     
 def prompt_manual_code_project_summary(project_name: str) -> str:
-    print(f"\n[NON-LLM] Let's capture a short summary for '{project_name}'.")
+    print(f"\n[NON-LLM] PROJECT SUMMARY for '{project_name}'")
     print("Describe what the project does (purpose, main features, tech stack).")
-    print("Use 1–3 sentences. Press ENTER on a blank line to finish.\n")
+    print("Write 1–3 sentences.\n")
 
-    lines = []
-    while True:
-        try:
-            line = input()
-        except EOFError:
-            break
-        if not line.strip():
-            break
-        lines.append(line.strip())
+    try:
+        summary = input("Project summary: ").strip()
+    except EOFError:
+        summary = ""
 
-    summary = " ".join(lines).strip()
     return summary or "[No manual project summary provided]"
+

--- a/src/analysis/code_individual/code_non_llm_analysis.py
+++ b/src/analysis/code_individual/code_non_llm_analysis.py
@@ -21,3 +21,21 @@ def run_code_non_llm_analysis(conn, user_id, project_name, zip_path, summary=Non
         'complexity_data': complexity_data,
         'git_data': git_data
     }
+    
+def prompt_manual_code_project_summary(project_name: str) -> str:
+    print(f"\n[NON-LLM] Let's capture a short summary for '{project_name}'.")
+    print("Describe what the project does (purpose, main features, tech stack).")
+    print("Use 1–3 sentences. Press ENTER on a blank line to finish.\n")
+
+    lines = []
+    while True:
+        try:
+            line = input()
+        except EOFError:
+            break
+        if not line.strip():
+            break
+        lines.append(line.strip())
+
+    summary = " ".join(lines).strip()
+    return summary or "[No manual project summary provided]"


### PR DESCRIPTION
## 📝 Description

This PR solves the missing non-llm summary collection. Previously, we only generated summaries for code projects by using an llm, hence we did not have any code project summaries when llm consent is not given. We had a manual prompt for the contribution summary but that was not stored in `project_summaries` yet. Now,
- Users are prompted to type a project summary for individual and collaborative code projects where llm consent is not given. This is stored as "summary_text" in the `project_summaries` table under `summary_json`
- Manual contribution summary for collaborative code projects (non llm) is now stored in `project_summaries`


**Closes:** #265 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] ran python -m pytest to make sure new change does not break previous tests
- [x] manually tested with uploading individual and collaborative code projects and giving no consent for llm use

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
Content of `summary_json` column of `project_summaries` table. When llm consent is not given, it now contains "non_llm_contribution_summary" for collaborative projects and "summary_text" for both individual and collaborative projects.
<img width="675" height="333" alt="Screenshot 2025-11-30 at 7 54 10 AM" src="https://github.com/user-attachments/assets/17d60eea-a2eb-49d2-8447-c682130b6a12" />