### PR TITLE
Delete api endpoints

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -194,7 +194,7 @@ Handles project ingestion, analysis, classification, and metadata updates.
             },
             "error": null
         }
-        ```          
+        ```
 
 - **Project Ranking**
     - **Description**: Returns/updates the ranked list of projects (with computed scores) and supports manual ranking overrides.
@@ -252,7 +252,7 @@ Handles project ingestion, analysis, classification, and metadata updates.
             - `400 Bad Request` if `project_ids` contains duplicates OR does not include every project_summary_id for the user
             - `404 Not Found` if any `project_id` does not exist / does not belong to the user
 
-    - **Patch One Project’s Manual Rank**
+    - **Patch One Project's Manual Rank**
         - **Endpoint**: `PATCH /projects/{project_id}/ranking`
         - **Description**: Sets or clears the manual rank for one project.
         - **Path Parameters**:
@@ -272,7 +272,7 @@ Handles project ingestion, analysis, classification, and metadata updates.
         - **Response Status**: `200 OK`
         - **Response DTO**: `ProjectRankingDTO`
         - **Error Responses**:
-            - `400 Bad Request` if `rank` is less than 1, or greater than the user’s project count
+            - `400 Bad Request` if `rank` is less than 1, or greater than the user's project count
             - `404 Not Found` if the project does not exist / does not belong to the user
 
     - **Reset Ranking to Automatic**
@@ -282,6 +282,39 @@ Handles project ingestion, analysis, classification, and metadata updates.
         - **Request Body**: None
         - **Response Status**: `200 OK`
         - **Response DTO**: `ProjectRankingDTO`
+
+- **Delete Project by ID**
+    - **Endpoint**: `DELETE /projects/{project_id}`
+    - **Description**: Permanently deletes a specific project and all its associated data (skills, metrics, files, etc.).
+    - **Path Parameters**:
+        - `{project_id}` (integer, required): The project_summary_id of the project to delete
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Response Status**: `200 OK` on success, `404 Not Found` if project doesn't exist or belong to user
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": null,
+            "error": null
+        }
+        ```
+
+- **Delete All Projects**
+    - **Endpoint**: `DELETE /projects`
+    - **Description**: Permanently deletes all projects belonging to the current user.
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Response Status**: `200 OK`
+    - **Response DTO**: `DeleteResultDTO`
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": {
+                "deleted_count": 3
+            },
+            "error": null
+        }
+        ```
 ---
 
 ## **Uploads Wizard**
@@ -898,6 +931,39 @@ Manages résumé-specific representations of projects.
         }
         ```
 
+- **Delete Resume by ID**
+    - **Endpoint**: `DELETE /resume/{resume_id}`
+    - **Description**: Permanently deletes a specific résumé snapshot.
+    - **Path Parameters**:
+        - `{resume_id}` (integer, required): The ID of the résumé snapshot to delete
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Response Status**: `200 OK` on success, `404 Not Found` if résumé doesn't exist or belong to user
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": null,
+            "error": null
+        }
+        ```
+
+- **Delete All Resumes**
+    - **Endpoint**: `DELETE /resume`
+    - **Description**: Permanently deletes all résumé snapshots belonging to the current user.
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Response Status**: `200 OK`
+    - **Response DTO**: `DeleteResultDTO`
+    - **Response Body**:
+        ```json
+        {
+            "success": true,
+            "data": {
+                "deleted_count": 2
+            },
+            "error": null
+        }
+        ```
+
 ---
 
 ## **Portfolio**
@@ -1127,6 +1193,9 @@ Example:
 
 - **GitHubLinkRequest**
     - `repo_full_name` (string, required)
+
+- **DeleteResultDTO** (used by `DELETE /projects` and `DELETE /resume`)
+    - `deleted_count` (int, required): Number of items deleted
 
 ---
 

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter, Depends, Query, UploadFile, File, HTTPException
 from sqlite3 import Connection
 
 from src.api.dependencies import get_db, get_current_user_id
-from src.api.schemas.common import ApiResponse
+from src.api.schemas.common import ApiResponse, DeleteResultDTO
 from src.api.schemas.projects import ProjectListDTO, ProjectListItemDTO, ProjectDetailDTO
 from src.api.schemas.uploads import (
     UploadDTO,
@@ -12,7 +12,12 @@ from src.api.schemas.uploads import (
     UploadProjectFilesDTO,
     MainFileRequestDTO,
 )
-from src.services.projects_service import list_projects, get_project_by_id
+from src.services.projects_service import (
+    list_projects,
+    get_project_by_id,
+    delete_project,
+    delete_all_projects,
+)
 from src.services.uploads_service import (
     start_upload,
     get_upload_status,
@@ -120,6 +125,16 @@ def post_upload_project_main_file(
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
 
 
+@router.delete("", response_model=ApiResponse[DeleteResultDTO])
+def delete_all_user_projects(
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """Delete all projects for the current user."""
+    count = delete_all_projects(conn, user_id)
+    return ApiResponse(success=True, data=DeleteResultDTO(deleted_count=count), error=None)
+
+
 # Use `:int` so non-integers like "ranking" never match this route.
 @router.get("/{project_id:int}", response_model=ApiResponse[ProjectDetailDTO])
 def get_project(
@@ -132,3 +147,16 @@ def get_project(
         raise HTTPException(status_code=404, detail="Project not found")
     dto = ProjectDetailDTO(**project)
     return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.delete("/{project_id:int}", response_model=ApiResponse[None])
+def delete_single_project(
+    project_id: int,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """Delete a single project by ID."""
+    deleted = delete_project(conn, user_id, project_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Project not found")
+    return ApiResponse(success=True, data=None, error=None)

--- a/src/api/routes/resumes.py
+++ b/src/api/routes/resumes.py
@@ -2,9 +2,16 @@ from fastapi import APIRouter, Depends, HTTPException
 from sqlite3 import Connection
 
 from src.api.dependencies import get_db, get_current_user_id
-from src.api.schemas.common import ApiResponse
+from src.api.schemas.common import ApiResponse, DeleteResultDTO
 from src.api.schemas.resumes import ResumeListDTO, ResumeListItemDTO, ResumeDetailDTO, ResumeGenerateRequestDTO, ResumeEditRequestDTO
-from src.services.resumes_service import list_user_resumes, get_resume_by_id, generate_resume, edit_resume
+from src.services.resumes_service import (
+    list_user_resumes,
+    get_resume_by_id,
+    generate_resume,
+    edit_resume,
+    delete_resume,
+    delete_all_resumes,
+)
 
 router = APIRouter(prefix="/resume", tags=["resume"])
 
@@ -15,8 +22,18 @@ def get_resumes(
 ):
     rows = list_user_resumes(conn, user_id)
     dto = ResumeListDTO(resumes=[ResumeListItemDTO(**row) for row in rows])
-    
+
     return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.delete("", response_model=ApiResponse[DeleteResultDTO])
+def delete_all_user_resumes(
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """Delete all resumes for the current user."""
+    count = delete_all_resumes(conn, user_id)
+    return ApiResponse(success=True, data=DeleteResultDTO(deleted_count=count), error=None)
 
 @router.get("/{resume_id}", response_model=ApiResponse[ResumeDetailDTO])
 def get_resume(
@@ -31,6 +48,19 @@ def get_resume(
 
     dto = ResumeDetailDTO(**resume)
     return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.delete("/{resume_id}", response_model=ApiResponse[None])
+def delete_single_resume(
+    resume_id: int,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    """Delete a single resume by ID."""
+    deleted = delete_resume(conn, user_id, resume_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Resume not found")
+    return ApiResponse(success=True, data=None, error=None)
 
 
 @router.post("/generate", response_model=ApiResponse[ResumeDetailDTO], status_code=201)

--- a/src/api/schemas/common.py
+++ b/src/api/schemas/common.py
@@ -11,3 +11,7 @@ class ApiResponse(BaseModel, Generic[T]):
     success: bool
     data: Optional[T] = None
     error: Optional[ErrorDTO] = None
+
+
+class DeleteResultDTO(BaseModel):
+    deleted_count: int

--- a/src/db/resumes.py
+++ b/src/db/resumes.py
@@ -95,11 +95,12 @@ def delete_resume_snapshot(
     conn: sqlite3.Connection,
     user_id: int,
     resume_id: int,
-) -> None:
+) -> bool:
     """
     Permanently delete a resume snapshot for a user.
+    Returns True if a row was deleted, False otherwise.
     """
-    conn.execute(
+    cur = conn.execute(
         """
         DELETE FROM resume_snapshots
         WHERE user_id = ? AND id = ?
@@ -107,3 +108,19 @@ def delete_resume_snapshot(
         (user_id, resume_id),
     )
     conn.commit()
+    return cur.rowcount > 0
+
+
+def delete_all_user_resumes(conn: sqlite3.Connection, user_id: int) -> int:
+    """
+    Delete all resume snapshots for a user. Returns count of deleted resumes.
+    """
+    cur = conn.execute(
+        """
+        DELETE FROM resume_snapshots
+        WHERE user_id = ?
+        """,
+        (user_id,),
+    )
+    conn.commit()
+    return cur.rowcount

--- a/src/services/projects_service.py
+++ b/src/services/projects_service.py
@@ -1,6 +1,8 @@
 import json
 from typing import List, Dict, Any, Optional
 from src.db.project_summaries import get_project_summaries_list, get_project_summary_by_id
+from src.db.delete_project import delete_project_everywhere, delete_all_user_projects
+
 
 def list_projects(conn, user_id: int) -> List[Dict[str, Any]]:
     """
@@ -8,24 +10,47 @@ def list_projects(conn, user_id: int) -> List[Dict[str, Any]]:
     """
     return get_project_summaries_list(conn, user_id)
 
-def get_project_by_id(conn,user_id: int, project_summary_id: int) -> Optional[Dict[str, Any]]:
+
+def get_project_by_id(conn, user_id: int, project_summary_id: int) -> Optional[Dict[str, Any]]:
     """
     Service method for retrieving a project by its ID.
     """
     row = get_project_summary_by_id(conn, user_id, project_summary_id)
     if not row:
         return None
-     
+
     # Parse the summary_json
     try:
         summary_dict = json.loads(row["summary_json"])
     except json.JSONDecodeError:
         summary_dict = {}
-    
+
     row_without_json = {k: v for k, v in row.items() if k != "summary_json"}
-    
+
     # Flatten it
     return {
-        **row_without_json, 
-        **summary_dict  
+        **row_without_json,
+        **summary_dict
     }
+
+
+def delete_project(conn, user_id: int, project_id: int) -> bool:
+    """
+    Delete a single project by ID.
+    Returns True if deleted, False if not found.
+    """
+    row = get_project_summary_by_id(conn, user_id, project_id)
+    if not row:
+        return False
+
+    project_name = row["project_name"]
+    delete_project_everywhere(conn, user_id, project_name)
+    return True
+
+
+def delete_all_projects(conn, user_id: int) -> int:
+    """
+    Delete all projects for a user.
+    Returns the count of deleted projects.
+    """
+    return delete_all_user_projects(conn, user_id)

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -1,5 +1,11 @@
 from typing import List, Dict, Any, Optional, Literal
-from src.db.resumes import list_resumes, get_resume_snapshot, update_resume_snapshot
+from src.db.resumes import (
+    list_resumes,
+    get_resume_snapshot,
+    update_resume_snapshot,
+    delete_resume_snapshot,
+    delete_all_user_resumes,
+)
 from src.menu.resume.helpers import (
     render_snapshot,
     apply_resume_only_updates,
@@ -163,3 +169,19 @@ def edit_resume(
             )
 
     return get_resume_by_id(conn, user_id, resume_id)
+
+
+def delete_resume(conn, user_id: int, resume_id: int) -> bool:
+    """
+    Delete a single resume by ID.
+    Returns True if deleted, False if not found.
+    """
+    return delete_resume_snapshot(conn, user_id, resume_id)
+
+
+def delete_all_resumes(conn, user_id: int) -> int:
+    """
+    Delete all resumes for a user.
+    Returns the count of deleted resumes.
+    """
+    return delete_all_user_resumes(conn, user_id)

--- a/tests/api/test_delete_endpoints.py
+++ b/tests/api/test_delete_endpoints.py
@@ -1,0 +1,271 @@
+"""Tests for DELETE API endpoints for projects and resumes."""
+import json
+from src.db.project_summaries import save_project_summary, get_project_summary_by_name
+from src.db.resumes import insert_resume_snapshot, list_resumes
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def create_test_project(conn, user_id, name, project_type="code", project_mode="individual"):
+    """Create a test project and return its ID."""
+    summary_json = json.dumps({
+        "project_name": name,
+        "project_type": project_type,
+        "project_mode": project_mode,
+        "languages": ["Python"],
+        "summary_text": f"Test project: {name}",
+        "metrics": {}
+    })
+    save_project_summary(conn, user_id, name, summary_json)
+    conn.commit()
+    project = get_project_summary_by_name(conn, user_id, name)
+    return project["project_summary_id"]
+
+
+def create_test_resume(conn, user_id, name):
+    """Create a test resume and return its ID."""
+    resume_json = json.dumps({
+        "projects": [{"project_name": f"Project for {name}"}],
+        "aggregated_skills": {}
+    })
+    resume_id = insert_resume_snapshot(conn, user_id, name, resume_json)
+    conn.commit()
+    return resume_id
+
+
+def create_other_user(conn, user_id=2, username="other-user"):
+    """Create another user for isolation tests."""
+    conn.execute(
+        "INSERT OR IGNORE INTO users(user_id, username, email) VALUES (?, ?, NULL)",
+        (user_id, username)
+    )
+    conn.commit()
+
+
+def assert_success_response(response, expected_status=200):
+    """Assert response is successful with expected status code."""
+    assert response.status_code == expected_status
+    body = response.json()
+    assert body["success"] is True
+    assert body["error"] is None
+    return body
+
+
+def assert_delete_single_success(response):
+    """Assert single delete response is successful."""
+    body = assert_success_response(response)
+    assert body["data"] is None
+    return body
+
+
+def assert_delete_all_success(response, expected_count):
+    """Assert delete all response is successful with expected count."""
+    body = assert_success_response(response)
+    assert body["data"]["deleted_count"] == expected_count
+    return body
+
+
+def assert_not_found(response):
+    """Assert response is 404 not found."""
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def assert_unauthorized(response):
+    """Assert response is 401 unauthorized."""
+    assert response.status_code == 401
+
+
+# ============================================================================
+# DELETE /projects/{project_id} tests
+# ============================================================================
+
+def test_delete_project_requires_auth(client):
+    """Test that DELETE /projects/{id} requires authentication."""
+    res = client.delete("/projects/1")
+    assert_unauthorized(res)
+
+
+def test_delete_project_not_found_returns_404(client, auth_headers):
+    """Test deleting a project that doesn't exist returns 404."""
+    res = client.delete("/projects/999", headers=auth_headers)
+    assert_not_found(res)
+
+
+def test_delete_project_success(client, auth_headers, seed_conn):
+    """Test successfully deleting a project."""
+    project_id = create_test_project(seed_conn, 1, "TestProject")
+
+    res = client.delete(f"/projects/{project_id}", headers=auth_headers)
+    assert_delete_single_success(res)
+
+    # Verify it's gone
+    assert get_project_summary_by_name(seed_conn, 1, "TestProject") is None
+
+
+def test_delete_project_wrong_user(client, auth_headers, seed_conn):
+    """Test that a user cannot delete another user's project."""
+    create_other_user(seed_conn)
+    project_id = create_test_project(seed_conn, 2, "OtherUserProject")
+
+    # Try to delete with user 1's auth (should 404 since user 1 can't see it)
+    res = client.delete(f"/projects/{project_id}", headers=auth_headers)
+    assert_not_found(res)
+
+    # Verify project still exists for user 2
+    assert get_project_summary_by_name(seed_conn, 2, "OtherUserProject") is not None
+
+
+# ============================================================================
+# DELETE /projects tests (delete all)
+# ============================================================================
+
+def test_delete_all_projects_requires_auth(client):
+    """Test that DELETE /projects requires authentication."""
+    res = client.delete("/projects")
+    assert_unauthorized(res)
+
+
+def test_delete_all_projects_empty_returns_zero(client, auth_headers):
+    """Test deleting all projects when none exist returns count 0."""
+    res = client.delete("/projects", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=0)
+
+
+def test_delete_all_projects_success(client, auth_headers, seed_conn):
+    """Test successfully deleting all projects."""
+    # Create multiple projects
+    for i in range(3):
+        create_test_project(seed_conn, 1, f"Project{i}")
+
+    # Verify they exist
+    for i in range(3):
+        assert get_project_summary_by_name(seed_conn, 1, f"Project{i}") is not None
+
+    # Delete all
+    res = client.delete("/projects", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=3)
+
+    # Verify they're all gone
+    for i in range(3):
+        assert get_project_summary_by_name(seed_conn, 1, f"Project{i}") is None
+
+
+def test_delete_all_projects_only_deletes_own_projects(client, auth_headers, seed_conn):
+    """Test that delete all only deletes the authenticated user's projects."""
+    # Create projects for both users
+    create_test_project(seed_conn, 1, "User1Project")
+    create_other_user(seed_conn)
+    create_test_project(seed_conn, 2, "User2Project")
+
+    # Delete all as user 1
+    res = client.delete("/projects", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=1)
+
+    # Verify user 1's project is gone
+    assert get_project_summary_by_name(seed_conn, 1, "User1Project") is None
+
+    # Verify user 2's project still exists
+    assert get_project_summary_by_name(seed_conn, 2, "User2Project") is not None
+
+
+# ============================================================================
+# DELETE /resume/{resume_id} tests
+# ============================================================================
+
+def test_delete_resume_requires_auth(client):
+    """Test that DELETE /resume/{id} requires authentication."""
+    res = client.delete("/resume/1")
+    assert_unauthorized(res)
+
+
+def test_delete_resume_not_found_returns_404(client, auth_headers):
+    """Test deleting a resume that doesn't exist returns 404."""
+    res = client.delete("/resume/999", headers=auth_headers)
+    assert_not_found(res)
+
+
+def test_delete_resume_success(client, auth_headers, seed_conn):
+    """Test successfully deleting a resume."""
+    resume_id = create_test_resume(seed_conn, 1, "Test Resume")
+
+    # Verify it exists
+    assert any(r["id"] == resume_id for r in list_resumes(seed_conn, 1))
+
+    # Delete it
+    res = client.delete(f"/resume/{resume_id}", headers=auth_headers)
+    assert_delete_single_success(res)
+
+    # Verify it's gone
+    assert not any(r["id"] == resume_id for r in list_resumes(seed_conn, 1))
+
+
+def test_delete_resume_wrong_user(client, auth_headers, seed_conn):
+    """Test that a user cannot delete another user's resume."""
+    create_other_user(seed_conn)
+    resume_id = create_test_resume(seed_conn, 2, "Other User Resume")
+
+    # Try to delete with user 1's auth (should 404 since user 1 can't see it)
+    res = client.delete(f"/resume/{resume_id}", headers=auth_headers)
+    assert_not_found(res)
+
+    # Verify user 2's resume still exists
+    assert any(r["id"] == resume_id for r in list_resumes(seed_conn, 2))
+
+
+# ============================================================================
+# DELETE /resume tests (delete all)
+# ============================================================================
+
+def test_delete_all_resumes_requires_auth(client):
+    """Test that DELETE /resume requires authentication."""
+    res = client.delete("/resume")
+    assert_unauthorized(res)
+
+
+def test_delete_all_resumes_empty_returns_zero(client, auth_headers):
+    """Test deleting all resumes when none exist returns count 0."""
+    res = client.delete("/resume", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=0)
+
+
+def test_delete_all_resumes_success(client, auth_headers, seed_conn):
+    """Test successfully deleting all resumes."""
+    # Create multiple resumes
+    resume_ids = []
+    for i in range(3):
+        resume_id = create_test_resume(seed_conn, 1, f"Resume {i}")
+        resume_ids.append(resume_id)
+
+    # Verify they exist
+    resumes_before = list_resumes(seed_conn, 1)
+    assert len(resumes_before) == 3
+
+    # Delete all
+    res = client.delete("/resume", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=3)
+
+    # Verify they're all gone
+    assert len(list_resumes(seed_conn, 1)) == 0
+
+
+def test_delete_all_resumes_only_deletes_own_resumes(client, auth_headers, seed_conn):
+    """Test that delete all only deletes the authenticated user's resumes."""
+    # Create resumes for both users
+    create_test_resume(seed_conn, 1, "User 1 Resume")
+    create_other_user(seed_conn)
+    create_test_resume(seed_conn, 2, "User 2 Resume")
+
+    # Delete all as user 1
+    res = client.delete("/resume", headers=auth_headers)
+    assert_delete_all_success(res, expected_count=1)
+
+    # Verify user 1's resumes are gone
+    assert len(list_resumes(seed_conn, 1)) == 0
+
+    # Verify user 2's resume still exists
+    assert len(list_resumes(seed_conn, 2)) == 1
+
+


### PR DESCRIPTION
## 📝 Description

This PR implements 4 DELETE API endpoints for projects and resumes, enabling users to delete their data via the API.

### Endpoints Added:
- `DELETE /projects/{project_id}`:Delete single project by ID 
- `DELETE /projects`: Delete ALL projects for user
-  `DELETE /resume/{resume_id}`: Delete single resume by ID
-  `DELETE /resume`: Delete ALL resumes for user 

Closes: #423 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests
Run the new test suite:
```bash
pytest tests/api/test_delete_endpoints.py -v
```

### Manual Testing Steps

**Setup:**
```bash
# 1. Start the API server
uvicorn src.api.main:app --reload

# 2. Open Swagger UI
open http://localhost:8000/docs

# 3. Create a test user and get a token
curl -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "Testpass123"}'

curl -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "Testpass123"}'
# Save the access_token from the response
```

**Test 1: Verify endpoints appear in Swagger**
- [ ] Navigate to http://localhost:8000/docs
- [ ] Confirm `DELETE /projects` appears under "projects" tag
- [ ] Confirm `DELETE /projects/{project_id}` appears under "projects" tag
- [ ] Confirm `DELETE /resume` appears under "resume" tag
- [ ] Confirm `DELETE /resume/{resume_id}` appears under "resume" tag

**Test 2: Auth required for all DELETE endpoints**
```bash
# All should return 401 Unauthorized
curl -X DELETE http://localhost:8000/projects/1
curl -X DELETE http://localhost:8000/projects
curl -X DELETE http://localhost:8000/resume/1
curl -X DELETE http://localhost:8000/resume
```
- [ ] All 4 requests return `401 Unauthorized`

**Test 3: Delete non-existent project returns 404**
```bash
curl -X DELETE http://localhost:8000/projects/99999 \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `404 Not Found` with `{"detail": "Project not found"}`

**Test 4: Delete non-existent resume returns 404**
```bash
curl -X DELETE http://localhost:8000/resume/99999 \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `404 Not Found` with `{"detail": "Resume not found"}`

**Test 5: Delete all projects when empty returns zero**
```bash
curl -X DELETE http://localhost:8000/projects \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `200 OK` with `{"success": true, "data": {"deleted_count": 0}}`

**Test 6: Delete all resumes when empty returns zero**
```bash
curl -X DELETE http://localhost:8000/resume \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `200 OK` with `{"success": true, "data": {"deleted_count": 0}}`

**Test 7: Full workflow - Create and delete a project**
```bash
# 1. Upload a project via ZIP (use the regular CLI interface by logging in with testuser)

# 2. List projects to get the project_id
curl -X GET http://localhost:8000/projects \
  -H "Authorization: Bearer <your_token>"
# Note the project_summary_id

# 3. Delete the project
curl -X DELETE http://localhost:8000/projects/<project_id> \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Delete returns `{"success": true, "data": null}`
- [ ] GET /projects no longer shows the deleted project

**Test 8: Full workflow - Create and delete a resume**
```bash
# 1. First create a project (needed for resume generation)
# 2. Generate a resume using the CLI and open the DB to get the resume ID
# 3. List resumes to confirm it exists
curl -X GET http://localhost:8000/resume \
  -H "Authorization: Bearer <your_token>"

# 4. Delete the resume
curl -X DELETE http://localhost:8000/resume/<resume_id> \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Delete returns `{"success": true, "data": null}`
- [ ] GET /resume no longer shows the deleted resume

**Test 9: Delete all projects with multiple projects**
```bash
# 1. Create 2-3 projects via upload
# 2. Verify they exist with GET /projects
# 3. Delete all
curl -X DELETE http://localhost:8000/projects \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `{"success": true, "data": {"deleted_count": N}}` where N matches project count
- [ ] GET /projects returns empty list

**Test 10: Delete all resumes with multiple resumes**
```bash
# 1. Generate 2-3 resumes
# 2. Verify they exist with GET /resume
# 3. Delete all
curl -X DELETE http://localhost:8000/resume \
  -H "Authorization: Bearer <your_token>"
```
- [ ] Returns `{"success": true, "data": {"deleted_count": N}}` where N matches resume count
- [ ] GET /resume returns empty list

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile (N/A - API only)

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

</details>
