### PR TITLE
Revise Key role to store position

### DIFF
--- a/src/analysis/code_collaborative/code_collaborative_analysis.py
+++ b/src/analysis/code_collaborative/code_collaborative_analysis.py
@@ -403,6 +403,17 @@ def _apply_basic_summary_without_git(
     frameworks = detect_frameworks(conn, project_name, user_id, zip_path) or set()
     summary.frameworks = sorted(frameworks) if frameworks else []
 
+    # Extract or prompt for key role (same logic as git path)
+    external_consent = get_latest_external_consent(conn, user_id)
+
+    if external_consent == "accepted" and clean_desc:
+        key_role = extract_key_role_llm(clean_desc)
+    else:
+        key_role = prompt_key_role(project_name)
+
+    if key_role:
+        summary.contributions["key_role"] = key_role
+
 def _build_db_payload_from_metrics(metrics: Mapping[str, Any], repo_path: str) -> dict[str, Any]:
     """
     Flatten the compute_metrics() output into a dict that matches the

--- a/src/analysis/code_collaborative/code_collaborative_analysis.py
+++ b/src/analysis/code_collaborative/code_collaborative_analysis.py
@@ -29,6 +29,7 @@ from src.analysis.code_collaborative.github_collaboration.print_collaboration_su
 from src.analysis.code_collaborative.no_git_contributions import (
     store_contributions_without_git,
 )
+from src.analysis.text_individual.llm_summary import extract_key_role_llm
 
 from .code_collaborative_analysis_helper import (
     DEBUG,
@@ -226,7 +227,6 @@ def analyze_code_project(conn: sqlite3.Connection,
             external_consent = None
 
         if external_consent == "accepted" and desc_clean:
-            from src.analysis.text_individual.llm_summary import extract_key_role_llm
             key_role = extract_key_role_llm(desc_clean)
         else:
             key_role = prompt_key_role(project_name)

--- a/src/analysis/code_collaborative/code_collaborative_analysis_helper.py
+++ b/src/analysis/code_collaborative/code_collaborative_analysis_helper.py
@@ -651,7 +651,7 @@ def prompt_collab_descriptions(projects: list[tuple[str, str]], consent: str) ->
         print("\nCONTRIBUTION SUMMARIES")
     print("Describe only your personal contributions to the collaborative project.")
     print("Write 1-3 sentences. Be specific about features/files you primarily worked on.")
-    print("Example: “Implemented login API in FastAPI and wrote tests for user_routes.py”.\n")
+    print('Example: "Implemented login API in FastAPI and wrote tests for user_routes.py".\n')
 
     descs = {}
     for project_name, _ in projects:
@@ -662,6 +662,19 @@ def prompt_collab_descriptions(projects: list[tuple[str, str]], consent: str) ->
         descs[project_name] = user_input or "[No manual contribution summary provided]"
 
     return descs
+
+
+def prompt_key_role(project_name: str) -> str:
+    """
+    Ask user for their role/title on a project.
+    Returns the role string entered by the user.
+    """
+    print("\nExamples: 'Backend Developer', 'Lead Author', 'Data Analyst', 'Full-Stack Developer'")
+    try:
+        role = input(f"Your role on '{project_name}': ").strip()
+    except EOFError:
+        role = ""
+    return role
 
 
 

--- a/src/analysis/text_collaborative/text_collab_analysis.py
+++ b/src/analysis/text_collaborative/text_collab_analysis.py
@@ -1,7 +1,8 @@
 import re
 import textwrap
 from src.analysis.text_individual.text_analyze import run_text_pipeline
-from src.analysis.text_individual.llm_summary import generate_text_llm_summary, generate_contribution_llm_summary
+from src.analysis.text_individual.llm_summary import generate_text_llm_summary, generate_contribution_llm_summary, extract_key_role_llm
+from src.analysis.code_collaborative.code_collaborative_analysis_helper import prompt_key_role
 from src.analysis.text_individual.alt_summary import prompt_manual_summary
 from src.analysis.skills.flows.text_skill_extraction import extract_text_skills
 from src.utils.helpers import normalize_pdf_paragraphs
@@ -139,6 +140,18 @@ def analyze_collaborative_text_project(
 
     user_sections = [sections[i - 1] for i in indices]
 
+    # ---------------------------------------------------------
+    # STEP 2A — Ask for contribution description (like code projects)
+    # ---------------------------------------------------------
+    print("\nDescribe your personal contributions to this collaborative text project.")
+    print("Write 1-3 sentences. Be specific about sections/content you primarily worked on.")
+    try:
+        contribution_desc = input(f"Your contribution to '{project_name}': ").strip()
+    except EOFError:
+        contribution_desc = ""
+
+    # Store the description
+    summary_obj.contributions["manual_contribution_summary"] = contribution_desc or "[No manual contribution summary provided]"
 
     contributed_text = "\n\n".join(s["text"] for s in user_sections)
     
@@ -313,6 +326,18 @@ def analyze_collaborative_text_project(
     print(textwrap.fill(contribution_summary, width=80, subsequent_indent="  "))
     if constants.VERBOSE:
         print("="*80 + "\n")
+
+    # ---------------------------------------------------------
+    # STEP 4B — Extract or prompt for key role
+    # ---------------------------------------------------------
+    contribution_desc = summary_obj.contributions.get("manual_contribution_summary", "")
+    if external_consent == "accepted" and contribution_desc and contribution_desc != "[No manual contribution summary provided]":
+        key_role = extract_key_role_llm(contribution_desc)
+    else:
+        key_role = prompt_key_role(project_name)
+
+    if key_role:
+        summary_obj.contributions["key_role"] = key_role
 
     # ---------------------------------------------------------
     # STEP 5 — Run skill detectors on ONLY the contributed text

--- a/src/analysis/text_individual/llm_summary.py
+++ b/src/analysis/text_individual/llm_summary.py
@@ -49,6 +49,51 @@ def generate_text_llm_summary(text: str) -> str:
         print(f"Error generating summary: {e}")
         return "[Summary unavailable due to API error]"
     
+def extract_key_role_llm(contribution_description: str) -> str:
+    """
+    Extract a key role/title from the user's contribution description using LLM.
+    Returns a concise professional role or title (2-4 words).
+    """
+    if not contribution_description or not contribution_description.strip():
+        return ""
+
+    # Truncate to avoid exceeding token limits
+    contribution_description = contribution_description[:2000]
+
+    prompt = f"""Based on this contribution description, extract a concise professional role or title (2-4 words).
+
+Examples of good roles: "Backend Developer", "Frontend Lead", "Data Analyst", "Lead Author", "Research Coordinator", "Full-Stack Developer", "Project Manager", "UI Designer", "Technical Writer"
+
+Contribution description:
+{contribution_description}
+
+Return ONLY the role title, nothing else. Do not include any explanation or punctuation."""
+
+    try:
+        completion = client.chat.completions.create(
+            model="llama-3.1-8b-instant",
+            messages=[
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a precise role extractor. You identify professional roles "
+                        "from contribution descriptions. Always respond with just 2-4 words."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+            temperature=0.1,
+            max_tokens=20,
+        )
+        role = completion.choices[0].message.content.strip()
+        # Clean up any quotes or extra punctuation
+        role = role.strip('"\'.,;:')
+        return role
+    except Exception as e:
+        print(f"Error extracting role: {e}")
+        return ""
+
+
 def generate_contribution_llm_summary(full_text, user_text):
     """
     LLM-generated FIRST-PERSON contribution summary.

--- a/tests/test_key_role.py
+++ b/tests/test_key_role.py
@@ -1,0 +1,281 @@
+"""
+Tests for the key role extraction feature.
+
+Tests cover:
+1. LLM-based role extraction (extract_key_role_llm)
+2. Manual role prompt (prompt_key_role)
+3. Integration with project summaries
+"""
+
+import builtins
+import pytest
+from unittest.mock import patch, MagicMock
+
+
+# -----------------------------
+# Tests for extract_key_role_llm
+# -----------------------------
+class TestExtractKeyRoleLLM:
+    """Tests for the LLM-based key role extraction function."""
+
+    def test_extract_key_role_llm_returns_role_from_description(self):
+        """Test that LLM extracts a role from a contribution description."""
+        from src.analysis.text_individual.llm_summary import extract_key_role_llm
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "Backend Developer"
+
+        with patch("src.analysis.text_individual.llm_summary.client") as mock_client:
+            mock_client.chat.completions.create.return_value = mock_completion
+
+            result = extract_key_role_llm("I implemented the REST API endpoints and database models")
+
+            assert result == "Backend Developer"
+            mock_client.chat.completions.create.assert_called_once()
+
+    def test_extract_key_role_llm_strips_quotes_and_punctuation(self):
+        """Test that extracted role is cleaned of quotes and punctuation."""
+        from src.analysis.text_individual.llm_summary import extract_key_role_llm
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = '"Lead Author".'
+
+        with patch("src.analysis.text_individual.llm_summary.client") as mock_client:
+            mock_client.chat.completions.create.return_value = mock_completion
+
+            result = extract_key_role_llm("I wrote the main thesis chapters")
+
+            assert result == "Lead Author"
+
+    def test_extract_key_role_llm_returns_empty_for_empty_input(self):
+        """Test that empty input returns empty string without calling LLM."""
+        from src.analysis.text_individual.llm_summary import extract_key_role_llm
+
+        with patch("src.analysis.text_individual.llm_summary.client") as mock_client:
+            result = extract_key_role_llm("")
+            assert result == ""
+            mock_client.chat.completions.create.assert_not_called()
+
+            result = extract_key_role_llm("   ")
+            assert result == ""
+            mock_client.chat.completions.create.assert_not_called()
+
+    def test_extract_key_role_llm_returns_empty_on_exception(self):
+        """Test that exceptions are handled gracefully and return empty string."""
+        from src.analysis.text_individual.llm_summary import extract_key_role_llm
+
+        with patch("src.analysis.text_individual.llm_summary.client") as mock_client:
+            mock_client.chat.completions.create.side_effect = Exception("API Error")
+
+            result = extract_key_role_llm("Some contribution description")
+
+            assert result == ""
+
+    def test_extract_key_role_llm_truncates_long_input(self):
+        """Test that very long input is truncated to 2000 characters."""
+        from src.analysis.text_individual.llm_summary import extract_key_role_llm
+
+        mock_completion = MagicMock()
+        mock_completion.choices = [MagicMock()]
+        mock_completion.choices[0].message.content = "Data Analyst"
+
+        long_description = "A" * 5000  # 5000 characters
+
+        with patch("src.analysis.text_individual.llm_summary.client") as mock_client:
+            mock_client.chat.completions.create.return_value = mock_completion
+
+            result = extract_key_role_llm(long_description)
+
+            # Verify the call was made
+            call_args = mock_client.chat.completions.create.call_args
+            messages = call_args.kwargs["messages"]
+            user_content = messages[1]["content"]
+
+            # The truncated description should be at most 2000 chars in the prompt
+            assert "A" * 2000 in user_content
+            assert "A" * 2001 not in user_content
+
+
+# -----------------------------
+# Tests for prompt_key_role
+# -----------------------------
+class TestPromptKeyRole:
+    """Tests for the manual key role prompt function."""
+
+    def test_prompt_key_role_returns_user_input(self):
+        """Test that prompt_key_role returns the user's input."""
+        from src.analysis.code_collaborative.code_collaborative_analysis_helper import prompt_key_role
+
+        with patch.object(builtins, "input", return_value="Frontend Developer"):
+            result = prompt_key_role("MyProject")
+            assert result == "Frontend Developer"
+
+    def test_prompt_key_role_strips_whitespace(self):
+        """Test that whitespace is stripped from input."""
+        from src.analysis.code_collaborative.code_collaborative_analysis_helper import prompt_key_role
+
+        with patch.object(builtins, "input", return_value="  Data Scientist  "):
+            result = prompt_key_role("MyProject")
+            assert result == "Data Scientist"
+
+    def test_prompt_key_role_returns_empty_on_eof(self):
+        """Test that EOFError returns empty string."""
+        from src.analysis.code_collaborative.code_collaborative_analysis_helper import prompt_key_role
+
+        with patch.object(builtins, "input", side_effect=EOFError):
+            result = prompt_key_role("MyProject")
+            assert result == ""
+
+    def test_prompt_key_role_returns_empty_for_blank_input(self):
+        """Test that blank input returns empty string."""
+        from src.analysis.code_collaborative.code_collaborative_analysis_helper import prompt_key_role
+
+        with patch.object(builtins, "input", return_value=""):
+            result = prompt_key_role("MyProject")
+            assert result == ""
+
+
+# -----------------------------
+# Integration tests for key role storage
+# -----------------------------
+class TestKeyRoleIntegration:
+    """Integration tests for key role storage in project summaries."""
+
+    def test_key_role_stored_in_code_collaborative_summary(self):
+        """Test that key_role is stored in contributions for code collaborative projects."""
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="TestProject",
+            project_type="code",
+            project_mode="collaborative"
+        )
+
+        # Simulate key role being added (as done in code_collaborative_analysis.py)
+        summary.contributions["key_role"] = "Backend Developer"
+        summary.contributions["manual_contribution_summary"] = "Implemented REST API"
+
+        assert summary.contributions["key_role"] == "Backend Developer"
+        assert "manual_contribution_summary" in summary.contributions
+
+    def test_key_role_stored_in_text_collaborative_summary(self):
+        """Test that key_role is stored in contributions for text collaborative projects."""
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="ResearchPaper",
+            project_type="text",
+            project_mode="collaborative"
+        )
+
+        summary.contributions["key_role"] = "Lead Author"
+        summary.contributions["manual_contribution_summary"] = "Wrote the introduction and methods sections"
+
+        assert summary.contributions["key_role"] == "Lead Author"
+
+    def test_key_role_stored_in_individual_code_summary(self):
+        """Test that key_role is stored in contributions for individual code projects."""
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="PersonalProject",
+            project_type="code",
+            project_mode="individual"
+        )
+
+        summary.contributions["key_role"] = "Full-Stack Developer"
+        summary.contributions["manual_contribution_summary"] = "Built the entire application"
+
+        assert summary.contributions["key_role"] == "Full-Stack Developer"
+
+    def test_key_role_stored_in_individual_text_summary(self):
+        """Test that key_role is stored in contributions for individual text projects."""
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="Thesis",
+            project_type="text",
+            project_mode="individual"
+        )
+
+        summary.contributions["key_role"] = "Researcher"
+        summary.contributions["manual_contribution_summary"] = "Conducted all research and writing"
+
+        assert summary.contributions["key_role"] == "Researcher"
+
+    def test_key_role_not_stored_when_empty(self):
+        """Test that empty key_role is not stored in contributions."""
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="TestProject",
+            project_type="code",
+            project_mode="collaborative"
+        )
+
+        # Simulate the conditional storage (as done in the analysis files)
+        key_role = ""
+        if key_role:
+            summary.contributions["key_role"] = key_role
+
+        assert "key_role" not in summary.contributions
+
+    def test_key_role_serializes_to_json(self):
+        """Test that key_role is properly serialized when converting to JSON."""
+        import json
+        from src.models.project_summary import ProjectSummary
+
+        summary = ProjectSummary(
+            project_name="TestProject",
+            project_type="code",
+            project_mode="collaborative"
+        )
+        summary.contributions["key_role"] = "DevOps Engineer"
+        summary.contributions["manual_contribution_summary"] = "Set up CI/CD pipeline"
+
+        json_data = json.dumps(summary.__dict__, default=str)
+        parsed = json.loads(json_data)
+
+        assert parsed["contributions"]["key_role"] == "DevOps Engineer"
+
+
+# -----------------------------
+# Tests for LLM vs Manual selection logic
+# -----------------------------
+class TestKeyRoleSelectionLogic:
+    """Tests for the logic that decides between LLM extraction and manual prompt."""
+
+    def test_uses_llm_when_consent_accepted_and_description_exists(self):
+        """Test that LLM is used when external consent is accepted and description exists."""
+        # This tests the logic pattern used in the analysis files
+        external_consent = "accepted"
+        contribution_desc = "I implemented the authentication system"
+
+        use_llm = external_consent == "accepted" and bool(contribution_desc)
+        assert use_llm is True
+
+    def test_uses_manual_when_consent_rejected(self):
+        """Test that manual prompt is used when consent is rejected."""
+        external_consent = "rejected"
+        contribution_desc = "I implemented the authentication system"
+
+        use_llm = external_consent == "accepted" and bool(contribution_desc)
+        assert use_llm is False
+
+    def test_uses_manual_when_description_empty(self):
+        """Test that manual prompt is used when description is empty."""
+        external_consent = "accepted"
+        contribution_desc = ""
+
+        use_llm = external_consent == "accepted" and bool(contribution_desc)
+        assert use_llm is False
+
+    def test_uses_manual_when_consent_none(self):
+        """Test that manual prompt is used when consent is None."""
+        external_consent = None
+        contribution_desc = "Some description"
+
+        use_llm = external_consent == "accepted" and bool(contribution_desc)
+        assert use_llm is False

--- a/tests/test_text_collab_analysis.py
+++ b/tests/test_text_collab_analysis.py
@@ -81,9 +81,12 @@ def test_analyze_collaborative_text_project(
 
     # Simulated user inputs in order:
     # 1) sections selected → "1,2"
-    # 2) supporting text files → "1" (first_draft)
-    # 3) CSV files → "1"
-    fake_inputs = iter(["1,2", "1", "1", "1"])
+    # 2) contribution description → "My contribution"
+    # 3) supporting text files → "1" (first_draft)
+    # 4) CSV files → "1"
+    # 5) manual contribution summary type → "1"
+    # 6) key role → "Developer"
+    fake_inputs = iter(["1,2", "My contribution", "1", "1", "1", "Developer"])
 
     with (
         patch("src.analysis.text_collaborative.text_collab_analysis.run_text_pipeline",


### PR DESCRIPTION
<!--
PR documentation for Key Role Feature (Storage Layer)
-->

## 📝 Description

This PR adds a "key role" feature that extracts/collects a professional role or title (e.g., "Backend Developer", "Lead Author", "Data Analyst") for users on their projects. The role is determined either via LLM extraction from the user's contribution description (if external consent is granted) or through a manual prompt.

**Scope:** This PR implements the **storage layer only**. The key role is collected and stored in the database but is not yet displayed in resumes or portfolios.

**Follow-up PR (issue: #422) will:**
- Display key role in resume snapshots
- Integrate key role into the "Customize Resume" functionality

**Closes:** #421

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests

```bash
python -m pytest tests/test_key_role.py -v
```

### Manual Test Scenarios

<details>
<summary>Click to expand manual testing instructions</summary>

#### Prerequisites
1. Have [DB Browser for SQLite](https://sqlitebrowser.org/) installed (or use `sqlite3` CLI)
2. Fresh database recommended: `rm local_storage.db` before testing

#### Test 1: Code Collaborative Project (LLM Path)

**Setup:** External consent = ACCEPTED

1. Run CLI: `python -m src.main`
2. Follow prompts:
   - Username: `testuser`
   - Accept user consent: `y`
   - Accept external consent: `y` (enables LLM)
   - Upload a code project ZIP with git history
   - Classify as: `collaborative`
3. When prompted for contribution description, enter:
   ```
   I implemented the REST API endpoints and wrote unit tests for authentication
   ```
4. **Expected:** Should NOT prompt for role (LLM extracts it automatically)
5. **Verify:**
   ```bash
   sqlite3 local_storage.db "SELECT json_extract(summary_json, '$.contributions.key_role') FROM project_summaries ORDER BY id DESC LIMIT 1;"
   ```
   **Expected:** `"Backend Developer"` or similar

#### Test 2: Code Collaborative Project (Manual Path)

**Setup:** External consent = REJECTED

1. Run CLI with new user, reject external consent
2. Upload code project, classify as `collaborative`
3. Enter contribution description
4. **Expected:** Should prompt: `Your role on '<project_name>':`
5. Enter role manually (e.g., `Frontend Developer`)
6. **Verify in database:** `key_role` should match your input

#### Test 3: Text Collaborative Project

1. Run CLI with rejected external consent
2. Upload text project (.docx/.pdf), classify as `collaborative`
3. Select sections, enter description, enter role when prompted
4. **Verify:** `key_role` present in contributions

#### Test 4: Individual Code Project

1. Upload code project, classify as `individual`
2. Enter contribution description
3. If LLM disabled, enter role when prompted
4. **Verify:** `key_role` present in contributions

#### Test 5: Individual Text Project

1. Upload text project, classify as `individual`
2. Enter description and role
3. **Verify:** `key_role` present in contributions

</details>
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
Key role stored in DB:
<img width="573" height="402" alt="Screenshot 2026-01-26 at 11 03 20 AM" src="https://github.com/user-attachments/assets/88b41875-f522-4f9d-b67d-3ae423099e96" />

---