### PR TITLE
wizard backbone - POST/projects/upload

### DIFF
--- a/debug_token.py
+++ b/debug_token.py
@@ -1,8 +1,0 @@
-from src.db import connect
-from src.github.token_store import get_github_token
-
-conn = connect()
-user_id = 15  # whatever your test user is
-
-token = get_github_token(conn, user_id)
-print("Decrypted token:", token)

--- a/docs/API.md
+++ b/docs/API.md
@@ -330,6 +330,38 @@ Example:
     - `project_mode` (string, optional)
     - `created_at` (string, optional)
 
+### **Upload Wizard DTOs (Projects Upload)**
+
+- **UploadDTO**
+    - `upload_id` (int, required)
+    - `status` (string, required)  
+      Allowed values:
+        - `"started"`
+        - `"parsed"`
+        - `"needs_classification"`
+        - `"needs_file_roles"`
+        - `"needs_summaries"`
+        - `"analyzing"`
+        - `"done"`
+        - `"failed"`
+    - `zip_name` (string, optional)
+    - `state` (object, optional)
+
+- **ClassificationsRequest**
+    - `assignments` (object, required)  
+      Shape: `{ "<project_name>": "<classification>" }`  
+      Allowed values:
+        - `"individual"`
+        - `"collaborative"`
+
+- **ProjectTypesRequest** 
+    - `project_types` (object, required)  
+      Shape: `{ "<project_name>": "<project_type>" }`  
+      Allowed values:
+        - `"text"`
+        - `"code"`
+
+
 ---
 
 ## **Best Practices**

--- a/src/api/dependencies.py
+++ b/src/api/dependencies.py
@@ -1,27 +1,31 @@
 from typing import Generator
-from src.db import connect
-from fastapi import Header, HTTPException
-from src.db import get_user_by_id
+from sqlite3 import Connection
 
-def get_db() -> Generator:
+from fastapi import Header, HTTPException, Depends
+
+from src.db import connect, init_schema, get_user_by_id
+
+
+def get_db() -> Generator[Connection, None, None]:
     conn = connect()
+    init_schema(conn)  # ensure tables exist for API requests
     try:
         yield conn
     finally:
         conn.close()
 
-def get_current_user_id(x_user_id: int | None = Header(default=None, alias="X-User-Id")) -> int:
-    # Temporary dev auth: read user id from request header. Later this should be replaced with real auth (JWT/session) w/o changing endpoints
-    if x_user_id is None: 
+
+def get_current_user_id(
+    conn: Connection = Depends(get_db),
+    x_user_id: int | None = Header(default=None, alias="X-User-Id"),
+) -> int:
+    # Temporary dev auth: read user id from request header. Later replace with real auth (JWT/session)
+    if x_user_id is None:
         raise HTTPException(status_code=401, detail="Missing X-User-Id header")
-    
-    conn = connect()
-    try:
-        user = get_user_by_id(conn, x_user_id)
-    finally:
-        conn.close()
-    
+
+    user = get_user_by_id(conn, x_user_id)
     if user is None:
         raise HTTPException(status_code=404, detail="User not found")
 
-    return x_user_id 
+    return x_user_id
+

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -4,9 +4,9 @@ from sqlite3 import Connection
 from src.api.dependencies import get_db, get_current_user_id
 from src.api.schemas.common import ApiResponse
 from src.api.schemas.projects import ProjectListDTO, ProjectListItemDTO
-from src.api.schemas.uploads import UploadDTO, ClassificationsRequest
+from src.api.schemas.uploads import UploadDTO, ClassificationsRequest, ProjectTypesRequest
 from src.services.projects_service import list_projects
-from src.services.uploads_service import start_upload, get_upload_status, submit_classifications
+from src.services.uploads_service import start_upload, get_upload_status, submit_classifications, submit_project_types
 
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -53,4 +53,15 @@ def post_upload_classifications(
     conn: Connection = Depends(get_db),
 ):
     upload = submit_classifications(conn, user_id, upload_id, payload.assignments)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+
+
+@router.post("/upload/{upload_id}/project-types", response_model=ApiResponse[UploadDTO])
+def post_upload_project_types(
+    upload_id: int,
+    payload: ProjectTypesRequest,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = submit_project_types(conn, user_id, upload_id, payload.project_types)
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -59,9 +59,9 @@ def post_upload_classifications(
 @router.post("/upload/{upload_id}/project-types", response_model=ApiResponse[UploadDTO])
 def post_upload_project_types(
     upload_id: int,
-    payload: ProjectTypesRequest,
+    body: ProjectTypesRequest,
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
-    upload = submit_project_types(conn, user_id, upload_id, payload.project_types)
+    upload = submit_project_types(conn, user_id, upload_id, body.project_types)
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -1,10 +1,12 @@
-from fastapi import APIRouter, Depends, Query
+from fastapi import APIRouter, Depends, Query, UploadFile, File
 from sqlite3 import Connection
 
 from src.api.dependencies import get_db, get_current_user_id
 from src.api.schemas.common import ApiResponse
 from src.api.schemas.projects import ProjectListDTO, ProjectListItemDTO
+from src.api.schemas.uploads import UploadDTO
 from src.services.projects_service import list_projects
+from src.services.uploads_service import start_upload
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -18,6 +20,12 @@ def get_projects(
     
     return ApiResponse(success=True, data=dto, error=None)
 
-@router.post("/upload")
-def post_projects():
-    return {"status": "ok"}
+
+@router.post("/upload", response_model=ApiResponse[UploadDTO])
+def post_projects_upload(
+    file: UploadFile = File(...),
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = start_upload(conn, user_id, file)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -4,9 +4,10 @@ from sqlite3 import Connection
 from src.api.dependencies import get_db, get_current_user_id
 from src.api.schemas.common import ApiResponse
 from src.api.schemas.projects import ProjectListDTO, ProjectListItemDTO
-from src.api.schemas.uploads import UploadDTO
+from src.api.schemas.uploads import UploadDTO, ClassificationsRequest
 from src.services.projects_service import list_projects
-from src.services.uploads_service import start_upload, get_upload_status
+from src.services.uploads_service import start_upload, get_upload_status, submit_classifications
+
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -43,3 +44,13 @@ def get_projects_upload(
 
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
 
+
+@router.post("/upload/{upload_id}/classifications", response_model=ApiResponse[UploadDTO])
+def post_upload_classifications(
+    upload_id: int,
+    payload: ClassificationsRequest,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = submit_classifications(conn, user_id, upload_id, payload.assignments)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -17,3 +17,7 @@ def get_projects(
     dto = ProjectListDTO(projects=[ProjectListItemDTO(**row) for row in rows])
     
     return ApiResponse(success=True, data=dto, error=None)
+
+@router.post("/upload")
+def post_projects():
+    return {"status": "ok"}

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -5,6 +5,7 @@ UploadStatus = Literal[
     "started",
     "parsed",
     "needs_classification",
+    "needs_project_types",
     "needs_file_roles",
     "needs_summaries",
     "analyzing",
@@ -22,5 +23,6 @@ class ClassificationsRequest(BaseModel):
     assignments: Dict[str, str]  # project_name -> individual|collaborative
 
 class ProjectTypesRequest(BaseModel):
-    project_types: Dict[str, Literal["code", "text"]]  # project_name -> code|text
+    project_types: Dict[str, str]  # project_name -> code|text
+
 

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -21,3 +21,6 @@ class UploadDTO(BaseModel):
 class ClassificationsRequest(BaseModel):
     assignments: Dict[str, str]  # project_name -> individual|collaborative
 
+class ProjectTypesRequest(BaseModel):
+    project_types: Dict[str, Literal["code", "text"]]  # project_name -> code|text
+

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -1,0 +1,23 @@
+from pydantic import BaseModel
+from typing import Any, Dict, Optional, Literal
+
+UploadStatus = Literal[
+    "started",
+    "parsed",
+    "needs_classification",
+    "needs_file_roles",
+    "needs_summaries",
+    "analyzing",
+    "done",
+    "failed",
+]
+
+class UploadDTO(BaseModel):
+    upload_id: int
+    status: UploadStatus
+    zip_name: Optional[str] = None
+    state: Dict[str, Any] = {}
+
+class ClassificationsRequest(BaseModel):
+    assignments: Dict[str, str]  # project_name -> individual|collaborative
+

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -188,6 +188,19 @@ from .project_rankings import (
     bulk_set_rankings,
 )
 
+# uploads
+from .uploads import (
+    create_upload,
+    get_upload_by_id,
+    list_uploads_for_user,
+    update_upload_status,
+    update_upload_zip_metadata,
+    set_upload_state,
+    patch_upload_state,
+    mark_upload_failed,
+    delete_upload,
+)
+
 __all__ = [
     "connect",
     "init_schema",
@@ -267,5 +280,23 @@ __all__ = [
     "clear_project_rank",
     "clear_all_rankings",
     "bulk_set_rankings",
-    "get_user_by_id"
+    "get_user_by_id",
+    "get_zip_name_for_project",
+    "insert_resume_snapshot",
+    "list_resumes",
+    "get_resume_snapshot",
+    "update_resume_snapshot",
+    "delete_resume_snapshot",
+    "delete_project_everywhere",
+    "insert_version_files",
+    "set_project_rank",
+    "create_upload",
+    "get_upload_by_id",
+    "list_uploads_for_user",
+    "update_upload_status",
+    "update_upload_zip_metadata",
+    "set_upload_state",
+    "patch_upload_state",
+    "mark_upload_failed",
+    "delete_upload",
 ]

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -628,3 +628,20 @@ CREATE TABLE IF NOT EXISTS project_rankings (
 
 CREATE INDEX IF NOT EXISTS idx_project_rankings_user
     ON project_rankings(user_id, manual_rank);
+
+CREATE TABLE IF NOT EXISTS uploads (
+  upload_id   INTEGER PRIMARY KEY AUTOINCREMENT,
+  user_id     INTEGER NOT NULL,
+  zip_name    TEXT,
+  zip_path    TEXT,
+  status      TEXT NOT NULL DEFAULT 'started'
+              CHECK(status IN ('started','parsed','needs_classification','needs_file_roles','needs_summaries','analyzing','done','failed')),
+  state_json  TEXT, 
+  created_at  TEXT DEFAULT CURRENT_TIMESTAMP,
+  updated_at  TEXT DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_uploads_user_time
+  ON uploads(user_id, created_at);
+

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -635,7 +635,7 @@ CREATE TABLE IF NOT EXISTS uploads (
   zip_name    TEXT,
   zip_path    TEXT,
   status      TEXT NOT NULL DEFAULT 'started'
-              CHECK(status IN ('started','parsed','needs_classification','needs_file_roles','needs_summaries','analyzing','done','failed')),
+              CHECK(status IN ('started','parsed','needs_classification','needs_project_types','needs_file_roles','needs_summaries','analyzing','done','failed')),
   state_json  TEXT, 
   created_at  TEXT DEFAULT CURRENT_TIMESTAMP,
   updated_at  TEXT DEFAULT CURRENT_TIMESTAMP,

--- a/src/db/uploads.py
+++ b/src/db/uploads.py
@@ -1,0 +1,283 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, List, Tuple
+
+
+# Keep statuses aligned with your CHECK constraint in tables.sql
+UPLOAD_STATUSES = {
+    "started",
+    "parsed",
+    "needs_classification",
+    "needs_file_roles",
+    "needs_summaries",
+    "ready_to_analyze",
+    "analyzing",
+    "done",
+    "failed",
+}
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+def create_upload(
+    conn: sqlite3.Connection,
+    user_id: int,
+    zip_name: Optional[str] = None,
+    zip_path: Optional[str] = None,
+    status: str = "started",
+    state: Optional[Dict[str, Any]] = None,
+) -> int:
+    """
+    Create a new upload session row and return upload_id.
+    """
+    if status not in UPLOAD_STATUSES:
+        raise ValueError(f"Invalid upload status: {status}")
+
+    now = _utc_now_iso()
+    state_json = json.dumps(state or {}, ensure_ascii=False)
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO uploads (user_id, zip_name, zip_path, status, state_json, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+        """,
+        (user_id, zip_name, zip_path, status, state_json, now, now),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def get_upload_by_id(conn: sqlite3.Connection, upload_id: int) -> Optional[Dict[str, Any]]:
+    """
+    Return upload row as a dict, including parsed state_json, or None if not found.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT upload_id, user_id, zip_name, zip_path, status, state_json, created_at, updated_at
+        FROM uploads
+        WHERE upload_id = ?
+        """,
+        (upload_id,),
+    )
+    row = cur.fetchone()
+    if not row:
+        return None
+
+    state = {}
+    if row[5]:
+        try:
+            state = json.loads(row[5])
+        except json.JSONDecodeError:
+            state = {}
+
+    return {
+        "upload_id": row[0],
+        "user_id": row[1],
+        "zip_name": row[2],
+        "zip_path": row[3],
+        "status": row[4],
+        "state": state,
+        "created_at": row[6],
+        "updated_at": row[7],
+    }
+
+
+def list_uploads_for_user(
+    conn: sqlite3.Connection,
+    user_id: int,
+    limit: int = 25,
+    offset: int = 0,
+) -> List[Dict[str, Any]]:
+    """
+    List recent uploads for a user (most recent first). Good for "resume upload" UX later.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT upload_id, user_id, zip_name, zip_path, status, state_json, created_at, updated_at
+        FROM uploads
+        WHERE user_id = ?
+        ORDER BY datetime(created_at) DESC
+        LIMIT ? OFFSET ?
+        """,
+        (user_id, limit, offset),
+    )
+    rows = cur.fetchall()
+
+    out: List[Dict[str, Any]] = []
+    for row in rows:
+        state = {}
+        if row[5]:
+            try:
+                state = json.loads(row[5])
+            except json.JSONDecodeError:
+                state = {}
+
+        out.append(
+            {
+                "upload_id": row[0],
+                "user_id": row[1],
+                "zip_name": row[2],
+                "zip_path": row[3],
+                "status": row[4],
+                "state": state,
+                "created_at": row[6],
+                "updated_at": row[7],
+            }
+        )
+    return out
+
+
+def update_upload_status(
+    conn: sqlite3.Connection,
+    upload_id: int,
+    status: str,
+) -> None:
+    """
+    Update only status.
+    """
+    if status not in UPLOAD_STATUSES:
+        raise ValueError(f"Invalid upload status: {status}")
+
+    now = _utc_now_iso()
+    cur = conn.cursor()
+    cur.execute(
+        """
+        UPDATE uploads
+        SET status = ?, updated_at = ?
+        WHERE upload_id = ?
+        """,
+        (status, now, upload_id),
+    )
+    conn.commit()
+
+
+def update_upload_zip_metadata(
+    conn: sqlite3.Connection,
+    upload_id: int,
+    zip_name: Optional[str] = None,
+    zip_path: Optional[str] = None,
+) -> None:
+    """
+    Update zip_name/zip_path (useful right after saving the uploaded file).
+    Only updates fields that are not None.
+    """
+    sets = []
+    params: List[Any] = []
+    if zip_name is not None:
+        sets.append("zip_name = ?")
+        params.append(zip_name)
+    if zip_path is not None:
+        sets.append("zip_path = ?")
+        params.append(zip_path)
+
+    if not sets:
+        return
+
+    sets.append("updated_at = ?")
+    params.append(_utc_now_iso())
+    params.append(upload_id)
+
+    cur = conn.cursor()
+    cur.execute(
+        f"""
+        UPDATE uploads
+        SET {", ".join(sets)}
+        WHERE upload_id = ?
+        """,
+        tuple(params),
+    )
+    conn.commit()
+
+
+def set_upload_state(
+    conn: sqlite3.Connection,
+    upload_id: int,
+    state: Dict[str, Any],
+    *,
+    status: Optional[str] = None,
+) -> None:
+    """
+    Replace state_json entirely. Optionally update status in the same write.
+    """
+    now = _utc_now_iso()
+    state_json = json.dumps(state or {}, ensure_ascii=False)
+
+    if status is not None and status not in UPLOAD_STATUSES:
+        raise ValueError(f"Invalid upload status: {status}")
+
+    if status is None:
+        sql = """
+            UPDATE uploads
+            SET state_json = ?, updated_at = ?
+            WHERE upload_id = ?
+        """
+        params = (state_json, now, upload_id)
+    else:
+        sql = """
+            UPDATE uploads
+            SET state_json = ?, status = ?, updated_at = ?
+            WHERE upload_id = ?
+        """
+        params = (state_json, status, now, upload_id)
+
+    cur = conn.cursor()
+    cur.execute(sql, params)
+    conn.commit()
+
+
+def patch_upload_state(
+    conn: sqlite3.Connection,
+    upload_id: int,
+    patch: Dict[str, Any],
+    *,
+    status: Optional[str] = None,
+) -> Dict[str, Any]:
+    """
+    Merge patch keys into existing state_json.
+    Returns the new merged state.
+    """
+    current = get_upload_by_id(conn, upload_id)
+    if current is None:
+        raise ValueError(f"Upload not found: {upload_id}")
+
+    state = current.get("state") or {}
+    state.update(patch or {})
+    set_upload_state(conn, upload_id, state, status=status)
+    return state
+
+
+def mark_upload_failed(
+    conn: sqlite3.Connection,
+    upload_id: int,
+    error_message: str,
+    *,
+    error_code: Optional[str] = None,
+) -> None:
+    """
+    Mark upload as failed and store error info in state_json.
+    """
+    patch = {
+        "error": {
+            "message": error_message,
+            "code": error_code,
+            "failed_at": _utc_now_iso(),
+        }
+    }
+    patch_upload_state(conn, upload_id, patch, status="failed")
+
+
+def delete_upload(conn: sqlite3.Connection, upload_id: int) -> None:
+    """
+    Optional: delete an upload row. Use carefully if you want resumability.
+    """
+    cur = conn.cursor()
+    cur.execute("DELETE FROM uploads WHERE upload_id = ?", (upload_id,))
+    conn.commit()

--- a/src/db/uploads.py
+++ b/src/db/uploads.py
@@ -11,6 +11,7 @@ UPLOAD_STATUSES = {
     "started",
     "parsed",
     "needs_classification",
+    "needs_project_types",
     "needs_file_roles",
     "needs_summaries",
     "analyzing",

--- a/src/db/uploads.py
+++ b/src/db/uploads.py
@@ -13,7 +13,6 @@ UPLOAD_STATUSES = {
     "needs_classification",
     "needs_file_roles",
     "needs_summaries",
-    "ready_to_analyze",
     "analyzing",
     "done",
     "failed",

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from fastapi import UploadFile
 import re
 
-from src.db.uploads import create_upload, update_upload_zip_metadata, set_upload_state
+from src.db.uploads import create_upload, update_upload_zip_metadata, set_upload_state, get_upload_by_id
 from src.utils.parsing import ZIP_DATA_DIR
 
 UPLOAD_DIR = Path(ZIP_DATA_DIR) / "_uploads"
@@ -26,7 +26,6 @@ def start_upload(conn, user_id: int, file: UploadFile) -> dict:
 
     update_upload_zip_metadata(conn, upload_id, zip_name=zip_name, zip_path=str(zip_path))
 
-    # placeholder for now
     set_upload_state(conn, upload_id, state={"message": "zip saved"}, status="parsed")
 
     return {
@@ -36,3 +35,14 @@ def start_upload(conn, user_id: int, file: UploadFile) -> dict:
         "state": {"message": "zip saved"},
     }
 
+def get_upload_status(conn, user_id: int, upload_id: int) -> dict | None:
+    row = get_upload_by_id(conn, upload_id)
+    if not row or row["user_id"] != user_id:
+        return None
+
+    return {
+        "upload_id": row["upload_id"],
+        "status": row["status"],
+        "zip_name": row.get("zip_name"),
+        "state": row.get("state") or {},
+    }

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from fastapi import UploadFile
+import re
+
+from src.db.uploads import create_upload, update_upload_zip_metadata, set_upload_state
+from src.utils.parsing import ZIP_DATA_DIR
+
+UPLOAD_DIR = Path(ZIP_DATA_DIR) / "_uploads"
+
+def _safe_name(name: str) -> str:
+    name = (name or "").strip()
+    name = name.split("/")[-1].split("\\")[-1]  # drop any path parts
+    name = re.sub(r"[^a-zA-Z0-9._-]+", "_", name)
+    return name or "upload.zip"
+
+def start_upload(conn, user_id: int, file: UploadFile) -> dict:
+    UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
+
+    upload_id = create_upload(conn, user_id, status="started", state={})
+
+    zip_name = _safe_name(file.filename or f"upload_{upload_id}.zip")
+    zip_path = UPLOAD_DIR / f"{upload_id}_{zip_name}"
+
+    with open(zip_path, "wb") as f:
+        f.write(file.file.read())
+
+    update_upload_zip_metadata(conn, upload_id, zip_name=zip_name, zip_path=str(zip_path))
+
+    # placeholder for now
+    set_upload_state(conn, upload_id, state={"message": "zip saved"}, status="parsed")
+
+    return {
+        "upload_id": upload_id,
+        "status": "parsed",
+        "zip_name": zip_name,
+        "state": {"message": "zip saved"},
+    }
+

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -1,17 +1,27 @@
 from pathlib import Path
-from fastapi import UploadFile
+from fastapi import UploadFile, HTTPException
 import re
+import shutil
 
-from src.db.uploads import create_upload, update_upload_zip_metadata, set_upload_state, get_upload_by_id
-from src.utils.parsing import ZIP_DATA_DIR
+from src.db.uploads import (
+    create_upload,
+    update_upload_zip_metadata,
+    set_upload_state,
+    get_upload_by_id,
+    patch_upload_state,
+)
+from src.utils.parsing import ZIP_DATA_DIR, parse_zip_file, analyze_project_layout
+from src.db.projects import record_project_classifications, store_parsed_files
 
 UPLOAD_DIR = Path(ZIP_DATA_DIR) / "_uploads"
 
+
 def _safe_name(name: str) -> str:
     name = (name or "").strip()
-    name = name.split("/")[-1].split("\\")[-1]  # drop any path parts
+    name = name.split("/")[-1].split("\\")[-1]
     name = re.sub(r"[^a-zA-Z0-9._-]+", "_", name)
     return name or "upload.zip"
+
 
 def start_upload(conn, user_id: int, file: UploadFile) -> dict:
     UPLOAD_DIR.mkdir(parents=True, exist_ok=True)
@@ -21,19 +31,50 @@ def start_upload(conn, user_id: int, file: UploadFile) -> dict:
     zip_name = _safe_name(file.filename or f"upload_{upload_id}.zip")
     zip_path = UPLOAD_DIR / f"{upload_id}_{zip_name}"
 
+    # stream copy (don’t read entire zip into memory)
     with open(zip_path, "wb") as f:
-        f.write(file.file.read())
+        shutil.copyfileobj(file.file, f)
 
     update_upload_zip_metadata(conn, upload_id, zip_name=zip_name, zip_path=str(zip_path))
 
-    set_upload_state(conn, upload_id, state={"message": "zip saved"}, status="parsed")
+    # Step 4A: parse + layout (same automatic work CLI does)
+    files_info = parse_zip_file(str(zip_path), user_id=user_id, conn=conn)
+    if not files_info:
+        set_upload_state(
+            conn,
+            upload_id,
+            state={"error": "No valid files were processed from ZIP."},
+            status="failed",
+        )
+        return {
+            "upload_id": upload_id,
+            "status": "failed",
+            "zip_name": zip_name,
+            "state": {"error": "No valid files were processed from ZIP."},
+        }
+
+    # optional: persist parsed metadata to DB (matches your CLI behavior if you already do this there)
+    store_parsed_files(conn, files_info, user_id)
+
+    layout = analyze_project_layout(files_info)
+
+    state = {
+        "zip_name": zip_name,
+        "zip_path": str(zip_path),
+        "layout": layout,
+        "files_info_count": len(files_info),
+    }
+
+    # after parsing, next step is usually classification
+    set_upload_state(conn, upload_id, state=state, status="needs_classification")
 
     return {
         "upload_id": upload_id,
-        "status": "parsed",
+        "status": "needs_classification",
         "zip_name": zip_name,
-        "state": {"message": "zip saved"},
+        "state": state,
     }
+
 
 def get_upload_status(conn, user_id: int, upload_id: int) -> dict | None:
     row = get_upload_by_id(conn, upload_id)
@@ -45,4 +86,46 @@ def get_upload_status(conn, user_id: int, upload_id: int) -> dict | None:
         "status": row["status"],
         "zip_name": row.get("zip_name"),
         "state": row.get("state") or {},
+    }
+
+
+def submit_classifications(conn, user_id: int, upload_id: int, assignments: dict[str, str]) -> dict:
+    upload = get_upload_by_id(conn, upload_id)
+    if not upload or upload["user_id"] != user_id:
+        raise HTTPException(status_code=404, detail="Upload not found")
+
+    if upload["status"] not in {"needs_classification", "parsed"}:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Upload not ready for classifications (status={upload['status']})",
+        )
+
+    if not assignments:
+        raise HTTPException(status_code=422, detail="assignments cannot be empty")
+
+    allowed = {"individual", "collaborative"}
+    invalid = {k: v for k, v in assignments.items() if v not in allowed}
+    if invalid:
+        raise HTTPException(status_code=422, detail={"invalid_assignments": invalid})
+
+    zip_path = upload.get("zip_path")
+    if not zip_path:
+        raise HTTPException(status_code=400, detail="Upload missing zip_path")
+
+    zip_name = Path(zip_path).stem
+
+    record_project_classifications(conn, user_id, zip_path, zip_name, assignments)
+
+    new_state = patch_upload_state(
+        conn,
+        upload_id,
+        patch={"classifications": assignments},
+        status="parsed",
+    )
+
+    return {
+        "upload_id": upload_id,
+        "status": "parsed",
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
     }

--- a/tests/api/test_uploads_wizard.py
+++ b/tests/api/test_uploads_wizard.py
@@ -1,0 +1,137 @@
+import io
+import zipfile
+
+from fastapi.testclient import TestClient
+
+from src.api.main import app
+import src.db as db
+
+client = TestClient(app)
+
+
+def _seed_user(user_id: int = 1):
+    conn = db.connect()
+    conn.execute(
+        "INSERT OR IGNORE INTO users(user_id, username) VALUES (?, 'test-user')",
+        (user_id,),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_zip_bytes(files: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as z:
+        for path, content in files.items():
+            z.writestr(path, content)
+    return buf.getvalue()
+
+
+def test_upload_requires_user_header():
+    zip_bytes = _make_zip_bytes({"ProjectA/readme.txt": "hello"})
+    res = client.post(
+        "/projects/upload",
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    )
+    assert res.status_code == 401
+
+
+def test_upload_invalid_user_is_404():
+    zip_bytes = _make_zip_bytes({"ProjectA/readme.txt": "hello"})
+    res = client.post(
+        "/projects/upload",
+        headers={"X-User-Id": "999"},
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "User not found"
+
+
+def test_upload_start_and_get_status():
+    _seed_user(1)
+
+    zip_bytes = _make_zip_bytes({"ProjectA/readme.txt": "hello"})
+    res = client.post(
+        "/projects/upload",
+        headers={"X-User-Id": "1"},
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+
+    upload = body["data"]
+    assert "upload_id" in upload
+    upload_id = upload["upload_id"]
+    assert upload["status"] in {"needs_classification", "failed"}
+
+    # GET upload status
+    res2 = client.get(f"/projects/upload/{upload_id}", headers={"X-User-Id": "1"})
+    assert res2.status_code == 200
+    body2 = res2.json()
+    assert body2["success"] is True
+    assert body2["data"]["upload_id"] == upload_id
+
+
+def test_submit_classifications_validates_values():
+    _seed_user(1)
+
+    zip_bytes = _make_zip_bytes({"ProjectA/readme.txt": "hello"})
+    start = client.post(
+        "/projects/upload",
+        headers={"X-User-Id": "1"},
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    ).json()
+    upload_id = start["data"]["upload_id"]
+
+    # invalid classification
+    bad = client.post(
+        f"/projects/upload/{upload_id}/classifications",
+        headers={"X-User-Id": "1"},
+        json={"assignments": {"ProjectA": "solo"}},
+    )
+    assert bad.status_code == 422
+
+    # valid classification
+    ok = client.post(
+        f"/projects/upload/{upload_id}/classifications",
+        headers={"X-User-Id": "1"},
+        json={"assignments": {"ProjectA": "individual"}},
+    )
+    assert ok.status_code == 200
+    ok_body = ok.json()
+    assert ok_body["success"] is True
+    assert ok_body["data"]["state"]["classifications"]["ProjectA"] == "individual"
+
+    # verify DB write exists
+    conn = db.connect()
+    row = conn.execute(
+        """
+        SELECT classification
+        FROM project_classifications
+        WHERE user_id = 1 AND project_name = 'ProjectA'
+        """,
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    assert row[0] == "individual"
+
+
+def test_submit_project_types_unknown_project_is_422():
+    _seed_user(1)
+
+    zip_bytes = _make_zip_bytes({"ProjectA/readme.txt": "hello"})
+    start = client.post(
+        "/projects/upload",
+        headers={"X-User-Id": "1"},
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    ).json()
+    upload_id = start["data"]["upload_id"]
+
+    # Unknown project key should 422
+    res = client.post(
+        f"/projects/upload/{upload_id}/project-types",
+        headers={"X-User-Id": "1"},
+        json={"project_types": {"NotAProject": "text"}},
+    )
+    assert res.status_code == 422


### PR DESCRIPTION
## 📝 Description

While designing `POST /projects/upload`, I realized the CLI “Option 1” flow can’t be represented as a single straightforward POST request because it requires multiple user inputs at different points (classifications, file selections, optional project-type decisions, etc.). To support the upcoming frontend, we need a resumable wizard-style upload session with multiple supporting endpoints (estimated about 19 total for the full flow). Please check out my brainstorm document [here](https://docs.google.com/document/d/1kRJgC2j8xNbDi3-oLfreiviYlPMAYofwUteH6d4g7gQ/edit?usp=sharing) for more details.

This PR implements the **first 4 wizard endpoints** and the underlying DB state needed to track upload progress and resume the flow safely. I plan on adding more PRs to complete the full scope of POST/ projects/ upload (the other 15 supporting endpoints).

### What’s Included (Endpoints 1–4)

#### 1) Start upload session + save zip

* `POST /projects/upload`
* Accepts a ZIP file (`multipart/form-data`) and creates an upload session.
* Saves the ZIP under `src/analysis/zip_data/_uploads/`.
* Parses the zip to detect project layout and stores wizard state in DB.

#### 2) Resume / poll upload status

* `GET /projects/upload/{upload_id}`
* Returns current upload `status` + `state` so the frontend can drive the next UI step.

#### 3) Submit project classifications (individual vs collaborative)

* `POST /projects/upload/{upload_id}/classifications`
* Persists user classifications:

  * Writes to existing `project_classifications` table (same as CLI behavior)
  * Also stores selections under `uploads.state_json` for frontend wizard state

#### 4) Submit project types (code vs text) — for mixed projects

* `POST /projects/upload/{upload_id}/project-types`
* Used only when a project needs an explicit user decision between `code` vs `text`.
* Stores the mapping under `uploads.state_json` (frontend needs this for later steps).


### Database Changes

* Added new `uploads` table to track resumable upload sessions:

  * `upload_id`, `user_id`, zip metadata, status, and a `state_json` blob for wizard state
* Added DB helper functions in `src/db/uploads.py` to create, read, and update upload session state.


### API / Infra Changes

* Updated `dependencies.py` so requests use a single shared DB connection (prevents mismatched connections / missing schema issues).
* Added upload DTOs in `src/api/schemas/uploads.py`.
* Added upload service logic in `src/services/uploads_service.py`.
* Added routes in `src/api/routes/projects.py`.

**Closes:** #377 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] run `python -m pytest`
- [x] manually test using Postman:

* Run the API locally:
  * `uvicorn src.api.main:app --reload`
* Ensure you have a valid user in the DB (for now, auth is via header).
  * Every request below must include:
    * Header: `X-User-Id: 1` (or another existing user_id)


### 1) Start Upload

**Request**
* `POST http://localhost:8000/projects/upload`
* Headers:
  * `X-User-Id: 1`
* Body:
  * `form-data`
    * key: `file` (type: File)
    * value: select a `.zip`

**Expected**
* `200 OK`
* Response includes:
  * `data.upload_id`
  * `data.status` (likely `needs_classification`)
  * `data.state.layout` (auto_assignments / pending_projects)


### 2) Check Upload Status (Resume / Poll)
**Request**
* `GET http://localhost:8000/projects/upload/{upload_id}`
* Headers:
  * `X-User-Id: 1`

**Expected**
* `200 OK`
* Response returns current `status` and `state` for that upload.


### 3) Submit Classifications

Use project names exactly as returned under:
* `data.state.layout.pending_projects`
* `data.state.layout.auto_assignments`

**Request**
* `POST http://localhost:8000/projects/upload/{upload_id}/classifications`
* Headers:
  * `X-User-Id: 1`
* Body (raw JSON) modify according to project name and assignment:
```json
{
  "assignments": {
    "PlantGrowthStudy": "individual"
  }
}
```

**Expected**
* `200 OK`
* Response `data.state.classifications` matches your submission.


### 4) Submit Project Types (Optional / Mixed Projects Only)
Only required if a project needs user selection between `code` vs `text`.
**Request**
* `POST http://localhost:8000/projects/upload/{upload_id}/project-types`
* Headers:
  * `X-User-Id: 1`
* Body (raw JSON) modify according to project name and type:
```json
{
  "project_types": {
    "PlantGrowthStudy": "text"
  }
}
```
**Expected**
* `200 OK`
* Response `data.state.project_types` matches your submission.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots