### PR TITLE
Refresh Resume Parameter

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -291,6 +291,15 @@ Handles project ingestion, analysis, classification, and metadata updates.
     - **Query Parameters**:
         - `refresh_resumes` (boolean, optional): If `true`, also removes the deleted project from any résumé snapshots. Résumés that become empty are deleted. Defaults to `false`.
     - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Request Body**: None
+    - **Example Requests**:
+        ```bash
+        # Delete project (default, resumes unchanged)
+        DELETE /projects/9
+
+        # Delete project and update resumes
+        DELETE /projects/9?refresh_resumes=true
+        ```
     - **Response Status**: `200 OK` on success, `404 Not Found` if project doesn't exist or belong to user
     - **Response Body**:
         ```json
@@ -307,6 +316,15 @@ Handles project ingestion, analysis, classification, and metadata updates.
     - **Query Parameters**:
         - `refresh_resumes` (boolean, optional): If `true`, also removes deleted projects from any résumé snapshots. Résumés that become empty are deleted. Defaults to `false`.
     - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Request Body**: None
+    - **Example Requests**:
+        ```bash
+        # Delete all projects (default, resumes unchanged)
+        DELETE /projects
+
+        # Delete all projects and update resumes
+        DELETE /projects?refresh_resumes=true
+        ```
     - **Response Status**: `200 OK`
     - **Response DTO**: `DeleteResultDTO`
     - **Response Body**:

--- a/docs/API.md
+++ b/docs/API.md
@@ -288,6 +288,8 @@ Handles project ingestion, analysis, classification, and metadata updates.
     - **Description**: Permanently deletes a specific project and all its associated data (skills, metrics, files, etc.).
     - **Path Parameters**:
         - `{project_id}` (integer, required): The project_summary_id of the project to delete
+    - **Query Parameters**:
+        - `refresh_resumes` (boolean, optional): If `true`, also removes the deleted project from any résumé snapshots. Résumés that become empty are deleted. Defaults to `false`.
     - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
     - **Response Status**: `200 OK` on success, `404 Not Found` if project doesn't exist or belong to user
     - **Response Body**:
@@ -302,6 +304,8 @@ Handles project ingestion, analysis, classification, and metadata updates.
 - **Delete All Projects**
     - **Endpoint**: `DELETE /projects`
     - **Description**: Permanently deletes all projects belonging to the current user.
+    - **Query Parameters**:
+        - `refresh_resumes` (boolean, optional): If `true`, also removes deleted projects from any résumé snapshots. Résumés that become empty are deleted. Defaults to `false`.
     - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
     - **Response Status**: `200 OK`
     - **Response DTO**: `DeleteResultDTO`

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -127,11 +127,12 @@ def post_upload_project_main_file(
 
 @router.delete("", response_model=ApiResponse[DeleteResultDTO])
 def delete_all_user_projects(
+    refresh_resumes: bool = Query(False, description="If true, remove deleted projects from resume snapshots"),
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
     """Delete all projects for the current user."""
-    count = delete_all_projects(conn, user_id)
+    count = delete_all_projects(conn, user_id, refresh_resumes=refresh_resumes)
     return ApiResponse(success=True, data=DeleteResultDTO(deleted_count=count), error=None)
 
 
@@ -152,11 +153,12 @@ def get_project(
 @router.delete("/{project_id:int}", response_model=ApiResponse[None])
 def delete_single_project(
     project_id: int,
+    refresh_resumes: bool = Query(False, description="If true, remove deleted project from resume snapshots"),
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
     """Delete a single project by ID."""
-    deleted = delete_project(conn, user_id, project_id)
+    deleted = delete_project(conn, user_id, project_id, refresh_resumes=refresh_resumes)
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found")
     return ApiResponse(success=True, data=None, error=None)

--- a/src/services/projects_service.py
+++ b/src/services/projects_service.py
@@ -34,10 +34,11 @@ def get_project_by_id(conn, user_id: int, project_summary_id: int) -> Optional[D
     }
 
 
-def delete_project(conn, user_id: int, project_id: int) -> bool:
+def delete_project(conn, user_id: int, project_id: int, refresh_resumes: bool = False) -> bool:
     """
     Delete a single project by ID.
     Returns True if deleted, False if not found.
+    If refresh_resumes is True, also remove the project from resume snapshots.
     """
     row = get_project_summary_by_id(conn, user_id, project_id)
     if not row:
@@ -45,12 +46,30 @@ def delete_project(conn, user_id: int, project_id: int) -> bool:
 
     project_name = row["project_name"]
     delete_project_everywhere(conn, user_id, project_name)
+
+    if refresh_resumes:
+        from src.menu.resume.resume import refresh_saved_resumes_after_project_delete
+        refresh_saved_resumes_after_project_delete(conn, user_id, project_name)
+
     return True
 
 
-def delete_all_projects(conn, user_id: int) -> int:
+def delete_all_projects(conn, user_id: int, refresh_resumes: bool = False) -> int:
     """
     Delete all projects for a user.
     Returns the count of deleted projects.
+    If refresh_resumes is True, also remove the projects from resume snapshots.
     """
-    return delete_all_user_projects(conn, user_id)
+    # Collect project names BEFORE deletion (needed for resume refresh)
+    if refresh_resumes:
+        summaries = get_project_summaries_list(conn, user_id)
+        project_names = [s["project_name"] for s in summaries]
+
+    count = delete_all_user_projects(conn, user_id)
+
+    if refresh_resumes and count > 0:
+        from src.menu.resume.resume import refresh_saved_resumes_after_project_delete
+        for project_name in project_names:
+            refresh_saved_resumes_after_project_delete(conn, user_id, project_name)
+
+    return count


### PR DESCRIPTION
## 📝 Description

Add optional `refresh_resumes` query parameter to DELETE project endpoints. When set to `true`, deleted projects are also removed from existing resume snapshots, matching the CLI behavior.

**Background:** The CLI already offers users a choice to refresh resumes after deleting projects. This PR brings that functionality to the API, allowing frontend clients to opt into the same behavior.

**Changes:**
- Added `refresh_resumes` boolean query parameter (defaults to `false`) to:
  - `DELETE /projects/{project_id}` - Single project deletion
  - `DELETE /projects` - Delete all projects
- When enabled, calls `refresh_saved_resumes_after_project_delete()` to update resume snapshots
- Resumes that become empty after project removal are automatically deleted

**Closes:** #439

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

**Automated tests:** Added 9 new test cases in `tests/api/test_delete_endpoints.py`

```bash
pytest tests/api/test_delete_endpoints.py
```

**Manual API testing:**

1. Start the server:
```bash
uvicorn src.api.main:app --reload
```

2. Register and login to get a token:
```bash
# Register
curl -s -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "TestPass123"}'

# Login and save token
TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username": "testuser", "password": "TestPass123"}' | jq -r '.access_token')
```

3. Create test data using the CLI (`python -m src.main`):
   - Upload a ZIP with at least 2 projects
   - Complete the analysis flow for both projects
   - Create a resume that includes both projects

4. Verify setup - list projects and resumes:
```bash
curl -s "http://localhost:8000/projects" -H "Authorization: Bearer $TOKEN"
curl -s "http://localhost:8000/resume" -H "Authorization: Bearer $TOKEN"
```

5. Test delete with `refresh_resumes=true`:
```bash
# Get project ID from step 4, then delete it
curl -s -X DELETE "http://localhost:8000/projects/<PROJECT_ID>?refresh_resumes=true" \
  -H "Authorization: Bearer $TOKEN"
```

6. Verify the resume was updated (deleted project should be removed) using the CLI
---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile (N/A - API only)

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

</details>