### PR TITLE
Post/resume/generate

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -477,10 +477,90 @@ Manages résumé-specific representations of projects.
             "error": null
         }
         ```
-        
-        
 
+- **Generate Resume**
+    - **Endpoint**: `POST /resume/generate`
+    - **Description**: Creates a new résumé snapshot from the user's projects. If `project_ids` is not provided, automatically selects the top 5 ranked projects. Builds the snapshot, enriches with contribution bullets and dates, and renders the text.
+    - **Headers**:
+        - `X-User-Id` (integer, required): Current user identifier
+    - **Request Body**: Uses `ResumeGenerateRequestDTO`
+        ```json
+        {
+            "name": "My Resume",
+            "project_ids": [1, 3, 5]
+        }
+        ```
+        - `name` (string, required): Name for the résumé snapshot
+        - `project_ids` (array of integers, optional): List of project IDs to include. If omitted, uses top 5 ranked projects.
+    - **Response Status**: `201 Created` or `400 Bad Request`
+    - **Response Body**: Uses `ResumeDetailDTO`
+        ```json
+        {
+            "success": true,
+            "data": {
+                "id": 2,
+                "name": "My Resume",
+                "created_at": "2024-01-15 14:30:00",
+                "projects": [...],
+                "aggregated_skills": {...},
+                "rendered_text": "..."
+            },
+            "error": null
+        }
+        ```
+    - **Error Responses**:
+        - `400 Bad Request`: No valid projects found for the given IDs
+        - `401 Unauthorized`: Missing X-User-Id header
+        - `404 Not Found`: User not found
 
+- **Edit Resume**
+    - **Endpoint**: `POST /resume/{resumeId}/edit`
+    - **Description**: Edits a specific project within a résumé snapshot. Supports two scopes: `resume_only` (changes apply only to this résumé) or `global` (changes apply to all résumés containing this project and update the project_summaries table).
+    - **Path Parameters**:
+        - `{resumeId}` (integer, required): The ID of the résumé snapshot to edit
+    - **Headers**:
+        - `X-User-Id` (integer, required): Current user identifier
+    - **Request Body**: Uses `ResumeEditRequestDTO`
+        ```json
+        {
+            "name": "Updated Resume Name",
+            "project_name": "MyProject",
+            "scope": "resume_only",
+            "display_name": "Custom Project Name",
+            "summary_text": "Updated project summary...",
+            "contribution_bullets": [
+                "Built feature X",
+                "Improved performance by 50%"
+            ]
+        }
+        ```
+        - `name` (string, optional): New name for the résumé (rename)
+        - `project_name` (string, required): Name of the project to edit within the résumé
+        - `scope` (string, required): Either `"resume_only"` or `"global"`
+            - `resume_only`: Changes apply only to this résumé
+            - `global`: Changes apply to all résumés and update project_summaries
+        - `display_name` (string, optional): Custom display name for the project
+        - `summary_text` (string, optional): Updated summary text
+        - `contribution_bullets` (array of strings, optional): Custom contribution bullet points
+    - **Response Status**: `200 OK` or `404 Not Found`
+    - **Response Body**: Uses `ResumeDetailDTO`
+        ```json
+        {
+            "success": true,
+            "data": {
+                "id": 1,
+                "name": "Updated Resume Name",
+                "created_at": "2024-01-12 10:30:00",
+                "projects": [...],
+                "aggregated_skills": {...},
+                "rendered_text": "..."
+            },
+            "error": null
+        }
+        ```
+    - **Error Responses**:
+        - `401 Unauthorized`: Missing X-User-Id header
+        - `404 Not Found`: Resume or project not found
 
 ---
 
@@ -598,6 +678,18 @@ Example:
     - `projects` (List[ResumeProjectDTO], optional)
     - `aggregated_skills` (AggregatedSkillsDTO, optional)
     - `rendered_text` (string, optional)
+
+- **ResumeGenerateRequestDTO**
+    - `name` (string, required): Name for the new résumé snapshot
+    - `project_ids` (List[int], optional): Project IDs to include. If omitted, uses top 5 ranked projects.
+
+- **ResumeEditRequestDTO**
+    - `name` (string, optional): New name for the résumé
+    - `project_name` (string, required): Name of the project to edit
+    - `scope` (string, required): Either `"resume_only"` or `"global"`
+    - `display_name` (string, optional): Custom display name for the project
+    - `summary_text` (string, optional): Updated summary text
+    - `contribution_bullets` (List[string], optional): Custom contribution bullet points
 
 - **ConsentRequestDTO**
     - `status` (string, required): Must be either "accepted" or "rejected"

--- a/docs/API.md
+++ b/docs/API.md
@@ -542,8 +542,7 @@ Manages résumé-specific representations of projects.
 - **Generate Resume**
     - **Endpoint**: `POST /resume/generate`
     - **Description**: Creates a new résumé snapshot from the user's projects. If `project_ids` is not provided, automatically selects the top 5 ranked projects. Builds the snapshot, enriches with contribution bullets and dates, and renders the text.
-    - **Headers**:
-        - `X-User-Id` (integer, required): Current user identifier
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
     - **Request Body**: Uses `ResumeGenerateRequestDTO`
         ```json
         {
@@ -552,7 +551,7 @@ Manages résumé-specific representations of projects.
         }
         ```
         - `name` (string, required): Name for the résumé snapshot
-        - `project_ids` (array of integers, optional): List of project IDs to include. If omitted, uses top 5 ranked projects.
+        - `project_ids` (array of integers, optional): List of `project_summary_id` values from the `project_summaries` table. Get these IDs from `GET /projects`. If omitted, uses top 5 ranked projects.
     - **Response Status**: `201 Created` or `400 Bad Request`
     - **Response Body**: Uses `ResumeDetailDTO`
         ```json
@@ -575,12 +574,11 @@ Manages résumé-specific representations of projects.
         - `404 Not Found`: User not found
 
 - **Edit Resume**
-    - **Endpoint**: `POST /resume/{resumeId}/edit`
-    - **Description**: Edits a specific project within a résumé snapshot. Supports two scopes: `resume_only` (changes apply only to this résumé) or `global` (changes apply to all résumés containing this project and update the project_summaries table).
+    - **Endpoint**: `POST /resume/{resume_id}/edit`
+    - **Description**: Edits a résumé snapshot. Can rename the résumé, edit project details, or both. Project editing is optional - you can rename a résumé without editing any project.
     - **Path Parameters**:
-        - `{resumeId}` (integer, required): The ID of the résumé snapshot to edit
-    - **Headers**:
-        - `X-User-Id` (integer, required): Current user identifier
+        - `{resume_id}` (integer, required): The `id` from `resume_snapshots` table. Get this from `GET /resume` list.
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
     - **Request Body**: Uses `ResumeEditRequestDTO`
         ```json
         {
@@ -592,17 +590,21 @@ Manages résumé-specific representations of projects.
             "contribution_bullets": [
                 "Built feature X",
                 "Improved performance by 50%"
-            ]
+            ],
+            "contribution_edit_mode": "replace"
         }
         ```
         - `name` (string, optional): New name for the résumé (rename)
-        - `project_name` (string, required): Name of the project to edit within the résumé
-        - `scope` (string, required): Either `"resume_only"` or `"global"`
-            - `resume_only`: Changes apply only to this résumé
-            - `global`: Changes apply to all résumés and update project_summaries
+        - `project_name` (string, optional): The text name of the project to edit. If omitted, only the résumé name is updated.
+        - `scope` (string, optional): Required when editing a project. Either `"resume_only"` or `"global"`. Defaults to `"resume_only"` if not specified.
+            - `resume_only`: Changes apply only to this résumé (stored as `resume_*_override` fields)
+            - `global`: Changes apply to all résumés and update `project_summaries.manual_overrides`
         - `display_name` (string, optional): Custom display name for the project
         - `summary_text` (string, optional): Updated summary text
         - `contribution_bullets` (array of strings, optional): Custom contribution bullet points
+        - `contribution_edit_mode` (string, optional): How to apply contribution bullets. Defaults to `"replace"`.
+            - `"replace"`: Replace all existing bullets with the provided list
+            - `"append"`: Keep existing bullets and add the provided bullets to the end
     - **Response Status**: `200 OK` or `404 Not Found`
     - **Response Body**: Uses `ResumeDetailDTO`
         ```json
@@ -620,8 +622,23 @@ Manages résumé-specific representations of projects.
         }
         ```
     - **Error Responses**:
-        - `401 Unauthorized`: Missing X-User-Id header
+        - `401 Unauthorized`: Missing or invalid Bearer token
         - `404 Not Found`: Resume or project not found
+    - **Example: Rename résumé only (no project editing)**:
+        ```json
+        {
+            "name": "My Updated Resume"
+        }
+        ```
+    - **Example: Append new bullets to existing**:
+        ```json
+        {
+            "project_name": "MyProject",
+            "scope": "resume_only",
+            "contribution_bullets": ["Added new feature Y"],
+            "contribution_edit_mode": "append"
+        }
+        ```
 
 ---
 
@@ -637,12 +654,38 @@ Manages portfolio showcase configuration.
 
 ---
 
-## **Path Variables**
+## **Path Variables & Identifiers**
 
-- `{project_id}` (integer, required): The ID of a project (project_summary_id)  
-- `{resume_id}` (integer, required): The ID of a résumé snapshot  
-- `{upload_id}` (integer, required): The ID of an upload session  
-- `{portfolio_id}` (integer, required): The ID of a portfolio (reserved for future use)  
+### Path Variables
+
+- `{project_id}` (integer): Maps to `project_summary_id` from the `project_summaries` table
+- `{resume_id}` (integer): Maps to `id` from the `resume_snapshots` table
+- `{upload_id}` (integer): Maps to `upload_id` from the `uploads` table
+- `{portfolio_id}` (integer): Reserved for future use
+
+### Important: Identifier Sources
+
+The API uses different identifiers depending on the resource. Here's where each identifier comes from:
+
+| API Parameter | Database Table | Database Column | Description |
+|---------------|----------------|-----------------|-------------|
+| `project_id` / `project_ids` | `project_summaries` | `project_summary_id` | Unique ID for a project summary |
+| `project_name` | Various tables | `project_name` | Text identifier used across tables |
+| `resume_id` | `resume_snapshots` | `id` | Unique ID for a saved résumé |
+| `upload_id` | `uploads` | `upload_id` | Unique ID for an upload session |
+| `user_id` | `users` | `user_id` | Unique ID for a user |
+
+**Note:** There is no generic `project_id` column in the database. Projects are primarily identified by:
+- `project_summary_id` (integer) - Used in API endpoints as `{project_id}`
+- `project_name` (text) - Used within résumé/portfolio data structures
+
+### How to Get Project IDs
+
+To get `project_summary_id` values for use in endpoints like `POST /resume/generate`:
+
+1. Call `GET /projects` to list all projects
+2. Each project in the response includes `project_summary_id`
+3. Use these IDs in the `project_ids` array  
 
 ---
 
@@ -742,15 +785,16 @@ Example:
 
 - **ResumeGenerateRequestDTO**
     - `name` (string, required): Name for the new résumé snapshot
-    - `project_ids` (List[int], optional): Project IDs to include. If omitted, uses top 5 ranked projects.
+    - `project_ids` (List[int], optional): List of `project_summary_id` values from `project_summaries` table. Get these from `GET /projects`. If omitted, uses top 5 ranked projects.
 
 - **ResumeEditRequestDTO**
     - `name` (string, optional): New name for the résumé
-    - `project_name` (string, required): Name of the project to edit
-    - `scope` (string, required): Either `"resume_only"` or `"global"`
+    - `project_name` (string, optional): Text name of the project to edit. If omitted, only name is updated.
+    - `scope` (string, optional): `"resume_only"` (default) or `"global"`. Required when editing a project.
     - `display_name` (string, optional): Custom display name for the project
     - `summary_text` (string, optional): Updated summary text
     - `contribution_bullets` (List[string], optional): Custom contribution bullet points
+    - `contribution_edit_mode` (string, optional): `"replace"` (default) or `"append"`
 
 - **ConsentRequestDTO**
     - `status` (string, required): Must be either "accepted" or "rejected"

--- a/docs/API.md
+++ b/docs/API.md
@@ -551,7 +551,7 @@ Manages résumé-specific representations of projects.
         }
         ```
         - `name` (string, required): Name for the résumé snapshot
-        - `project_ids` (array of integers, optional): List of `project_summary_id` values from the `project_summaries` table. Get these IDs from `GET /projects`. If omitted, uses top 5 ranked projects.
+        - `project_ids` (array of integers, optional): List of `project_summary_id` values from the `project_summaries` table. Get these IDs from `GET /projects`. If omitted (no project_ids, just name), uses top 5 ranked projects.
     - **Response Status**: `201 Created` or `400 Bad Request`
     - **Response Body**: Uses `ResumeDetailDTO`
         ```json
@@ -595,7 +595,7 @@ Manages résumé-specific representations of projects.
         }
         ```
         - `name` (string, optional): New name for the résumé (rename)
-        - `project_name` (string, optional): The text name of the project to edit. If omitted, only the résumé name is updated.
+        - `project_name` (string, optional): The text name of the project to edit. If omitted (no "project_name", just "name"), only the résumé name is updated.
         - `scope` (string, optional): Required when editing a project. Either `"resume_only"` or `"global"`. Defaults to `"resume_only"` if not specified.
             - `resume_only`: Changes apply only to this résumé (stored as `resume_*_override` fields)
             - `global`: Changes apply to all résumés and update `project_summaries.manual_overrides`

--- a/src/api/routes/resumes.py
+++ b/src/api/routes/resumes.py
@@ -70,6 +70,7 @@ def post_resume_edit(
         display_name=request.display_name,
         summary_text=request.summary_text,
         contribution_bullets=request.contribution_bullets,
+        contribution_edit_mode=request.contribution_edit_mode,
     )
 
     if not resume:

--- a/src/api/routes/resumes.py
+++ b/src/api/routes/resumes.py
@@ -3,8 +3,8 @@ from sqlite3 import Connection
 
 from src.api.dependencies import get_db, get_current_user_id
 from src.api.schemas.common import ApiResponse
-from src.api.schemas.resumes import ResumeListDTO, ResumeListItemDTO, ResumeDetailDTO
-from src.services.resumes_service import list_user_resumes, get_resume_by_id
+from src.api.schemas.resumes import ResumeListDTO, ResumeListItemDTO, ResumeDetailDTO, ResumeGenerateRequestDTO, ResumeEditRequestDTO
+from src.services.resumes_service import list_user_resumes, get_resume_by_id, generate_resume, edit_resume
 
 router = APIRouter(prefix="/resume", tags=["resume"])
 
@@ -25,9 +25,55 @@ def get_resume(
     conn: Connection = Depends(get_db),
 ):
     resume = get_resume_by_id(conn, user_id, resume_id)
-    
+
     if not resume:
         raise HTTPException(status_code=404, detail="Resume not found")
-    
+
+    dto = ResumeDetailDTO(**resume)
+    return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.post("/generate", response_model=ApiResponse[ResumeDetailDTO], status_code=201)
+def post_resume_generate(
+    request: ResumeGenerateRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    resume = generate_resume(
+        conn,
+        user_id,
+        name=request.name,
+        project_ids=request.project_ids,
+    )
+
+    if not resume:
+        raise HTTPException(status_code=400, detail="No valid projects found for the given IDs")
+
+    dto = ResumeDetailDTO(**resume)
+    return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.post("/{resume_id}/edit", response_model=ApiResponse[ResumeDetailDTO])
+def post_resume_edit(
+    resume_id: int,
+    request: ResumeEditRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    resume = edit_resume(
+        conn,
+        user_id,
+        resume_id,
+        project_name=request.project_name,
+        scope=request.scope,
+        name=request.name,
+        display_name=request.display_name,
+        summary_text=request.summary_text,
+        contribution_bullets=request.contribution_bullets,
+    )
+
+    if not resume:
+        raise HTTPException(status_code=404, detail="Resume or project not found")
+
     dto = ResumeDetailDTO(**resume)
     return ApiResponse(success=True, data=dto, error=None)

--- a/src/api/schemas/resumes.py
+++ b/src/api/schemas/resumes.py
@@ -46,3 +46,4 @@ class ResumeEditRequestDTO(BaseModel):
     display_name: Optional[str] = None
     summary_text: Optional[str] = None
     contribution_bullets: Optional[List[str]] = None
+    contribution_edit_mode: Optional[Literal["append", "replace"]] = "replace"

--- a/src/api/schemas/resumes.py
+++ b/src/api/schemas/resumes.py
@@ -41,8 +41,8 @@ class ResumeGenerateRequestDTO(BaseModel):
 
 class ResumeEditRequestDTO(BaseModel):
     name: Optional[str] = None
-    project_name: str
-    scope: Literal["resume_only", "global"]
+    project_name: Optional[str] = None
+    scope: Optional[Literal["resume_only", "global"]] = None
     display_name: Optional[str] = None
     summary_text: Optional[str] = None
     contribution_bullets: Optional[List[str]] = None

--- a/src/api/schemas/resumes.py
+++ b/src/api/schemas/resumes.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel
-from typing import Any, List, Optional, Dict
+from typing import Any, List, Optional, Dict, Literal
 
 class ResumeListItemDTO(BaseModel):
     id: int
@@ -34,3 +34,15 @@ class ResumeDetailDTO(BaseModel):
     projects: List[ResumeProjectDTO] = []
     aggregated_skills: AggregatedSkillsDTO = AggregatedSkillsDTO()
     rendered_text: Optional[str] = None
+
+class ResumeGenerateRequestDTO(BaseModel):
+    name: str
+    project_ids: Optional[List[int]] = None
+
+class ResumeEditRequestDTO(BaseModel):
+    name: Optional[str] = None
+    project_name: str
+    scope: Literal["resume_only", "global"]
+    display_name: Optional[str] = None
+    summary_text: Optional[str] = None
+    contribution_bullets: Optional[List[str]] = None

--- a/src/menu/portfolio.py
+++ b/src/menu/portfolio.py
@@ -23,10 +23,7 @@ from src.insights.portfolio import (
     resolve_portfolio_summary_text,
 )
 from src.export.portfolio_docx import export_portfolio_to_docx
-from src.services.resume_overrides import (
-    apply_manual_overrides_to_resumes,
-    update_project_manual_overrides,
-)
+from src.services import resume_overrides
 
 
 def view_portfolio_menu(conn, user_id: int, username: str) -> None:
@@ -385,7 +382,7 @@ def _handle_edit_portfolio_wording(conn, user_id: int, username: str) -> bool:
         print("[Portfolio] Updated wording for this portfolio.")
         return True
 
-    manual_overrides = update_project_manual_overrides(conn, user_id, project_name, updates)
+    manual_overrides = resume_overrides.update_project_manual_overrides(conn, user_id, project_name, updates)
     if manual_overrides is None:
         print("Unable to update project summary for global overrides.")
         return False
@@ -394,7 +391,7 @@ def _handle_edit_portfolio_wording(conn, user_id: int, username: str) -> bool:
     # so the global manual_overrides take effect (they have lower priority).
     _clear_portfolio_overrides_for_fields(conn, user_id, project_name, set(updates.keys()))
 
-    apply_manual_overrides_to_resumes(
+    resume_overrides.apply_manual_overrides_to_resumes(
         conn,
         user_id,
         project_name,

--- a/src/menu/portfolio.py
+++ b/src/menu/portfolio.py
@@ -23,9 +23,9 @@ from src.insights.portfolio import (
     resolve_portfolio_summary_text,
 )
 from src.export.portfolio_docx import export_portfolio_to_docx
-from src.menu.resume.flow import (
-    _apply_manual_overrides_to_resumes,
-    _update_project_manual_overrides,
+from src.services.resume_overrides import (
+    apply_manual_overrides_to_resumes,
+    update_project_manual_overrides,
 )
 
 
@@ -385,7 +385,7 @@ def _handle_edit_portfolio_wording(conn, user_id: int, username: str) -> bool:
         print("[Portfolio] Updated wording for this portfolio.")
         return True
 
-    manual_overrides = _update_project_manual_overrides(conn, user_id, project_name, updates)
+    manual_overrides = update_project_manual_overrides(conn, user_id, project_name, updates)
     if manual_overrides is None:
         print("Unable to update project summary for global overrides.")
         return False
@@ -394,12 +394,13 @@ def _handle_edit_portfolio_wording(conn, user_id: int, username: str) -> bool:
     # so the global manual_overrides take effect (they have lower priority).
     _clear_portfolio_overrides_for_fields(conn, user_id, project_name, set(updates.keys()))
 
-    _apply_manual_overrides_to_resumes(
+    apply_manual_overrides_to_resumes(
         conn,
         user_id,
         project_name,
         manual_overrides,
         set(updates.keys()),
+        log_summary=True,
     )
     print("[Portfolio] Updated wording across resumes and portfolio.")
     return True

--- a/src/services/resume_generation.py
+++ b/src/services/resume_generation.py
@@ -1,0 +1,85 @@
+from typing import Iterable, List, Optional, Tuple
+import json
+
+from src.db import get_all_user_project_summaries
+from src.db.project_summaries import get_project_summary_by_id
+from src.db.resumes import insert_resume_snapshot
+from src.menu.resume.helpers import (
+    build_resume_snapshot,
+    enrich_snapshot_with_contributions,
+    load_project_summaries,
+    render_snapshot,
+)
+from src.models.project_summary import ProjectSummary
+
+
+def load_project_summaries_by_ids(
+    conn,
+    user_id: int,
+    project_ids: Iterable[int],
+) -> List[ProjectSummary]:
+    summaries: List[ProjectSummary] = []
+
+    for project_id in project_ids:
+        row = get_project_summary_by_id(conn, user_id, project_id)
+        if not row or not row.get("summary_json"):
+            continue
+        try:
+            summary_dict = json.loads(row["summary_json"])
+            summaries.append(ProjectSummary.from_dict(summary_dict))
+        except Exception:
+            continue
+
+    return summaries
+
+
+def load_all_project_summaries(conn, user_id: int) -> List[ProjectSummary]:
+    return load_project_summaries(conn, user_id, get_all_user_project_summaries)
+
+
+def select_ranked_summaries(
+    summaries: List[ProjectSummary],
+    ranked: List[tuple[str, float]],
+    selected_indices: Optional[Iterable[int]] = None,
+    max_projects: int = 5,
+) -> Tuple[List[ProjectSummary], List[str]]:
+    ranked_names = [name for name, _score in ranked]
+    ranked_dict = {name: score for name, score in ranked}
+
+    selected_names: List[str] = []
+    if selected_indices:
+        valid = [idx for idx in set(selected_indices) if 1 <= idx <= len(ranked_names)]
+        for idx in sorted(valid)[:max_projects]:
+            selected_names.append(ranked_names[idx - 1])
+    if not selected_names:
+        selected_names = ranked_names[:max_projects]
+
+    selected_summaries = [s for s in summaries if s.project_name in selected_names]
+    selected_summaries.sort(key=lambda s: ranked_dict.get(s.project_name, 0.0), reverse=True)
+    return selected_summaries, selected_names
+
+
+def build_resume_snapshot_data(
+    conn,
+    user_id: int,
+    summaries: List[ProjectSummary],
+    print_output: bool = False,
+) -> Optional[Tuple[dict, str]]:
+    if not summaries:
+        return None
+
+    snapshot = build_resume_snapshot(summaries)
+    snapshot = enrich_snapshot_with_contributions(conn, user_id, snapshot)
+    rendered = render_snapshot(conn, user_id, snapshot, print_output=print_output)
+    return snapshot, rendered
+
+
+def insert_resume_snapshot_record(
+    conn,
+    user_id: int,
+    name: str,
+    snapshot: dict,
+    rendered: str,
+) -> int:
+    resume_json = json.dumps(snapshot, default=str)
+    return insert_resume_snapshot(conn, user_id, name, resume_json, rendered)

--- a/src/services/resume_overrides.py
+++ b/src/services/resume_overrides.py
@@ -1,0 +1,127 @@
+from typing import Any, Dict, Iterable, Optional
+import json
+
+from src.db import get_project_summary_by_name, update_project_summary_json
+from src.db.resumes import list_resumes, get_resume_snapshot, update_resume_snapshot
+from src.menu.resume.helpers import apply_resume_only_updates, resume_only_override_fields, render_snapshot
+
+
+def update_project_manual_overrides(
+    conn,
+    user_id: int,
+    project_name: str,
+    updates: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Update manual overrides in project_summaries table."""
+    summary_row = get_project_summary_by_name(conn, user_id, project_name)
+    if not summary_row:
+        return None
+
+    try:
+        summary_dict = json.loads(summary_row["summary_json"])
+    except Exception:
+        return None
+
+    overrides = summary_dict.get("manual_overrides") or {}
+    if not isinstance(overrides, dict):
+        overrides = {}
+
+    for key, value in updates.items():
+        if value:
+            overrides[key] = value
+        else:
+            overrides.pop(key, None)
+
+    if overrides:
+        summary_dict["manual_overrides"] = overrides
+    else:
+        summary_dict.pop("manual_overrides", None)
+
+    updated = update_project_summary_json(conn, user_id, project_name, json.dumps(summary_dict))
+    if not updated:
+        return None
+    return overrides
+
+
+def apply_manual_overrides_to_resumes(
+    conn,
+    user_id: int,
+    project_name: str,
+    overrides: Dict[str, Any],
+    fields: Iterable[str],
+    force_resume_id: Optional[int] = None,
+    log_summary: bool = False,
+) -> None:
+    """Apply global overrides to all saved resumes containing this project."""
+    resumes = list_resumes(conn, user_id)
+    updated = 0
+    skipped_fields = 0
+
+    field_set = set(fields)
+
+    for r in resumes:
+        record = get_resume_snapshot(conn, user_id, r["id"])
+        if not record:
+            continue
+        try:
+            snapshot = json.loads(record["resume_json"])
+        except Exception:
+            continue
+
+        projects = snapshot.get("projects") or []
+        changed = False
+
+        for entry in projects:
+            if entry.get("project_name") != project_name:
+                continue
+
+            resume_only_fields = resume_only_override_fields(entry)
+            force_update = force_resume_id == r["id"]
+
+            # If this is the selected resume, clear resume-only overrides so global applies.
+            if force_update and resume_only_fields:
+                clear_updates = {field: None for field in field_set}
+                apply_resume_only_updates(entry, clear_updates)
+                resume_only_fields = resume_only_override_fields(entry)
+
+            if "display_name" in field_set:
+                if "display_name" in resume_only_fields and not force_update:
+                    skipped_fields += 1
+                else:
+                    if overrides.get("display_name"):
+                        entry["manual_display_name"] = overrides["display_name"]
+                    else:
+                        entry.pop("manual_display_name", None)
+                    changed = True
+
+            if "summary_text" in field_set:
+                if "summary_text" in resume_only_fields and not force_update:
+                    skipped_fields += 1
+                else:
+                    if overrides.get("summary_text"):
+                        entry["manual_summary_text"] = overrides["summary_text"]
+                    else:
+                        entry.pop("manual_summary_text", None)
+                    changed = True
+
+            if "contribution_bullets" in field_set:
+                if "contribution_bullets" in resume_only_fields and not force_update:
+                    skipped_fields += 1
+                else:
+                    if overrides.get("contribution_bullets"):
+                        entry["manual_contribution_bullets"] = overrides["contribution_bullets"]
+                    else:
+                        entry.pop("manual_contribution_bullets", None)
+                    changed = True
+
+        if changed:
+            rendered = render_snapshot(conn, user_id, snapshot, print_output=False)
+            updated_json = json.dumps(snapshot, default=str)
+            update_resume_snapshot(conn, user_id, r["id"], updated_json, rendered)
+            updated += 1
+
+    if log_summary and (updated or skipped_fields):
+        print(
+            f"[Resume] Updated {updated} resume(s); "
+            f"skipped {skipped_fields} field update(s) due to resume-only overrides."
+        )

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -1,5 +1,16 @@
-from typing import List, Dict, Any, Optional
-from src.db.resumes import list_resumes, get_resume_snapshot
+from typing import List, Dict, Any, Optional, Literal
+from src.db.resumes import list_resumes, get_resume_snapshot, insert_resume_snapshot, update_resume_snapshot
+from src.db.project_summaries import get_project_summary_by_id, get_project_summary_by_name, update_project_summary_json
+from src.db import get_all_user_project_summaries
+from src.models.project_summary import ProjectSummary
+from src.menu.resume.helpers import (
+    build_resume_snapshot,
+    render_snapshot,
+    enrich_snapshot_with_contributions,
+    apply_resume_only_updates,
+    resume_only_override_fields,
+)
+from src.insights.rank_projects.rank_project_importance import collect_project_data
 import json
 
 def list_user_resumes(conn, user_id: int) -> List[Dict[str, Any]]:
@@ -30,3 +41,239 @@ def get_resume_by_id(conn, user_id: int, resume_id: int) -> Optional[Dict[str, A
         "rendered_text": record.get("rendered_text"),
         **snapshot  # projects, aggregated_skills
     }
+
+def generate_resume(
+    conn,
+    user_id: int,
+    name: str,
+    project_ids: Optional[List[int]] = None,
+) -> Optional[Dict[str, Any]]:
+    summaries: List[ProjectSummary] = []
+
+    if project_ids:
+        # Fetch project summaries by IDs
+        for project_id in project_ids:
+            row = get_project_summary_by_id(conn, user_id, project_id)
+            if row and row.get("summary_json"):
+                try:
+                    summary_dict = json.loads(row["summary_json"])
+                    summaries.append(ProjectSummary.from_dict(summary_dict))
+                except (json.JSONDecodeError, Exception):
+                    continue
+    else:
+        # No project_ids provided - use top 5 ranked projects (like menu flow)
+        ranked = collect_project_data(conn, user_id)
+        if not ranked:
+            return None
+
+        top_names = [proj_name for proj_name, _score in ranked[:5]]
+
+        # Load all summaries and filter to top ranked
+        all_rows = get_all_user_project_summaries(conn, user_id)
+        for row in all_rows:
+            if row["project_name"] in top_names:
+                try:
+                    summary_dict = json.loads(row["summary_json"])
+                    summaries.append(ProjectSummary.from_dict(summary_dict))
+                except (json.JSONDecodeError, Exception):
+                    continue
+
+        # Sort by ranking order
+        ranked_dict = {proj_name: score for proj_name, score in ranked}
+        summaries.sort(key=lambda s: ranked_dict.get(s.project_name, 0.0), reverse=True)
+
+    if not summaries:
+        return None
+
+    # Build snapshot (extracts projects and aggregates skills)
+    snapshot = build_resume_snapshot(summaries)
+
+    # Enrich with contribution bullets and dates
+    snapshot = enrich_snapshot_with_contributions(conn, user_id, snapshot)
+
+    # Render to text
+    rendered = render_snapshot(conn, user_id, snapshot, print_output=False)
+
+    # Store in DB
+    resume_json = json.dumps(snapshot, default=str)
+    resume_id = insert_resume_snapshot(conn, user_id, name, resume_json, rendered)
+    return get_resume_by_id(conn, user_id, resume_id)
+
+def edit_resume(
+    conn,
+    user_id: int,
+    resume_id: int,
+    project_name: str,
+    scope: Literal["resume_only", "global"],
+    name: Optional[str] = None,
+    display_name: Optional[str] = None,
+    summary_text: Optional[str] = None,
+    contribution_bullets: Optional[List[str]] = None,
+) -> Optional[Dict[str, Any]]:
+
+    # Get the resume record
+    record = get_resume_snapshot(conn, user_id, resume_id)
+    if not record:
+        return None
+
+    try:
+        snapshot = json.loads(record["resume_json"])
+    except json.JSONDecodeError:
+        return None
+
+    # Update resume name if provided
+    if name is not None:
+        conn.execute(
+            "UPDATE resume_snapshots SET name = ? WHERE user_id = ? AND id = ?",
+            (name, user_id, resume_id),
+        )
+        conn.commit()
+
+    # Find the project entry in the snapshot
+    projects = snapshot.get("projects") or []
+    project_entry = None
+    for p in projects:
+        if p.get("project_name") == project_name:
+            project_entry = p
+            break
+
+    if not project_entry:
+        return None
+
+    # Build updates dict
+    updates: Dict[str, Any] = {}
+    if display_name is not None:
+        updates["display_name"] = display_name or None
+    if summary_text is not None:
+        updates["summary_text"] = summary_text or None
+    if contribution_bullets is not None:
+        updates["contribution_bullets"] = contribution_bullets or None
+
+    if not updates:
+        # No field updates, just return existing
+        return get_resume_by_id(conn, user_id, resume_id)
+
+    if scope == "resume_only":
+        # Apply resume-only overrides
+        apply_resume_only_updates(project_entry, updates)
+        rendered = render_snapshot(conn, user_id, snapshot, print_output=False)
+        updated_json = json.dumps(snapshot, default=str)
+        update_resume_snapshot(conn, user_id, resume_id, updated_json, rendered)
+
+    else:  # scope == "global"
+        # Update project_summaries and fan out to all resumes
+        manual_overrides = _update_project_manual_overrides(conn, user_id, project_name, updates)
+        if manual_overrides is not None:
+            _apply_manual_overrides_to_resumes(
+                conn,
+                user_id,
+                project_name,
+                manual_overrides,
+                set(updates.keys()),
+                force_resume_id=resume_id,
+            )
+
+    return get_resume_by_id(conn, user_id, resume_id)
+
+
+def _update_project_manual_overrides(
+    conn,
+    user_id: int,
+    project_name: str,
+    updates: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    """Update manual overrides in project_summaries table."""
+    summary_row = get_project_summary_by_name(conn, user_id, project_name)
+    if not summary_row:
+        return None
+
+    try:
+        summary_dict = json.loads(summary_row["summary_json"])
+    except Exception:
+        return None
+
+    overrides = summary_dict.get("manual_overrides") or {}
+    if not isinstance(overrides, dict):
+        overrides = {}
+
+    for key, value in updates.items():
+        if value:
+            overrides[key] = value
+        else:
+            overrides.pop(key, None)
+
+    if overrides:
+        summary_dict["manual_overrides"] = overrides
+    else:
+        summary_dict.pop("manual_overrides", None)
+
+    updated = update_project_summary_json(conn, user_id, project_name, json.dumps(summary_dict))
+    if not updated:
+        return None
+    return overrides
+
+
+def _apply_manual_overrides_to_resumes(
+    conn,
+    user_id: int,
+    project_name: str,
+    overrides: Dict[str, Any],
+    fields: set,
+    force_resume_id: Optional[int] = None,
+) -> None:
+    """Apply global overrides to all saved resumes containing this project."""
+    resumes = list_resumes(conn, user_id)
+
+    for r in resumes:
+        record = get_resume_snapshot(conn, user_id, r["id"])
+        if not record:
+            continue
+        try:
+            snapshot = json.loads(record["resume_json"])
+        except Exception:
+            continue
+
+        projects = snapshot.get("projects") or []
+        changed = False
+
+        for entry in projects:
+            if entry.get("project_name") != project_name:
+                continue
+
+            resume_only_fields = resume_only_override_fields(entry)
+            force_update = force_resume_id == r["id"]
+
+            # If this is the selected resume, clear resume-only overrides so global applies
+            if force_update and resume_only_fields:
+                clear_updates = {field: None for field in fields}
+                apply_resume_only_updates(entry, clear_updates)
+                resume_only_fields = resume_only_override_fields(entry)
+
+            if "display_name" in fields:
+                if "display_name" not in resume_only_fields or force_update:
+                    if overrides.get("display_name"):
+                        entry["manual_display_name"] = overrides["display_name"]
+                    else:
+                        entry.pop("manual_display_name", None)
+                    changed = True
+
+            if "summary_text" in fields:
+                if "summary_text" not in resume_only_fields or force_update:
+                    if overrides.get("summary_text"):
+                        entry["manual_summary_text"] = overrides["summary_text"]
+                    else:
+                        entry.pop("manual_summary_text", None)
+                    changed = True
+
+            if "contribution_bullets" in fields:
+                if "contribution_bullets" not in resume_only_fields or force_update:
+                    if overrides.get("contribution_bullets"):
+                        entry["manual_contribution_bullets"] = overrides["contribution_bullets"]
+                    else:
+                        entry.pop("manual_contribution_bullets", None)
+                    changed = True
+
+        if changed:
+            rendered = render_snapshot(conn, user_id, snapshot, print_output=False)
+            updated_json = json.dumps(snapshot, default=str)
+            update_resume_snapshot(conn, user_id, r["id"], updated_json, rendered)

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -9,6 +9,7 @@ from src.menu.resume.helpers import (
     enrich_snapshot_with_contributions,
     apply_resume_only_updates,
     resume_only_override_fields,
+    resolve_resume_contribution_bullets,
 )
 from src.insights.rank_projects.rank_project_importance import collect_project_data
 import json
@@ -109,6 +110,7 @@ def edit_resume(
     display_name: Optional[str] = None,
     summary_text: Optional[str] = None,
     contribution_bullets: Optional[List[str]] = None,
+    contribution_edit_mode: Literal["append", "replace"] = "replace",
 ) -> Optional[Dict[str, Any]]:
 
     # Get the resume record
@@ -147,7 +149,13 @@ def edit_resume(
     if summary_text is not None:
         updates["summary_text"] = summary_text or None
     if contribution_bullets is not None:
-        updates["contribution_bullets"] = contribution_bullets or None
+        if contribution_edit_mode == "append" and contribution_bullets:
+            # Append new bullets to existing ones
+            current_bullets = resolve_resume_contribution_bullets(project_entry)
+            updates["contribution_bullets"] = current_bullets + contribution_bullets
+        else:
+            # Replace mode: use provided bullets directly
+            updates["contribution_bullets"] = contribution_bullets or None
 
     if not updates:
         # No field updates, just return existing

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -104,8 +104,8 @@ def edit_resume(
     conn,
     user_id: int,
     resume_id: int,
-    project_name: str,
-    scope: Literal["resume_only", "global"],
+    project_name: Optional[str] = None,
+    scope: Optional[Literal["resume_only", "global"]] = None,
     name: Optional[str] = None,
     display_name: Optional[str] = None,
     summary_text: Optional[str] = None,
@@ -130,6 +130,14 @@ def edit_resume(
             (name, user_id, resume_id),
         )
         conn.commit()
+
+    # If no project_name provided, just return after name update (name-only edit)
+    if project_name is None:
+        return get_resume_by_id(conn, user_id, resume_id)
+
+    # For project editing, scope is required
+    if scope is None:
+        scope = "resume_only"  # Default to resume_only if not specified
 
     # Find the project entry in the snapshot
     projects = snapshot.get("projects") or []

--- a/tests/api/test_resumes.py
+++ b/tests/api/test_resumes.py
@@ -299,6 +299,27 @@ def test_edit_resume_update_name(client, auth_headers, seed_conn):
     assert body["data"]["name"] == "New Name"
 
 
+def test_edit_resume_name_only(client, auth_headers, seed_conn):
+    """Test renaming a resume without editing any project (name-only update)"""
+    resume_json = json.dumps({
+        "projects": [{"project_name": "TestProject"}],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(seed_conn, 1, "Original Name", resume_json)
+    seed_conn.commit()
+
+    # Only provide name, no project_name or scope
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={"name": "Renamed Resume"},
+        headers=auth_headers
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["name"] == "Renamed Resume"
+
+
 def test_edit_resume_contribution_bullets(client, auth_headers, seed_conn):
     """Test editing contribution bullets with replace mode (default)"""
     resume_json = json.dumps({

--- a/tests/api/test_resumes.py
+++ b/tests/api/test_resumes.py
@@ -4,6 +4,7 @@ import pytest
 from src.api.main import app
 import src.db as db
 from src.db.resumes import insert_resume_snapshot
+from src.db.project_summaries import save_project_summary, get_project_summary_by_name
 
 client = TestClient(app)
 @pytest.fixture
@@ -123,3 +124,265 @@ def test_get_resume_by_id_success(setup_db):
     assert len(data["projects"]) == 1
     assert data["projects"][0]["project_name"] == "TestProject"
     assert data["aggregated_skills"]["languages"] == ["Python"]
+
+# POST /resume/generate tests
+def test_generate_resume_requires_user_header():
+    """Test that POST /resume/generate requires X-User-Id header"""
+    res = client.post("/resume/generate", json={"name": "Test"})
+    assert res.status_code == 401
+
+
+def test_generate_resume_with_false_user():
+    """Test that POST /resume/generate returns 404 for non-existent user"""
+    res = client.post("/resume/generate", json={"name": "Test"}, headers={"X-User-Id": "999999"})
+    assert res.status_code == 404
+    assert "not found" in res.json()["detail"].lower()
+
+
+def test_generate_resume_no_projects_returns_error(setup_db):
+    """Test that generating resume with no projects returns 400"""
+    res = client.post(
+        "/resume/generate",
+        json={"name": "Empty Resume", "project_ids": []},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 400
+    assert "no valid projects" in res.json()["detail"].lower()
+
+
+def test_generate_resume_invalid_project_ids_returns_error(setup_db):
+    """Test that generating resume with invalid project IDs returns 400"""
+    res = client.post(
+        "/resume/generate",
+        json={"name": "Bad Resume", "project_ids": [999, 1000]},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 400
+    assert "no valid projects" in res.json()["detail"].lower()
+
+
+def test_generate_resume_with_project_ids_success(setup_db):
+    """Test generating a resume with specific project IDs"""
+    # Create project summaries
+    summary_json = json.dumps({
+        "project_name": "TestProject",
+        "project_type": "code",
+        "project_mode": "individual",
+        "languages": ["Python", "JavaScript"],
+        "frameworks": ["FastAPI"],
+        "summary_text": "A test project",
+        "metrics": {}
+    })
+    save_project_summary(setup_db, 1, "TestProject", summary_json)
+    project_id = get_project_summary_by_name(setup_db, 1, "TestProject")["project_summary_id"]
+
+    res = client.post(
+        "/resume/generate",
+        json={"name": "My Resume", "project_ids": [project_id]},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+
+    data = body["data"]
+    assert data["name"] == "My Resume"
+    assert "id" in data
+    assert len(data["projects"]) == 1
+    assert data["projects"][0]["project_name"] == "TestProject"
+    assert "Python" in data["aggregated_skills"]["languages"]
+
+
+def test_generate_resume_without_project_ids_uses_top_ranked(setup_db):
+    """Test generating resume without project_ids uses top 5 ranked projects"""
+    # Create multiple project summaries
+    for i in range(3):
+        summary_json = json.dumps({
+            "project_name": f"Project{i}",
+            "project_type": "code",
+            "project_mode": "individual",
+            "languages": ["Python"],
+            "frameworks": [],
+            "summary_text": f"Project {i} description",
+            "metrics": {}
+        })
+        save_project_summary(setup_db, 1, f"Project{i}", summary_json)
+
+    res = client.post(
+        "/resume/generate",
+        json={"name": "Auto Resume"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 201
+    body = res.json()
+    assert body["success"] is True
+
+    data = body["data"]
+    assert data["name"] == "Auto Resume"
+    assert len(data["projects"]) <= 5  # Max 5 projects
+
+
+# POST /resume/{resume_id}/edit tests
+def test_edit_resume_requires_user_header():
+    """Test that POST /resume/{id}/edit requires X-User-Id header"""
+    res = client.post("/resume/1/edit", json={
+        "project_name": "Test",
+        "scope": "resume_only"
+    })
+    assert res.status_code == 401
+
+
+def test_edit_resume_not_found(setup_db):
+    """Test editing a resume that doesn't exist"""
+    res = client.post(
+        "/resume/999/edit",
+        json={"project_name": "Test", "scope": "resume_only"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 404
+    assert "not found" in res.json()["detail"].lower()
+
+
+def test_edit_resume_project_not_found(setup_db):
+    """Test editing a project that doesn't exist in the resume"""
+    resume_json = json.dumps({
+        "projects": [{"project_name": "ExistingProject"}],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(setup_db, 1, "Test Resume", resume_json)
+
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={"project_name": "NonExistentProject", "scope": "resume_only"},
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 404
+    assert "not found" in res.json()["detail"].lower()
+
+
+def test_edit_resume_resume_only_scope(setup_db):
+    """Test editing a resume with resume_only scope"""
+    resume_json = json.dumps({
+        "projects": [{
+            "project_name": "TestProject",
+            "project_type": "code",
+            "project_mode": "individual",
+            "summary_text": "Original summary"
+        }],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(setup_db, 1, "Test Resume", resume_json)
+
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={
+            "project_name": "TestProject",
+            "scope": "resume_only",
+            "summary_text": "Updated summary",
+            "display_name": "Custom Display Name"
+        },
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+
+    # Verify the rendered_text was updated (contains the new summary)
+    data = body["data"]
+    assert data["rendered_text"] is not None
+    assert "Updated summary" in data["rendered_text"]
+    assert "Custom Display Name" in data["rendered_text"]
+
+
+def test_edit_resume_update_name(setup_db):
+    """Test renaming a resume"""
+    resume_json = json.dumps({
+        "projects": [{"project_name": "TestProject"}],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(setup_db, 1, "Old Name", resume_json)
+
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={
+            "name": "New Name",
+            "project_name": "TestProject",
+            "scope": "resume_only"
+        },
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["data"]["name"] == "New Name"
+
+
+def test_edit_resume_contribution_bullets(setup_db):
+    """Test editing contribution bullets"""
+    resume_json = json.dumps({
+        "projects": [{
+            "project_name": "TestProject",
+            "project_type": "code",
+            "project_mode": "individual"
+        }],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(setup_db, 1, "Test Resume", resume_json)
+
+    bullets = ["Built feature X", "Improved performance by 50%"]
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={
+            "project_name": "TestProject",
+            "scope": "resume_only",
+            "contribution_bullets": bullets
+        },
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 200
+
+    # Verify the rendered_text contains the new bullets
+    data = res.json()["data"]
+    assert data["rendered_text"] is not None
+    assert "Built feature X" in data["rendered_text"]
+    assert "Improved performance by 50%" in data["rendered_text"]
+
+
+def test_edit_resume_global_scope(setup_db):
+    """Test editing with global scope updates project_summaries"""
+    # Create project summary first
+    summary_json = json.dumps({
+        "project_name": "TestProject",
+        "project_type": "code",
+        "project_mode": "individual",
+        "languages": ["Python"],
+        "summary_text": "Original",
+        "metrics": {}
+    })
+    save_project_summary(setup_db, 1, "TestProject", summary_json)
+
+    # Create resume with this project
+    resume_json = json.dumps({
+        "projects": [{
+            "project_name": "TestProject",
+            "project_type": "code",
+            "summary_text": "Original"
+        }],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(setup_db, 1, "Test Resume", resume_json)
+
+    res = client.post(
+        f"/resume/{resume_id}/edit",
+        json={
+            "project_name": "TestProject",
+            "scope": "global",
+            "summary_text": "Globally updated summary"
+        },
+        headers={"X-User-Id": "1"}
+    )
+    assert res.status_code == 200
+
+    # Verify project_summaries was updated with manual_overrides
+    project_row = get_project_summary_by_name(setup_db, 1, "TestProject")
+    summary_dict = json.loads(project_row["summary_json"])
+    assert summary_dict.get("manual_overrides", {}).get("summary_text") == "Globally updated summary"

--- a/tests/test_portfolio_view.py
+++ b/tests/test_portfolio_view.py
@@ -321,7 +321,7 @@ def test_portfolio_edit_global_updates_manual_overrides(conn, monkeypatch):
     def _fake_apply(*args, **kwargs):
         called["applied"] = True
 
-    monkeypatch.setattr("src.menu.portfolio._apply_manual_overrides_to_resumes", _fake_apply)
+    monkeypatch.setattr("src.services.resume_overrides.apply_manual_overrides_to_resumes", _fake_apply)
 
     inputs = iter(["1", "2", "1", "Global summary"])
     monkeypatch.setattr("builtins.input", lambda _="": next(inputs))
@@ -391,7 +391,7 @@ def test_portfolio_global_edit_clears_portfolio_override(conn, capsys, monkeypat
 
     # Mock _apply_manual_overrides_to_resumes to avoid resume-related side effects
     monkeypatch.setattr(
-        "src.menu.portfolio._apply_manual_overrides_to_resumes",
+        "src.services.resume_overrides.apply_manual_overrides_to_resumes",
         lambda *args, **kwargs: None,
     )
 

--- a/tests/test_resume_snapshot.py
+++ b/tests/test_resume_snapshot.py
@@ -323,7 +323,7 @@ def test_render_snapshot_uses_manual_overrides():
 
 
 def test_manual_overrides_skip_resume_only(monkeypatch):
-    from src.menu.resume.flow import _apply_manual_overrides_to_resumes
+    from src.services.resume_overrides import apply_manual_overrides_to_resumes
 
     conn = sqlite3.connect(":memory:")
     init_schema(conn)
@@ -378,7 +378,7 @@ def test_manual_overrides_skip_resume_only(monkeypatch):
     insert_resume_snapshot(conn, user_id, "Resume B", json.dumps(snap_b), "rendered")
 
     overrides = {"summary_text": "Manual summary", "display_name": "Manual Name"}
-    _apply_manual_overrides_to_resumes(
+    apply_manual_overrides_to_resumes(
         conn,
         user_id,
         "ProjX",
@@ -402,7 +402,7 @@ def test_manual_overrides_skip_resume_only(monkeypatch):
 
 
 def test_manual_overrides_force_resume_updates_resume_only():
-    from src.menu.resume.flow import _apply_manual_overrides_to_resumes
+    from src.services.resume_overrides import apply_manual_overrides_to_resumes
 
     conn = sqlite3.connect(":memory:")
     init_schema(conn)
@@ -440,7 +440,7 @@ def test_manual_overrides_force_resume_updates_resume_only():
     resume_ids = {r["name"]: r["id"] for r in resumes}
 
     overrides = {"summary_text": "Manual summary", "display_name": "Manual Name"}
-    _apply_manual_overrides_to_resumes(
+    apply_manual_overrides_to_resumes(
         conn,
         user_id,
         "ProjX",


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description
This PR adds endpoint for POST generate resume, and edit resume based on it's id. 
The POST generate resume will create a new resume from the user's projects. if the user does not choose which project to be included in the snapshot, it will automatically choose top 5 project.

edit resume will edit a specific project within a resume (either on that resume only or globally)

**Closes:** #399 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [x] pytest
- [x] Generate resume endpoint test:
        1. POST http://localhost:8000/resume/generate 
        2. Header: X-User-Id, value: (your user id that contains project that has been analyzed)
        3. Body: raw json :{
                               "name": "My Resume",
                               "project_ids": [1, 3, 5] -> (your project ids, optional)
                              }
        4.  Send
        5. Check whether resume snapshot is generated
- [x] Edit resume endpoint test:
        1. POST http://localhost:8000/resume/{resume_id}/edit
        2. Body raw json: 
{
  "project_name": "MyProject",
  "scope": "resume_only",
  "contribution_bullets": ["New bullet 1", "New bullet 2"],
  "contribution_edit_mode": "append" or "replace"
}       
        3. Send
        4. Check whether the resume snapshot edited properly



---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
Generate test:
<img width="835" height="206" alt="Screenshot 2026-01-24 at 8 16 30 PM" src="https://github.com/user-attachments/assets/19bba562-17fe-464a-9a0e-c8ba0f8eeff2" />
<img width="845" height="295" alt="Screenshot 2026-01-24 at 8 16 42 PM" src="https://github.com/user-attachments/assets/c3dd0ddd-ce72-4e82-82f0-f7bd2d1ee8d3" />
<img width="438" height="173" alt="Screenshot 2026-01-24 at 8 17 11 PM" src="https://github.com/user-attachments/assets/91b50359-db53-41e8-90b1-1602c0c36902" />
<img width="438" height="173" alt="Screenshot 2026-01-24 at 8 17 11 PM" src="https://github.com/user-attachments/assets/b92e61fc-6a9c-444a-a712-9f5df23d1836" />

Edit test
<img width="846" height="301" alt="Screenshot 2026-01-24 at 8 19 34 PM" src="https://github.com/user-attachments/assets/b2f10487-d18d-46e1-a49b-417fc9ffb123" />
<img width="856" height="297" alt="Screenshot 2026-01-24 at 8 19 45 PM" src="https://github.com/user-attachments/assets/5a83b0a0-aaa2-420e-a90d-52db9aafc2f5" />
<img width="440" height="161" alt="Screenshot 2026-01-24 at 8 20 04 PM" src="https://github.com/user-attachments/assets/a6494d61-5797-4217-b3e8-00b4dc04e26a" />
<img width="939" height="185" alt="Screenshot 2026-01-24 at 8 20 19 PM" src="https://github.com/user-attachments/assets/1b93021b-97f2-4d4a-ac34-c76a742a225c" />

Test with user_id does not exist:
<img width="860" height="294" alt="Screenshot 2026-01-24 at 8 22 12 PM" src="https://github.com/user-attachments/assets/c690cf7a-30d4-4561-9389-d248c4002ed5" />

Test with user_id exist, resume id does not exist:
<img width="856" height="538" alt="Screenshot 2026-01-24 at 8 29 15 PM" src="https://github.com/user-attachments/assets/74bb9e4e-956d-4e3c-a01e-fedc99634430" />

Test with existing resume id and user id but project name does not exist
<img width="851" height="520" alt="Screenshot 2026-01-24 at 8 30 22 PM" src="https://github.com/user-attachments/assets/553c1e45-8e5c-4b1f-9c23-c8b99db320cb" />


</details>