### PR TITLE
Customize portfolios

### DIFF
--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -196,15 +196,15 @@ def export_resume_record_to_docx(
         date_line = format_date_range(p.get("start_date"), p.get("end_date"))
         add_role_date_line(doc, role, date_line)
 
-        # bullets (same logic you already have)
+        # bullets - priority: overrides first, then base contribution_bullets
         custom_bullets = _resume_contribution_bullets(p)
         contrib_bullets = _clean_bullets(p.get("contribution_bullets") or [])
 
         bullets_to_use: List[str] = []
-        if contrib_bullets:
-            bullets_to_use = contrib_bullets
-        elif custom_bullets:
+        if custom_bullets:
             bullets_to_use = custom_bullets
+        elif contrib_bullets:
+            bullets_to_use = contrib_bullets
         else:
             if p.get("project_type") == "code":
                 activities = p.get("activities") or []

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -265,10 +265,11 @@ def export_resume_record_to_pdf(
         story.append(Paragraph(str(title), ProjectTitleStyle))
         story.append(Paragraph(meta, MetaItalic))
 
+        # Priority: resume-specific override > global override > base field
         bullets = _clean_bullets(
-            p.get("contribution_bullets")
-            or p.get("resume_contributions_override")
+            p.get("resume_contributions_override")
             or p.get("manual_contribution_bullets")
+            or p.get("contribution_bullets")
             or []
         )
 

--- a/src/insights/portfolio/__init__.py
+++ b/src/insights/portfolio/__init__.py
@@ -5,7 +5,9 @@ from .formatters import (
     format_activity_line,
     format_skills_block,
     format_summary_block,
+    resolve_portfolio_contribution_bullets,
     resolve_portfolio_display_name,
+    resolve_portfolio_summary_text,
 )
 
 __all__ = [
@@ -15,5 +17,7 @@ __all__ = [
     "format_activity_line",
     "format_skills_block",
     "format_summary_block",
+    "resolve_portfolio_contribution_bullets",
     "resolve_portfolio_display_name",
+    "resolve_portfolio_summary_text",
 ]

--- a/src/insights/portfolio/formatters.py
+++ b/src/insights/portfolio/formatters.py
@@ -384,8 +384,9 @@ def format_summary_block(
         if len(manual_bullets) == 1:
             lines.append(f"  - My contribution: {manual_bullets[0]}")
         else:
+            lines.append("  My contributions:")
             for bullet in manual_bullets:
-                lines.append(f"  - Contribution: {bullet}")
+                lines.append(f"    - {bullet}")
         return lines
 
     # Code projects

--- a/src/insights/portfolio/formatters.py
+++ b/src/insights/portfolio/formatters.py
@@ -40,10 +40,79 @@ def _manual_overrides(summary: Dict[str, Any]) -> Dict[str, Any]:
     return overrides
 
 
+def _portfolio_overrides(summary: Dict[str, Any]) -> Dict[str, Any]:
+    overrides = summary.get("portfolio_overrides") or {}
+    if not isinstance(overrides, dict):
+        return {}
+    return overrides
+
+
 def resolve_portfolio_display_name(summary: Dict[str, Any], project_name: str) -> str:
+    portfolio = _portfolio_overrides(summary)
+    manual_name = _clean_str(portfolio.get("display_name"))
+    if manual_name:
+        return manual_name
     overrides = _manual_overrides(summary)
     manual_name = _clean_str(overrides.get("display_name"))
     return manual_name or project_name
+
+
+def resolve_portfolio_summary_text(summary: Dict[str, Any]) -> str | None:
+    portfolio = _portfolio_overrides(summary)
+    manual_summary = _clean_str(portfolio.get("summary_text"))
+    if manual_summary:
+        return manual_summary
+    overrides = _manual_overrides(summary)
+    manual_summary = _clean_str(overrides.get("summary_text"))
+    if manual_summary:
+        return manual_summary
+    return _clean_str(summary.get("summary_text"))
+
+
+def resolve_portfolio_contribution_bullets(
+    summary: Dict[str, Any],
+    project_type: str,
+    project_mode: str,
+    conn,
+    user_id: int,
+    project_name: str,
+) -> List[str]:
+    portfolio = _portfolio_overrides(summary)
+    bullets = _clean_bullets(portfolio.get("contribution_bullets"))
+    if bullets:
+        return bullets
+
+    overrides = _manual_overrides(summary)
+    bullets = _clean_bullets(overrides.get("contribution_bullets"))
+    if bullets:
+        return bullets
+
+    contributions = summary.get("contributions") or {}
+    if project_type == "code":
+        manual_contrib = contributions.get("manual_contribution_summary") or contributions.get(
+            "non_llm_contribution_summary"
+        )
+        if isinstance(manual_contrib, str) and manual_contrib.strip():
+            return [manual_contrib.strip()]
+
+        llm_contrib = contributions.get("llm_contribution_summary")
+        if isinstance(llm_contrib, str) and llm_contrib.strip():
+            return [llm_contrib.strip()]
+
+        if project_mode == "collaborative" and conn and user_id is not None and project_name:
+            non_llm_content = get_code_collaborative_non_llm_summary(conn, user_id, project_name)
+            if isinstance(non_llm_content, str) and non_llm_content.strip():
+                return [non_llm_content.strip()]
+
+        return []
+
+    if project_type == "text":
+        text_collab = contributions.get("text_collab") or {}
+        text_contrib = text_collab.get("contribution_summary")
+        if isinstance(text_contrib, str) and text_contrib.strip():
+            return [text_contrib.strip()]
+
+    return []
 
 def format_duration(
     project_type: str,
@@ -296,10 +365,18 @@ def format_summary_block(
       Summary: <summary_text>
     """
     lines: List[str] = []
+    portfolio = _portfolio_overrides(summary)
     manual = _manual_overrides(summary)
-    project_summary = _clean_str(manual.get("summary_text")) or summary.get("summary_text") or ""
+    project_summary = (
+        _clean_str(portfolio.get("summary_text"))
+        or _clean_str(manual.get("summary_text"))
+        or summary.get("summary_text")
+        or ""
+    )
     contributions = summary.get("contributions") or {}
-    manual_bullets = _clean_bullets(manual.get("contribution_bullets"))
+    manual_bullets = _clean_bullets(portfolio.get("contribution_bullets"))
+    if not manual_bullets:
+        manual_bullets = _clean_bullets(manual.get("contribution_bullets"))
 
     if manual_bullets:
         lines.append("Summary:")

--- a/src/menu/portfolio.py
+++ b/src/menu/portfolio.py
@@ -28,9 +28,53 @@ from src.menu.resume.flow import (
     _update_project_manual_overrides,
 )
 
+
+def view_portfolio_menu(conn, user_id: int, username: str) -> None:
+    """
+    Portfolio submenu with options to view, edit, and export.
+    """
+    while True:
+        print("\nPortfolio options:")
+        print("")
+        print("1. View portfolio")
+        print("2. Edit wording")
+        print("3. Export to Word (.docx)")
+        print("4. Back to main menu")
+        choice = input("Select an option (1-4): ").strip()
+
+        if choice == "1":
+            _display_portfolio(conn, user_id, username)
+            print("")
+            continue
+        elif choice == "2":
+            handled = _handle_edit_portfolio_wording(conn, user_id, username)
+            if handled:
+                print("")
+                continue
+        elif choice == "3":
+            handled = _handle_export_portfolio(conn, user_id, username)
+            if handled:
+                print("")
+                continue
+        elif choice == "4":
+            print("")
+            return
+        else:
+            print("Invalid choice, please enter 1, 2, 3, or 4.")
+
+
+# Keep old function name as alias for backwards compatibility
 def view_portfolio_items(conn, user_id: int, username: str) -> None:
     """
-    Display a ranked portfolio view for the user.
+    Backwards-compatible alias for view_portfolio_menu.
+    """
+    view_portfolio_menu(conn, user_id, username)
+
+
+def _display_portfolio(conn, user_id: int, username: str) -> bool:
+    """
+    Display the ranked portfolio view (no prompts).
+    Returns True if portfolio was displayed, False if no projects.
     """
     try:
         project_scores = collect_project_data(conn, user_id)
@@ -39,7 +83,7 @@ def view_portfolio_items(conn, user_id: int, username: str) -> None:
             print(f"\n{'=' * 80}")
             print("No projects found. Please analyze some projects first.")
             print(f"{'=' * 80}\n")
-            return
+            return False
 
         print(f"\n{'=' * 80}")
         print(f"Portfolio view for {username}")
@@ -85,29 +129,27 @@ def view_portfolio_items(conn, user_id: int, username: str) -> None:
             print()  # blank line between projects
 
         print(f"{'=' * 80}\n")
-
-        # --- Export prompt ---
-        answer = input(
-            "Do you want to export this portfolio to a Word document (.docx)? (y/n) "
-        ).strip().lower()
-
-        if answer == "y":
-            out_file = export_portfolio_to_docx(conn, user_id, username, out_dir="./out")
-            print(f"\nSaving portfolio to {out_file} ...")
-            print("✓ Export complete.\n")
-
-        edit_answer = input(
-            "Do you want to edit wording in this portfolio? (y/n) "
-        ).strip().lower()
-        if edit_answer == "y":
-            _handle_edit_portfolio_wording(conn, user_id, username)
-
-        print("\nReturning to main menu...\n")
-        return
+        return True
 
     except Exception as e:
         print(f"Error displaying portfolio items: {e}")
         print(f"{'=' * 80}\n")
+        return False
+
+
+def _handle_export_portfolio(conn, user_id: int, username: str) -> bool:
+    """
+    Export the portfolio to a Word document.
+    """
+    project_scores = collect_project_data(conn, user_id)
+    if not project_scores:
+        print("No projects found. Please analyze some projects first.")
+        return False
+
+    out_file = export_portfolio_to_docx(conn, user_id, username, out_dir="./out")
+    print(f"\nSaving portfolio to {out_file} ...")
+    print("Export complete.\n")
+    return True
 
 
 def _prompt_edit_sections() -> set[str]:

--- a/src/menu/portfolio.py
+++ b/src/menu/portfolio.py
@@ -6,10 +6,11 @@ Menu option for viewing portfolio items.
 
 from __future__ import annotations
 
+import json
 from typing import Any, Dict, List, Tuple
 
 from src.insights.rank_projects.rank_project_importance import collect_project_data
-from src.db import get_project_summary_row
+from src.db import get_project_summary_by_name, get_project_summary_row, update_project_summary_json
 from src.insights.portfolio import (
     format_duration,
     format_languages,
@@ -17,9 +18,15 @@ from src.insights.portfolio import (
     format_activity_line,
     format_skills_block,
     format_summary_block,
+    resolve_portfolio_contribution_bullets,
     resolve_portfolio_display_name,
+    resolve_portfolio_summary_text,
 )
 from src.export.portfolio_docx import export_portfolio_to_docx
+from src.menu.resume.flow import (
+    _apply_manual_overrides_to_resumes,
+    _update_project_manual_overrides,
+)
 
 def view_portfolio_items(conn, user_id: int, username: str) -> None:
     """
@@ -88,10 +95,225 @@ def view_portfolio_items(conn, user_id: int, username: str) -> None:
             out_file = export_portfolio_to_docx(conn, user_id, username, out_dir="./out")
             print(f"\nSaving portfolio to {out_file} ...")
             print("✓ Export complete.\n")
-        else:
-            print("\nReturning to main menu...\n")
-            return
+
+        edit_answer = input(
+            "Do you want to edit wording in this portfolio? (y/n) "
+        ).strip().lower()
+        if edit_answer == "y":
+            _handle_edit_portfolio_wording(conn, user_id, username)
+
+        print("\nReturning to main menu...\n")
+        return
 
     except Exception as e:
         print(f"Error displaying portfolio items: {e}")
         print(f"{'=' * 80}\n")
+
+
+def _prompt_edit_sections() -> set[str]:
+    print("\nWhat would you like to edit?")
+    print("1. Summary text")
+    print("2. Contribution bullets")
+    print("3. Display name")
+    raw = input("Select one or more (e.g., 1,3) or press Enter to cancel: ").strip()
+    if not raw:
+        return set()
+    selected: set[str] = set()
+    for token in raw.replace(" ", "").split(","):
+        if token == "1":
+            selected.add("summary_text")
+        elif token == "2":
+            selected.add("contribution_bullets")
+        elif token == "3":
+            selected.add("display_name")
+    return selected
+
+
+def _collect_section_updates(
+    sections: set[str],
+    project_entry: dict,
+    conn,
+    user_id: int,
+) -> dict[str, Any]:
+    updates: dict[str, Any] = {}
+    if "display_name" in sections:
+        display_name = input("New display name (leave blank to clear): ").strip()
+        updates["display_name"] = display_name or None
+    if "summary_text" in sections:
+        summary_text = input("New summary text (leave blank to clear): ").strip()
+        updates["summary_text"] = summary_text or None
+    if "contribution_bullets" in sections:
+        current_bullets = resolve_portfolio_contribution_bullets(
+            project_entry.get("summary") or {},
+            project_entry.get("project_type") or "unknown",
+            project_entry.get("project_mode") or "individual",
+            conn,
+            user_id,
+            project_entry.get("project_name") or "",
+        )
+
+        if current_bullets:
+            print("\nCurrent contributions:")
+            for bullet in current_bullets:
+                print(f"  - {bullet}")
+
+            print("\nHow would you like to edit?")
+            print("1. Add on to existing contributions")
+            print("2. Completely rewrite")
+            mode = input("Select (1-2): ").strip()
+
+            if mode == "1":
+                print("\nEnter additional contribution bullets (one per line). Press Enter on a blank line to finish.")
+                new_bullets: list[str] = []
+                while True:
+                    line = input("> ").strip()
+                    if not line:
+                        break
+                    new_bullets.append(line)
+                if new_bullets:
+                    updates["contribution_bullets"] = current_bullets + new_bullets
+            else:
+                print("\nEnter contribution bullets (one per line). Press Enter on a blank line to finish.")
+                bullets: list[str] = []
+                while True:
+                    line = input("> ").strip()
+                    if not line:
+                        break
+                    bullets.append(line)
+                updates["contribution_bullets"] = bullets or None
+        else:
+            print("Enter contribution bullets (one per line). Press Enter on a blank line to finish.")
+            bullets: list[str] = []
+            while True:
+                line = input("> ").strip()
+                if not line:
+                    break
+                bullets.append(line)
+            updates["contribution_bullets"] = bullets or None
+
+    return updates
+
+
+def _update_project_portfolio_overrides(
+    conn,
+    user_id: int,
+    project_name: str,
+    updates: dict[str, Any],
+) -> dict[str, Any] | None:
+    summary_row = get_project_summary_by_name(conn, user_id, project_name)
+    if not summary_row:
+        return None
+
+    try:
+        summary_dict = json.loads(summary_row["summary_json"])
+    except Exception:
+        return None
+
+    overrides = summary_dict.get("portfolio_overrides") or {}
+    if not isinstance(overrides, dict):
+        overrides = {}
+
+    for key, value in updates.items():
+        if value:
+            overrides[key] = value
+        else:
+            overrides.pop(key, None)
+
+    if overrides:
+        summary_dict["portfolio_overrides"] = overrides
+    else:
+        summary_dict.pop("portfolio_overrides", None)
+
+    updated = update_project_summary_json(conn, user_id, project_name, json.dumps(summary_dict))
+    if not updated:
+        return None
+    return overrides
+
+
+def _handle_edit_portfolio_wording(conn, user_id: int, username: str) -> bool:
+    project_scores = collect_project_data(conn, user_id)
+    if not project_scores:
+        print("No projects found. Please analyze some projects first.")
+        return False
+
+    portfolio_entries: list[dict[str, Any]] = []
+    print("\nProjects in this portfolio:")
+    for project_name, score in project_scores:
+        row = get_project_summary_row(conn, user_id, project_name)
+        if row is None:
+            continue
+        summary = row.get("summary") or {}
+        display = resolve_portfolio_display_name(summary, project_name)
+        summary_text = resolve_portfolio_summary_text(summary) or ""
+        preview = (summary_text[:60] + "...") if summary_text and len(summary_text) > 60 else summary_text
+        suffix = f" — {preview}" if preview else ""
+        portfolio_entries.append(
+            {
+                "project_name": project_name,
+                "project_type": row.get("project_type") or summary.get("project_type"),
+                "project_mode": row.get("project_mode") or summary.get("project_mode"),
+                "summary": summary,
+            }
+        )
+        print(f"{len(portfolio_entries)}. {display}{suffix}")
+
+    if not portfolio_entries:
+        print("No portfolio entries found to edit.")
+        return False
+
+    proj_choice = input("Select a project to edit (number) or press Enter to cancel: ").strip()
+    if not proj_choice.isdigit():
+        print("Cancelled.")
+        return False
+
+    idx = int(proj_choice)
+    if idx < 1 or idx > len(portfolio_entries):
+        print("Invalid selection.")
+        return False
+
+    project_entry = portfolio_entries[idx - 1]
+    project_name = project_entry.get("project_name") or ""
+    if not project_name:
+        print("Selected project is missing a project name.")
+        return False
+
+    print("\nApply changes to:")
+    print("1. This portfolio only")
+    print("2. All resumes & portfolio")
+    scope_choice = input("Select scope (1-2): ").strip()
+    if scope_choice not in {"1", "2"}:
+        print("Cancelled.")
+        return False
+
+    sections = _prompt_edit_sections()
+    if not sections:
+        print("Cancelled.")
+        return False
+
+    updates = _collect_section_updates(sections, project_entry, conn, user_id)
+    if not updates:
+        print("No updates provided.")
+        return False
+
+    if scope_choice == "1":
+        overrides = _update_project_portfolio_overrides(conn, user_id, project_name, updates)
+        if overrides is None:
+            print("Unable to update portfolio overrides.")
+            return False
+        print("[Portfolio] Updated wording for this portfolio.")
+        return True
+
+    manual_overrides = _update_project_manual_overrides(conn, user_id, project_name, updates)
+    if manual_overrides is None:
+        print("Unable to update project summary for global overrides.")
+        return False
+
+    _apply_manual_overrides_to_resumes(
+        conn,
+        user_id,
+        project_name,
+        manual_overrides,
+        set(updates.keys()),
+    )
+    print("[Portfolio] Updated wording across resumes and portfolio.")
+    return True

--- a/tests/test_portfolio_docx.py
+++ b/tests/test_portfolio_docx.py
@@ -265,6 +265,53 @@ def test_portfolio_export_uses_manual_overrides(monkeypatch, tmp_path, mem_conn)
     assert "Contribution: Did X" in txt
     assert "Contribution: Did Y" in txt
 
+
+def test_portfolio_export_uses_portfolio_overrides(monkeypatch, tmp_path, mem_conn):
+    import src.export.portfolio_docx as exp
+
+    monkeypatch.setattr(exp, "collect_project_data", lambda conn, user_id: [("proj1", 0.8)])
+    monkeypatch.setattr(exp, "format_duration", lambda *a, **k: "Duration: N/A")
+    monkeypatch.setattr(exp, "format_activity_line", lambda *a, **k: "Activity: N/A")
+    monkeypatch.setattr(exp, "format_skills_block", lambda summary: ["Skills: N/A"])
+
+    summary = {
+        "project_name": "proj1",
+        "project_type": "code",
+        "project_mode": "individual",
+        "languages": [],
+        "frameworks": [],
+        "summary_text": "Original summary",
+        "metrics": {},
+        "contributions": {},
+        "manual_overrides": {
+            "display_name": "Manual Name",
+            "summary_text": "Manual summary",
+            "contribution_bullets": ["Manual X"],
+        },
+        "portfolio_overrides": {
+            "display_name": "Portfolio Name",
+            "summary_text": "Portfolio summary",
+            "contribution_bullets": ["Portfolio A", "Portfolio B"],
+        },
+    }
+
+    mem_conn.execute(
+        """
+        INSERT INTO project_summaries(user_id, project_name, project_type, project_mode, summary_json, created_at)
+        VALUES(?,?,?,?,?,?)
+        """,
+        (1, "proj1", "code", "individual", json.dumps(summary), "2026-01-01"),
+    )
+    mem_conn.commit()
+
+    out_dir = tmp_path / "out"
+    path = exp.export_portfolio_to_docx(mem_conn, 1, "salma", out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "Portfolio Name" in txt
+    assert "Project: Portfolio summary" in txt
+    assert "Contribution: Portfolio A" in txt
+    assert "Contribution: Portfolio B" in txt
 def test_portfolio_export_embeds_thumbnail_when_available(monkeypatch, tmp_path, mem_conn):
     import src.export.portfolio_docx as exp
 
@@ -329,4 +376,3 @@ def test_portfolio_export_embeds_thumbnail_when_available(monkeypatch, tmp_path,
     doc = Document(str(path))
     # robust: check the docx package has at least one image part
     assert len(doc.part.package.image_parts) >= 1
-

--- a/tests/test_portfolio_docx.py
+++ b/tests/test_portfolio_docx.py
@@ -125,27 +125,13 @@ def test_portfolio_export_happy_creates_out_and_contains_fields(monkeypatch, tmp
     assert "Project: test project" in txt
 
 
-def test_portfolio_view_decline_export(monkeypatch, mem_conn, capsys):
+def test_portfolio_menu_back_without_export(monkeypatch, mem_conn, capsys):
     """
-    Covers: P2 (user answers 'n' -> no export call)
+    Covers: P2 (user selects 'Back' -> no export call)
     """
     import src.menu.portfolio as menu
 
     monkeypatch.setattr(menu, "collect_project_data", lambda conn, user_id: [("paper", 0.1)])
-    monkeypatch.setattr(
-        menu,
-        "get_project_summary_row",
-        lambda conn, user_id, name: {
-            "summary": {"summary_text": "x"},
-            "project_type": "text",
-            "project_mode": "individual",
-            "created_at": "2026-01-01",
-        },
-    )
-    monkeypatch.setattr(menu, "format_duration", lambda *a, **k: "Duration: N/A")
-    monkeypatch.setattr(menu, "format_activity_line", lambda *a, **k: "Activity: N/A")
-    monkeypatch.setattr(menu, "format_skills_block", lambda s: ["Skills: N/A"])
-    monkeypatch.setattr(menu, "format_summary_block", lambda *a, **k: ["Summary: x"])
 
     called = {"export": False}
 
@@ -153,11 +139,12 @@ def test_portfolio_view_decline_export(monkeypatch, mem_conn, capsys):
         called["export"] = True
 
     monkeypatch.setattr(menu, "export_portfolio_to_docx", _fake_export)
-    monkeypatch.setattr("builtins.input", lambda _: "n")
+    # Select option 4 (Back to main menu) immediately
+    monkeypatch.setattr("builtins.input", lambda _: "4")
 
-    menu.view_portfolio_items(mem_conn, user_id=1, username="salma")
+    menu.view_portfolio_menu(mem_conn, user_id=1, username="salma")
     out = capsys.readouterr().out
-    assert "Returning to main menu" in out
+    assert "Portfolio options:" in out
     assert called["export"] is False
 
 
@@ -262,8 +249,9 @@ def test_portfolio_export_uses_manual_overrides(monkeypatch, tmp_path, mem_conn)
     txt = _doc_text(path)
     assert "Manual Name" in txt
     assert "Project: Manual summary" in txt
-    assert "Contribution: Did X" in txt
-    assert "Contribution: Did Y" in txt
+    assert "My contributions:" in txt
+    assert "Did X" in txt
+    assert "Did Y" in txt
 
 
 def test_portfolio_export_uses_portfolio_overrides(monkeypatch, tmp_path, mem_conn):
@@ -310,8 +298,11 @@ def test_portfolio_export_uses_portfolio_overrides(monkeypatch, tmp_path, mem_co
     txt = _doc_text(path)
     assert "Portfolio Name" in txt
     assert "Project: Portfolio summary" in txt
-    assert "Contribution: Portfolio A" in txt
-    assert "Contribution: Portfolio B" in txt
+    assert "My contributions:" in txt
+    assert "Portfolio A" in txt
+    assert "Portfolio B" in txt
+
+
 def test_portfolio_export_embeds_thumbnail_when_available(monkeypatch, tmp_path, mem_conn):
     import src.export.portfolio_docx as exp
 


### PR DESCRIPTION
## 📝 Description

Adds portfolio wording customization with local vs global overrides. Users can edit display name, summary text, and contribution bullets from the portfolio view, choosing either portfolio-only changes or global updates shared with resumes. Includes tests for override precedence.

Note: this branch will be rebased once PR #393 is merged. 

**Closes:** #395

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Manual: View a portfolio, choose "edit wording," update display name/summary/contributions (portfolio-only), re-open the portfolio to verify. Then repeat with "All resumes & portfolio" and confirm a saved resume snapshot reflects the global change.

- [x] `pytest tests/test_portfolio_view.py tests/test_portfolio_docx.py`

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
<details>
<summary>Click to expand screenshots</summary>

Edit Portfolio Contributions (global example with no existing contributions for portfolio):
Editing portfolio:
<img width="802" height="432" alt="Screenshot 2026-01-21 at 8 51 11 PM" src="https://github.com/user-attachments/assets/fdc6328a-25f1-4d2d-aac4-d94be37edd4d" />

Portfolio view:
<img width="749" height="290" alt="Screenshot 2026-01-21 at 8 51 24 PM" src="https://github.com/user-attachments/assets/156bad5d-5010-4632-b691-803438c1e40d" />

Resume view:
<img width="977" height="188" alt="Screenshot 2026-01-21 at 8 51 35 PM" src="https://github.com/user-attachments/assets/ddac25b1-5d30-498c-af5b-95570b939f5b" />

</details>