### PR TITLE
POST & GET privacy-consent

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -99,7 +99,57 @@ Handles user consent for internal processing and external integrations.
 
 ### **Endpoints**
 
+- **Record Internal Processing Consent**
+    - **Endpoint**: `POST /privacy-consent/internal`
+    - **Description**: Records the user's consent for internal data processing
+    - **Headers**:
+        - `X-User-Id` (integer, required): Current user identifier
+    - **Request Body**:
+        ```json
+        {
+            "status": "accepted"
+        }
+        ```
+    - **Response Status**: `201 Created`
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": {
+                "consent_id": 1,
+                "user_id": 1,
+                "status": "accepted",
+                "timestamp": "2026-01-17T12:34:56.789012"
+            },
+            "error": null
+        }
+        ```
 
+- **Record External Integration Consent**
+    - **Endpoint**: `POST /privacy-consent/external`
+    - **Description**: Records the user's consent for external service integrations
+    - **Headers**:
+        - `X-User-Id` (integer, required): Current user identifier
+    - **Request Body**:
+        ```json
+        {
+            "status": "rejected"
+        }
+        ```
+    - **Response Status**: `201 Created`
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": {
+                "consent_id": 2,
+                "user_id": 1,
+                "status": "rejected",
+                "timestamp": "2026-01-17T12:35:00.123456"
+            },
+            "error": null
+        }
+        ```
 
 ---
 
@@ -164,6 +214,15 @@ Example:
     - `project_type` (string, optional)
     - `project_mode` (string, optional)
     - `created_at` (string, optional)
+
+- **ConsentRequestDTO**
+    - `status` (string, required): Must be either "accepted" or "rejected"
+
+- **ConsentResponseDTO**
+    - `consent_id` (int, required): Unique identifier for the consent record
+    - `user_id` (int, required): User who gave the consent
+    - `status` (string, required): "accepted" or "rejected"
+    - `timestamp` (string, required): ISO 8601 timestamp of when consent was recorded
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -151,6 +151,25 @@ Handles user consent for internal processing and external integrations.
         }
         ```
 
+- **Get Consent Status**
+    - **Endpoint**: `GET /privacy-consent/status`
+    - **Description**: Retrieves the current consent status for the authenticated user (returns the most recent consent for each type)
+    - **Headers**:
+        - `X-User-Id` (integer, required): Current user identifier
+    - **Response Status**: `200 OK`
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": {
+                "user_id": 1,
+                "internal_consent": "accepted",
+                "external_consent": "rejected"
+            },
+            "error": null
+        }
+        ```
+
 ---
 
 ## **Skills**
@@ -223,6 +242,11 @@ Example:
     - `user_id` (int, required): User who gave the consent
     - `status` (string, required): "accepted" or "rejected"
     - `timestamp` (string, required): ISO 8601 timestamp of when consent was recorded
+
+- **ConsentStatusDTO**
+    - `user_id` (int, required): User identifier
+    - `internal_consent` (string, optional): Latest internal consent status, or null if not set
+    - `external_consent` (string, optional): Latest external consent status, or null if not set
 
 ---
 

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from src.api.routes.projects import router as projects_router
+from src.api.routes.consent import router as consent_router
 
 app = FastAPI(title="Capstone API")
 
@@ -8,3 +9,4 @@ def health():
     return {"status": "ok"}
 
 app.include_router(projects_router)
+app.include_router(consent_router)

--- a/src/api/routes/consent.py
+++ b/src/api/routes/consent.py
@@ -1,0 +1,67 @@
+from fastapi import APIRouter, Depends
+from sqlite3 import Connection
+from datetime import datetime
+
+from src.api.dependencies import get_db, get_current_user_id
+from src.api.schemas.common import ApiResponse
+from src.api.schemas.consent import ConsentRequestDTO, ConsentResponseDTO
+from src.consent.consent import record_consent
+from src.consent.external_consent import record_external_consent
+
+router = APIRouter(prefix="/privacy-consent", tags=["consent"])
+
+
+@router.post("/internal", response_model=ApiResponse[ConsentResponseDTO], status_code=201)
+def record_internal_consent_endpoint(
+    request: ConsentRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """
+    Record internal processing consent for the authenticated user.
+
+    The user's consent status is recorded in the database with a timestamp.
+    """
+    # Record consent using existing function
+    consent_id = record_consent(conn, request.status, user_id)
+
+    # Get the timestamp that was just recorded
+    timestamp = datetime.now().isoformat()
+
+    # Build response DTO
+    response_dto = ConsentResponseDTO(
+        consent_id=consent_id,
+        user_id=user_id,
+        status=request.status,
+        timestamp=timestamp
+    )
+
+    return ApiResponse(success=True, data=response_dto, error=None)
+
+
+@router.post("/external", response_model=ApiResponse[ConsentResponseDTO], status_code=201)
+def record_external_consent_endpoint(
+    request: ConsentRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """
+    Record external integration consent for the authenticated user.
+
+    The user's consent status for external services is recorded in the database with a timestamp.
+    """
+    # Record consent using existing function
+    consent_id = record_external_consent(conn, request.status, user_id)
+
+    # Get the timestamp that was just recorded
+    timestamp = datetime.now().isoformat()
+
+    # Build response DTO
+    response_dto = ConsentResponseDTO(
+        consent_id=consent_id,
+        user_id=user_id,
+        status=request.status,
+        timestamp=timestamp
+    )
+
+    return ApiResponse(success=True, data=response_dto, error=None)

--- a/src/api/schemas/consent.py
+++ b/src/api/schemas/consent.py
@@ -1,0 +1,15 @@
+from pydantic import BaseModel, Field
+from typing import Literal
+
+
+class ConsentRequestDTO(BaseModel):
+    status: Literal["accepted", "rejected"] = Field(
+        ...,
+        description="User consent status - must be 'accepted' or 'rejected'"
+    )
+
+class ConsentResponseDTO(BaseModel):
+    consent_id: int
+    user_id: int
+    status: str
+    timestamp: str

--- a/src/api/schemas/consent.py
+++ b/src/api/schemas/consent.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Literal
+from typing import Literal, Optional
 
 
 class ConsentRequestDTO(BaseModel):
@@ -13,3 +13,9 @@ class ConsentResponseDTO(BaseModel):
     user_id: int
     status: str
     timestamp: str
+
+
+class ConsentStatusDTO(BaseModel):
+    user_id: int
+    internal_consent: Optional[str] = None
+    external_consent: Optional[str] = None

--- a/tests/api/test_consent_api.py
+++ b/tests/api/test_consent_api.py
@@ -1,8 +1,29 @@
+import pytest
 from fastapi.testclient import TestClient
 from src.api.main import app
 import src.db as db
 
 client = TestClient(app)
+
+
+@pytest.fixture
+def test_user():
+    """Create test user with id 1."""
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+    return 1
+
+
+@pytest.fixture
+def test_user_2():
+    """Create test user with id 2."""
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (2, 'new-user', NULL)")
+    conn.commit()
+    conn.close()
+    return 2
 
 
 # POST /privacy-consent/internal tests
@@ -22,36 +43,26 @@ def test_internal_consent_with_invalid_user():
     assert res.json()["detail"] == "User not found"
 
 
-def test_internal_consent_accepted():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_internal_consent_accepted(test_user):
     res = client.post(
         "/privacy-consent/internal",
         json={"status": "accepted"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
     assert res.status_code == 201
     body = res.json()
     assert body["success"] is True
     assert body["data"]["status"] == "accepted"
-    assert body["data"]["user_id"] == 1
+    assert body["data"]["user_id"] == test_user
     assert "consent_id" in body["data"]
     assert "timestamp" in body["data"]
 
 
-def test_internal_consent_rejected():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_internal_consent_rejected(test_user):
     res = client.post(
         "/privacy-consent/internal",
         json={"status": "rejected"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
     assert res.status_code == 201
     body = res.json()
@@ -59,16 +70,11 @@ def test_internal_consent_rejected():
     assert body["data"]["status"] == "rejected"
 
 
-def test_internal_consent_invalid_status():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_internal_consent_invalid_status(test_user):
     res = client.post(
         "/privacy-consent/internal",
         json={"status": "maybe"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
     assert res.status_code == 422
 
@@ -80,34 +86,24 @@ def test_external_consent_requires_user_header():
     assert res.status_code == 401
 
 
-def test_external_consent_accepted():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_external_consent_accepted(test_user):
     res = client.post(
         "/privacy-consent/external",
         json={"status": "accepted"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
     assert res.status_code == 201
     body = res.json()
     assert body["success"] is True
     assert body["data"]["status"] == "accepted"
-    assert body["data"]["user_id"] == 1
+    assert body["data"]["user_id"] == test_user
 
 
-def test_external_consent_rejected():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_external_consent_rejected(test_user):
     res = client.post(
         "/privacy-consent/external",
         json={"status": "rejected"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
     assert res.status_code == 201
     body = res.json()
@@ -128,43 +124,33 @@ def test_get_consent_status_with_invalid_user():
     assert res.json()["detail"] == "User not found"
 
 
-def test_get_consent_status_no_consents():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (2, 'new-user', NULL)")
-    conn.commit()
-    conn.close()
-
-    res = client.get("/privacy-consent/status", headers={"X-User-Id": "2"})
+def test_get_consent_status_no_consents(test_user_2):
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": str(test_user_2)})
     assert res.status_code == 200
     body = res.json()
     assert body["success"] is True
-    assert body["data"]["user_id"] == 2
+    assert body["data"]["user_id"] == test_user_2
     assert body["data"]["internal_consent"] is None
     assert body["data"]["external_consent"] is None
 
 
-def test_get_consent_status_after_recording():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_get_consent_status_after_recording(test_user):
     # Record internal consent
     client.post(
         "/privacy-consent/internal",
         json={"status": "accepted"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
 
     # Record external consent
     client.post(
         "/privacy-consent/external",
         json={"status": "rejected"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
 
     # Get status
-    res = client.get("/privacy-consent/status", headers={"X-User-Id": "1"})
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": str(test_user)})
     assert res.status_code == 200
     body = res.json()
     assert body["success"] is True
@@ -172,28 +158,23 @@ def test_get_consent_status_after_recording():
     assert body["data"]["external_consent"] == "rejected"
 
 
-def test_get_consent_status_returns_latest():
-    conn = db.connect()
-    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
-    conn.commit()
-    conn.close()
-
+def test_get_consent_status_returns_latest(test_user):
     # Record initial consent
     client.post(
         "/privacy-consent/internal",
         json={"status": "accepted"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
 
     # Change consent
     client.post(
         "/privacy-consent/internal",
         json={"status": "rejected"},
-        headers={"X-User-Id": "1"}
+        headers={"X-User-Id": str(test_user)}
     )
 
     # Get status - should return the latest (rejected)
-    res = client.get("/privacy-consent/status", headers={"X-User-Id": "1"})
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": str(test_user)})
     assert res.status_code == 200
     body = res.json()
     assert body["data"]["internal_consent"] == "rejected"

--- a/tests/api/test_consent_api.py
+++ b/tests/api/test_consent_api.py
@@ -1,0 +1,199 @@
+from fastapi.testclient import TestClient
+from src.api.main import app
+import src.db as db
+
+client = TestClient(app)
+
+
+# POST /privacy-consent/internal tests
+
+def test_internal_consent_requires_user_header():
+    res = client.post("/privacy-consent/internal", json={"status": "accepted"})
+    assert res.status_code == 401
+
+
+def test_internal_consent_with_invalid_user():
+    res = client.post(
+        "/privacy-consent/internal",
+        json={"status": "accepted"},
+        headers={"X-User-Id": "9999"}
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "User not found"
+
+
+def test_internal_consent_accepted():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/privacy-consent/internal",
+        json={"status": "accepted"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["status"] == "accepted"
+    assert body["data"]["user_id"] == 1
+    assert "consent_id" in body["data"]
+    assert "timestamp" in body["data"]
+
+
+def test_internal_consent_rejected():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/privacy-consent/internal",
+        json={"status": "rejected"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["status"] == "rejected"
+
+
+def test_internal_consent_invalid_status():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/privacy-consent/internal",
+        json={"status": "maybe"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 422
+
+
+# POST /privacy-consent/external tests
+
+def test_external_consent_requires_user_header():
+    res = client.post("/privacy-consent/external", json={"status": "accepted"})
+    assert res.status_code == 401
+
+
+def test_external_consent_accepted():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/privacy-consent/external",
+        json={"status": "accepted"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["status"] == "accepted"
+    assert body["data"]["user_id"] == 1
+
+
+def test_external_consent_rejected():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.post(
+        "/privacy-consent/external",
+        json={"status": "rejected"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["status"] == "rejected"
+
+
+# GET /privacy-consent/status tests
+
+def test_get_consent_status_requires_user_header():
+    res = client.get("/privacy-consent/status")
+    assert res.status_code == 401
+
+
+def test_get_consent_status_with_invalid_user():
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": "9999"})
+    assert res.status_code == 404
+    assert res.json()["detail"] == "User not found"
+
+
+def test_get_consent_status_no_consents():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (2, 'new-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": "2"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["user_id"] == 2
+    assert body["data"]["internal_consent"] is None
+    assert body["data"]["external_consent"] is None
+
+
+def test_get_consent_status_after_recording():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    # Record internal consent
+    client.post(
+        "/privacy-consent/internal",
+        json={"status": "accepted"},
+        headers={"X-User-Id": "1"}
+    )
+
+    # Record external consent
+    client.post(
+        "/privacy-consent/external",
+        json={"status": "rejected"},
+        headers={"X-User-Id": "1"}
+    )
+
+    # Get status
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": "1"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["internal_consent"] == "accepted"
+    assert body["data"]["external_consent"] == "rejected"
+
+
+def test_get_consent_status_returns_latest():
+    conn = db.connect()
+    conn.execute("INSERT OR IGNORE INTO users(user_id, username, email) VALUES (1, 'test-user', NULL)")
+    conn.commit()
+    conn.close()
+
+    # Record initial consent
+    client.post(
+        "/privacy-consent/internal",
+        json={"status": "accepted"},
+        headers={"X-User-Id": "1"}
+    )
+
+    # Change consent
+    client.post(
+        "/privacy-consent/internal",
+        json={"status": "rejected"},
+        headers={"X-User-Id": "1"}
+    )
+
+    # Get status - should return the latest (rejected)
+    res = client.get("/privacy-consent/status", headers={"X-User-Id": "1"})
+    assert res.status_code == 200
+    body = res.json()
+    assert body["data"]["internal_consent"] == "rejected"


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds endpoint for GET/privacy-consent and POST/privacy-consent. For the post endpoint, it is divided into two, external and internal. both post and get requires the request header to include user id.  

**Closes:** #373 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] pytest
- [x] manual testing:
        - start the api: uvicorn src.api.main:app --reload
        - go to http://localhost:8000/docs
        - test get endpoint under consent (does get return the correct consents for the user id that was entered)
        - test post endpoint under consent (does the consent in db recorded correctly)

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="1214" height="749" alt="Screenshot 2026-01-17 at 8 41 03 PM" src="https://github.com/user-attachments/assets/345d0060-afd0-4eaa-93b0-fb4372accb11" />
<img width="1067" height="333" alt="Screenshot 2026-01-17 at 8 41 44 PM" src="https://github.com/user-attachments/assets/4dbd32bf-5945-4f6e-b933-cabb1066b168" />
<img width="1067" height="522" alt="Screenshot 2026-01-17 at 8 41 50 PM" src="https://github.com/user-attachments/assets/94b00d9f-093e-4a46-9f3c-1f563ce0edc3" />
<img width="1074" height="342" alt="Screenshot 2026-01-17 at 8 42 12 PM" src="https://github.com/user-attachments/assets/c2231b2e-cf43-4c37-bf27-47443de697ee" />
<img width="1081" height="461" alt="Screenshot 2026-01-17 at 8 42 22 PM" src="https://github.com/user-attachments/assets/46cf4fe6-166a-483c-9064-1fe9e1eb765f" />
<img width="652" height="20" alt="Screenshot 2026-01-17 at 8 42 52 PM" src="https://github.com/user-attachments/assets/9e24ad20-3037-42ff-a229-653de691eb1b" />
<img width="662" height="34" alt="Screenshot 2026-01-17 at 8 43 09 PM" src="https://github.com/user-attachments/assets/a1c26ddf-59e2-4219-abc9-573df43b769a" />

</details>