### PR TITLE
Api/ contributed section selection

### DIFF
--- a/src/analysis/text_collaborative/text_collab_analysis.py
+++ b/src/analysis/text_collaborative/text_collab_analysis.py
@@ -12,6 +12,7 @@ try:
     from src import constants
 except ModuleNotFoundError:
     import constants
+from src.analysis.text_collaborative.text_sections import extract_document_sections
 
 def analyze_collaborative_text_project(
     conn,
@@ -102,7 +103,7 @@ def analyze_collaborative_text_project(
     # ---------------------------------------------------------
     # STEP 2 — Extract sections or paragraphs for user selection
     # ---------------------------------------------------------
-    sections = _extract_document_sections(full_main_text)
+    sections = extract_document_sections(full_main_text)
 
     print("\nSelect the sections/paragraphs YOU contributed to:")
     for i, sec in enumerate(sections, start=1):
@@ -404,61 +405,6 @@ def _load_main_text(parsed_files, main_file_name, zip_path, conn, user_id):
 
     path = os.path.join(base_path, match["file_path"])
     return extract_text_file(path, conn, user_id) or ""
-
-
-def _extract_document_sections(full_text: str):
-    """
-    Detect headers OR paragraph previews.
-    Return list of {header, preview, text}.
-    """
-
-    lines = full_text.split("\n")
-    sections = []
-    buffer = []
-    current_header = None
-
-    header_pattern = re.compile(r"^[A-Z][A-Za-z ]{2,}$")  # e.g. "Introduction", "Method"
-
-    for line in lines:
-        stripped = line.strip()
-
-        if header_pattern.match(stripped):  # header detected
-            # flush previous section
-            if buffer:
-                section_text = "\n".join(buffer).strip()
-                sections.append({
-                    "header": current_header,
-                    "preview": section_text[:60],
-                    "text": section_text
-                })
-                buffer = []
-
-            current_header = stripped
-        else:
-            buffer.append(stripped)
-
-    # flush last
-    if buffer:
-        section_text = "\n".join(buffer).strip()
-        sections.append({
-            "header": current_header,
-            "preview": section_text[:60],
-            "text": section_text
-        })
-
-    # If NO headers at all → use paragraph previews
-    if all(s["header"] is None for s in sections):
-        paragraphs = [p.strip() for p in full_text.split("\n") if p.strip()]
-        sections = []
-        for p in paragraphs:
-            preview = " ".join(p.split()[:5])
-            sections.append({
-                "header": None,
-                "preview": preview + "...",
-                "text": p
-            })
-
-    return sections
 
 
 def _manual_contribution_summary_prompt():

--- a/src/analysis/text_collaborative/text_sections.py
+++ b/src/analysis/text_collaborative/text_sections.py
@@ -1,0 +1,55 @@
+import re
+
+def extract_document_sections(full_text: str):
+    """
+    Detect headers OR paragraph previews.
+    Return list of {header, preview, text}.
+    """
+
+    lines = full_text.split("\n")
+    sections = []
+    buffer = []
+    current_header = None
+
+    header_pattern = re.compile(r"^[A-Z][A-Za-z ]{2,}$")  # e.g. "Introduction", "Method"
+
+    for line in lines:
+        stripped = line.strip()
+
+        if header_pattern.match(stripped):  # header detected
+            # flush previous section
+            if buffer:
+                section_text = "\n".join(buffer).strip()
+                sections.append({
+                    "header": current_header,
+                    "preview": section_text[:60],
+                    "text": section_text
+                })
+                buffer = []
+
+            current_header = stripped
+        else:
+            buffer.append(stripped)
+
+    # flush last
+    if buffer:
+        section_text = "\n".join(buffer).strip()
+        sections.append({
+            "header": current_header,
+            "preview": section_text[:60],
+            "text": section_text
+        })
+
+    # If NO headers at all → use paragraph previews
+    if all(s["header"] is None for s in sections):
+        paragraphs = [p.strip() for p in full_text.split("\n") if p.strip()]
+        sections = []
+        for p in paragraphs:
+            preview = " ".join(p.split()[:5])
+            sections.append({
+                "header": None,
+                "preview": preview + "...",
+                "text": p
+            })
+
+    return sections

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -124,6 +124,35 @@ def post_upload_project_main_file(
     upload = set_project_main_file(conn, user_id, upload_id, project_name, body.relpath)
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
 
+@router.get(
+    "/upload/{upload_id}/projects/{project_name}/text/sections",
+    response_model=ApiResponse[MainFileSectionsDTO]
+)
+def get_main_file_sections(
+    upload_id: int,
+    project_name: str,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    data = list_main_file_sections(conn, user_id, upload_id, project_name)
+    if not data:
+        raise HTTPException(status_code=404, detail="Main file sections not found")
+    return ApiResponse(success=True, data=MainFileSectionsDTO(**data), error=None)
+
+@router.post(
+    "/upload/{upload_id}/projects/{project_name}/text/contributions",
+    response_model=ApiResponse[MainFileContributionDTO]
+)
+def post_main_file_contributed_sections(
+    upload_id: int,
+    project_name: str,
+    body: ContributedSectionsRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    data = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, body.relpath)
+    return ApiResponse(success=True, data=MainFileContributionDTO(**data), error=None)
+
 
 @router.delete("", response_model=ApiResponse[DeleteResultDTO])
 def delete_all_user_projects(

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -11,6 +11,9 @@ from src.api.schemas.uploads import (
     DedupResolveRequestDTO,
     UploadProjectFilesDTO,
     MainFileRequestDTO,
+    MainFileSectionsDTO,
+    MainFileContributionDTO,
+    ContributedSectionsRequestDTO,
 )
 from src.services.projects_service import (
     list_projects,
@@ -26,6 +29,10 @@ from src.services.uploads_service import (
     submit_project_types,
     list_project_files,
     set_project_main_file,
+)
+from src.services.uploads_contribution_service import (
+    list_main_file_sections,
+    set_main_file_contributed_sections,
 )
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -141,7 +148,7 @@ def get_main_file_sections(
 
 @router.post(
     "/upload/{upload_id}/projects/{project_name}/text/contributions",
-    response_model=ApiResponse[MainFileContributionDTO]
+    response_model=ApiResponse[UploadDTO]
 )
 def post_main_file_contributed_sections(
     upload_id: int,
@@ -150,8 +157,8 @@ def post_main_file_contributed_sections(
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
-    data = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, body.relpath)
-    return ApiResponse(success=True, data=MainFileContributionDTO(**data), error=None)
+    data = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, body.contributed_sections)
+    return ApiResponse(success=True, data=UploadDTO(**data), error=None)
 
 
 @router.delete("", response_model=ApiResponse[DeleteResultDTO])

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -11,8 +11,7 @@ from src.api.schemas.uploads import (
     DedupResolveRequestDTO,
     UploadProjectFilesDTO,
     MainFileRequestDTO,
-    MainFileSectionsDTO,
-    MainFileContributionDTO,
+    MainFileSectionsResponseDTO,
     ContributedSectionsRequestDTO,
 )
 from src.services.projects_service import (
@@ -133,7 +132,7 @@ def post_upload_project_main_file(
 
 @router.get(
     "/upload/{upload_id}/projects/{project_name}/text/sections",
-    response_model=ApiResponse[MainFileSectionsDTO]
+    response_model=ApiResponse[MainFileSectionsResponseDTO],
 )
 def get_main_file_sections(
     upload_id: int,
@@ -144,11 +143,11 @@ def get_main_file_sections(
     data = list_main_file_sections(conn, user_id, upload_id, project_name)
     if not data:
         raise HTTPException(status_code=404, detail="Main file sections not found")
-    return ApiResponse(success=True, data=MainFileSectionsDTO(**data), error=None)
+    return ApiResponse(success=True, data=MainFileSectionsResponseDTO(**data), error=None)
 
 @router.post(
     "/upload/{upload_id}/projects/{project_name}/text/contributions",
-    response_model=ApiResponse[UploadDTO]
+    response_model=ApiResponse[UploadDTO],
 )
 def post_main_file_contributed_sections(
     upload_id: int,
@@ -157,7 +156,7 @@ def post_main_file_contributed_sections(
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
-    data = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, body.contributed_sections)
+    data = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, body.selected_section_ids)
     return ApiResponse(success=True, data=UploadDTO(**data), error=None)
 
 

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -47,10 +47,18 @@ class UploadProjectFilesDTO(BaseModel):
 class MainFileRequestDTO(BaseModel):
     relpath: str
     
-class MainFileSectionsDTO(BaseModel):
-    project_name: str
-    section_number: int
+
+class MainFileSectionDTO(BaseModel):
+    id: int
+    title: str
+    preview: str
     content: str
-    
+    is_truncated: bool = False
+
+class MainFileSectionsResponseDTO(BaseModel):
+    project_name: str
+    main_file: str
+    sections: List[MainFileSectionDTO]
+
 class ContributedSectionsRequestDTO(BaseModel):
-    contributed_sections: Dict[str, str]
+    selected_section_ids: List[int]

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -46,4 +46,11 @@ class UploadProjectFilesDTO(BaseModel):
 
 class MainFileRequestDTO(BaseModel):
     relpath: str
-
+    
+class MainFileSectionsDTO(BaseModel):
+    project_name: str
+    section_number: int
+    content: str
+    
+class ContributedSectionsRequestDTO(BaseModel):
+    contributed_sections: Dict[str, str]

--- a/src/services/uploads_contribution_service.py
+++ b/src/services/uploads_contribution_service.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import sqlite3
 from pathlib import Path
 from fastapi import HTTPException
+from typing import Optional
 
 from src.db.uploads import get_upload_by_id, patch_upload_state
 from src.utils.parsing import ZIP_DATA_DIR
 from src.services.uploads_file_roles_util import safe_relpath
 from src.utils.helpers import extract_text_file, normalize_pdf_paragraphs
-
 from src.analysis.text_collaborative.text_sections import extract_document_sections
 
 
@@ -23,18 +23,27 @@ def list_main_file_sections(
     *,
     max_section_chars: int = 2000,
 ) -> dict:
-    upload = _require_upload(conn, user_id, upload_id)
-    _require_status(upload, _ALLOWED_SECTION_STATUSES)
+    upload, state, main_file_relpath, abs_path = _get_main_file_context(
+        conn, user_id, upload_id, project_name
+    )
 
-    state = upload.get("state") or {}
-    main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
+    sections_raw, cache_patch = _get_cached_or_compute_sections(
+        conn=conn,
+        user_id=user_id,
+        state=state,
+        project_name=project_name,
+        abs_path=abs_path,
+        relpath=main_file_relpath,
+    )
 
-    zip_path = upload.get("zip_path") or state.get("zip_path")
-    if not zip_path:
-        raise HTTPException(status_code=400, detail="Upload missing zip_path")
-
-    abs_path = _resolve_main_file_abs_path(zip_path, main_file_relpath)
-    sections_raw = _derive_main_file_sections(conn, user_id, abs_path, main_file_relpath)
+    # Persist cache only if we had to compute.
+    if cache_patch:
+        patch_upload_state(
+            conn,
+            upload["upload_id"],
+            patch=cache_patch,
+            status=upload["status"],
+        )
 
     sections = []
     for i, s in enumerate(sections_raw, start=1):
@@ -50,9 +59,9 @@ def list_main_file_sections(
         sections.append(
             {
                 "id": i,
-                "title": title,        # matches what CLI prints (header else preview)
-                "preview": preview,    # same preview string used in CLI list
-                "content": content,    # paragraph/section content
+                "title": title,
+                "preview": preview,
+                "content": content,
                 "is_truncated": is_truncated,
             }
         )
@@ -67,18 +76,18 @@ def set_main_file_contributed_sections(
     project_name: str,
     selected_section_ids: list[int],
 ) -> dict:
-    upload = _require_upload(conn, user_id, upload_id)
-    _require_status(upload, _ALLOWED_SECTION_STATUSES)
+    upload, state, main_file_relpath, abs_path = _get_main_file_context(
+        conn, user_id, upload_id, project_name
+    )
 
-    state = upload.get("state") or {}
-    main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
-
-    zip_path = upload.get("zip_path") or state.get("zip_path")
-    if not zip_path:
-        raise HTTPException(status_code=400, detail="Upload missing zip_path")
-
-    abs_path = _resolve_main_file_abs_path(zip_path, main_file_relpath)
-    sections_raw = _derive_main_file_sections(conn, user_id, abs_path, main_file_relpath)
+    sections_raw, cache_patch = _get_cached_or_compute_sections(
+        conn=conn,
+        user_id=user_id,
+        state=state,
+        project_name=project_name,
+        abs_path=abs_path,
+        relpath=main_file_relpath,
+    )
     n_sections = len(sections_raw)
 
     selected_section_ids = selected_section_ids or []
@@ -101,9 +110,87 @@ def set_main_file_contributed_sections(
     proj["main_section_ids"] = deduped_sorted
     contributions[project_name] = proj
 
-    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+    patch: dict = {"contributions": contributions}
+    if cache_patch:
+        # one DB write: store derived_sections + contributions together
+        patch.update(cache_patch)
 
-    return {"upload_id": upload["upload_id"], "status": upload["status"], "zip_name": upload.get("zip_name"), "state": new_state}
+    new_state = patch_upload_state(
+        conn,
+        upload["upload_id"],
+        patch=patch,
+        status=upload["status"],
+    )
+
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+# -----------------------
+# Shared main-file context
+# -----------------------
+def _get_main_file_context(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+) -> tuple[dict, dict, str, Path]:
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload, _ALLOWED_SECTION_STATUSES)
+
+    state = upload.get("state") or {}
+    main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
+
+    zip_path = upload.get("zip_path") or state.get("zip_path")
+    if not zip_path:
+        raise HTTPException(status_code=400, detail="Upload missing zip_path")
+
+    abs_path = _resolve_main_file_abs_path(zip_path, main_file_relpath)
+    return upload, state, main_file_relpath, abs_path
+
+
+# -----------------------
+# Cached sections helper
+# -----------------------
+def _get_cached_or_compute_sections(
+    *,
+    conn: sqlite3.Connection,
+    user_id: int,
+    state: dict,
+    project_name: str,
+    abs_path: Path,
+    relpath: str,
+) -> tuple[list[dict], Optional[dict]]:
+    """
+    Returns (sections, patch) where patch is a state patch to persist the cache
+    (or None if we reused a valid cache).
+    Cache key: state["derived_sections"][project_name] = {"main_file": relpath, "sections": [...]}
+    """
+    derived_sections = state.get("derived_sections")
+    if not isinstance(derived_sections, dict):
+        derived_sections = {}
+
+    cache = derived_sections.get(project_name)
+    if isinstance(cache, dict):
+        cached_main_file = cache.get("main_file")
+        cached_sections = cache.get("sections")
+        if cached_main_file == relpath and isinstance(cached_sections, list) and cached_sections:
+            return cached_sections, None
+
+    sections = _derive_main_file_sections(conn, user_id, abs_path, relpath)
+
+    # build a patch that preserves other projects' cached sections
+    derived_sections_new = dict(derived_sections)
+    derived_sections_new[project_name] = {
+        "main_file": relpath,
+        "sections": sections,
+    }
+
+    return sections, {"derived_sections": derived_sections_new}
 
 
 # -----------------------
@@ -125,7 +212,7 @@ def _derive_main_file_sections(
             detail={"message": "Main file could not be extracted or is empty", "relpath": relpath},
         )
 
-    # ✅ EXACTLY what CLI does before extract_document_sections()
+    # EXACTLY what CLI does before extract_document_sections()
     normalized_paragraphs = normalize_pdf_paragraphs(raw) or []
     normalized_text = "\n\n".join(normalized_paragraphs).strip()
 

--- a/src/services/uploads_contribution_service.py
+++ b/src/services/uploads_contribution_service.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import re
+import sqlite3
+from pathlib import Path
+from fastapi import HTTPException
+
+from src.db.uploads import get_upload_by_id, patch_upload_state
+from src.utils.parsing import ZIP_DATA_DIR
+from src.services.uploads_file_roles_util import safe_relpath
+from src.utils.helpers import extract_text_file
+
+
+_ALLOWED_SECTION_STATUSES = {"needs_file_roles", "needs_summaries", "analyzing", "done"}
+
+
+def list_main_file_sections(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    *,
+    max_section_chars: int = 2000,
+) -> dict:
+    """
+    Returns numbered sections from the selected main file.
+    Stores nothing; purely derived from current upload + main file selection.
+    """
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload, _ALLOWED_SECTION_STATUSES)
+
+    state = upload.get("state") or {}
+    main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
+
+    abs_path = _resolve_main_file_abs_path(main_file_relpath)
+    if not abs_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail={"message": "Main file not found on disk", "relpath": main_file_relpath},
+        )
+
+    full_text = extract_text_file(str(abs_path), conn, user_id) or ""
+    if not full_text.strip():
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Main file could not be extracted or is empty", "relpath": main_file_relpath},
+        )
+
+    sections_raw = _extract_sections(full_text)
+
+    sections = []
+    for i, s in enumerate(sections_raw, start=1):
+        title = (s.get("header") or "").strip()
+        preview = (s.get("preview") or "").strip()
+        content = (s.get("text") or "").strip()
+
+        if not title:
+            title = preview or f"Section {i}"
+
+        is_truncated = False
+        if max_section_chars is not None and max_section_chars > 0 and len(content) > max_section_chars:
+            content = content[:max_section_chars].rstrip() + "…"
+            is_truncated = True
+
+        sections.append(
+            {
+                "id": i,
+                "title": title,
+                "preview": preview,
+                "content": content,
+                "is_truncated": is_truncated,
+            }
+        )
+
+    return {
+        "project_name": project_name,
+        "main_file": main_file_relpath,
+        "sections": sections,
+    }
+
+
+def set_main_file_contributed_sections(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    selected_section_ids: list[int],
+) -> dict:
+    """
+    Validates selection IDs against server-derived sections and persists only the IDs into uploads.state_json.
+    """
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload, _ALLOWED_SECTION_STATUSES)
+
+    state = upload.get("state") or {}
+    main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
+
+    abs_path = _resolve_main_file_abs_path(main_file_relpath)
+    if not abs_path.exists():
+        raise HTTPException(
+            status_code=404,
+            detail={"message": "Main file not found on disk", "relpath": main_file_relpath},
+        )
+
+    full_text = extract_text_file(str(abs_path), conn, user_id) or ""
+    if not full_text.strip():
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Main file could not be extracted or is empty", "relpath": main_file_relpath},
+        )
+
+    sections_raw = _extract_sections(full_text)
+    n_sections = len(sections_raw)
+
+    # Allow empty selection (means 0 contribution)
+    selected_section_ids = selected_section_ids or []
+
+    # Validate ids
+    invalid = sorted({i for i in selected_section_ids if not isinstance(i, int) or i < 1 or i > n_sections})
+    if invalid:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "selected_section_ids contains invalid ids",
+                "invalid_ids": invalid,
+                "valid_range": [1, n_sections],
+            },
+        )
+
+    deduped_sorted = sorted(set(selected_section_ids))
+
+    # Persist into state_json under a contributions namespace
+    contributions = dict(state.get("contributions") or {})
+    proj = dict(contributions.get(project_name) or {})
+    proj["main_file"] = main_file_relpath
+    proj["main_section_ids"] = deduped_sorted
+    contributions[project_name] = proj
+
+    # Patch (safe even if patch is shallow)
+    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+# Helpers
+def _require_upload(conn: sqlite3.Connection, user_id: int, upload_id: int) -> dict:
+    upload = get_upload_by_id(conn, upload_id)
+    if not upload or upload["user_id"] != user_id:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    return upload
+
+
+def _require_status(upload: dict, allowed: set[str]) -> None:
+    status = upload.get("status")
+    if status not in allowed:
+        raise HTTPException(status_code=409, detail=f"Upload not ready for this action (status={status})")
+
+
+def _get_main_file_relpath_or_409(state: dict, project_name: str) -> str:
+    file_roles = state.get("file_roles") or {}
+    proj_roles = file_roles.get(project_name) or {}
+    relpath = proj_roles.get("main_file")
+
+    if not relpath:
+        raise HTTPException(
+            status_code=409,
+            detail={"message": "Main file not selected for this project", "project_name": project_name},
+        )
+
+    try:
+        return safe_relpath(relpath)
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e))
+
+
+def _resolve_main_file_abs_path(relpath: str) -> Path:
+    # relpath is ZIP_DATA_DIR-relative (posix style)
+    base = Path(ZIP_DATA_DIR).resolve()
+    p = (base / Path(relpath)).resolve()
+    # hard safety: ensure under ZIP_DATA_DIR
+    if base not in p.parents and p != base:
+        raise HTTPException(status_code=422, detail="Invalid relpath (escapes ZIP_DATA_DIR)")
+    return p
+
+
+def _extract_sections(full_text: str) -> list[dict]:
+    """
+    Split into sections by simple header detection, else fallback to paragraph chunks.
+    Returns list of {header, preview, text}.
+    """
+
+    lines = full_text.split("\n")
+    sections: list[dict] = []
+
+    # fairly permissive header line, but avoids tiny 1-2 char lines
+    header_re = re.compile(r"^[A-Z][A-Za-z0-9 ,:\-]{2,}$")
+
+    buf: list[str] = []
+    current_header: str | None = None
+
+    def flush():
+        nonlocal buf, current_header
+        text = "\n".join([x for x in buf if x.strip()]).strip()
+        buf = []
+        if not text:
+            return
+        preview = text[:60].replace("\n", " ").strip()
+        sections.append({"header": current_header, "preview": preview, "text": text})
+
+    for raw in lines:
+        s = raw.strip()
+        if not s:
+            # keep blank lines as soft separators
+            buf.append("")
+            continue
+
+        if header_re.match(s) and len(s.split()) <= 10:
+            # new header
+            if buf:
+                flush()
+            current_header = s
+            continue
+
+        buf.append(s)
+
+    if buf:
+        flush()
+
+    # If we didn't really detect headers, fallback to paragraph-ish chunks
+    if not sections or all(sec.get("header") is None for sec in sections):
+        chunks = [c.strip() for c in re.split(r"\n\s*\n+", full_text.strip()) if c.strip()]
+        sections = []
+        for c in chunks:
+            preview_words = " ".join(c.split()[:8]).strip()
+            sections.append(
+                {
+                    "header": None,
+                    "preview": (preview_words + "…") if preview_words else c[:60],
+                    "text": c,
+                }
+            )
+
+    return sections

--- a/src/services/uploads_contribution_service.py
+++ b/src/services/uploads_contribution_service.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 import sqlite3
 from pathlib import Path
 from fastapi import HTTPException
@@ -8,7 +7,9 @@ from fastapi import HTTPException
 from src.db.uploads import get_upload_by_id, patch_upload_state
 from src.utils.parsing import ZIP_DATA_DIR
 from src.services.uploads_file_roles_util import safe_relpath
-from src.utils.helpers import extract_text_file
+from src.utils.helpers import extract_text_file, normalize_pdf_paragraphs
+
+from src.analysis.text_collaborative.text_sections import extract_document_sections
 
 
 _ALLOWED_SECTION_STATUSES = {"needs_file_roles", "needs_summaries", "analyzing", "done"}
@@ -22,65 +23,41 @@ def list_main_file_sections(
     *,
     max_section_chars: int = 2000,
 ) -> dict:
-    """
-    Returns numbered sections from the selected main file.
-    Stores nothing; purely derived from current upload + main file selection.
-    """
     upload = _require_upload(conn, user_id, upload_id)
     _require_status(upload, _ALLOWED_SECTION_STATUSES)
 
     state = upload.get("state") or {}
     main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
 
-    zip_path = upload.get("zip_path") or (upload.get("state") or {}).get("zip_path")
+    zip_path = upload.get("zip_path") or state.get("zip_path")
     if not zip_path:
         raise HTTPException(status_code=400, detail="Upload missing zip_path")
-    
+
     abs_path = _resolve_main_file_abs_path(zip_path, main_file_relpath)
-    if not abs_path.exists():
-        raise HTTPException(
-            status_code=404,
-            detail={"message": "Main file not found on disk", "relpath": main_file_relpath},
-        )
-
-    full_text = extract_text_file(str(abs_path), conn, user_id) or ""
-    if not full_text.strip():
-        raise HTTPException(
-            status_code=422,
-            detail={"message": "Main file could not be extracted or is empty", "relpath": main_file_relpath},
-        )
-
-    sections_raw = _extract_sections(full_text)
+    sections_raw = _derive_main_file_sections(conn, user_id, abs_path, main_file_relpath)
 
     sections = []
     for i, s in enumerate(sections_raw, start=1):
-        title = (s.get("header") or "").strip()
+        title = (s.get("header") or "").strip() or (s.get("preview") or "").strip() or f"Section {i}"
         preview = (s.get("preview") or "").strip()
         content = (s.get("text") or "").strip()
 
-        if not title:
-            title = preview or f"Section {i}"
-
         is_truncated = False
-        if max_section_chars is not None and max_section_chars > 0 and len(content) > max_section_chars:
+        if max_section_chars and len(content) > max_section_chars:
             content = content[:max_section_chars].rstrip() + "…"
             is_truncated = True
 
         sections.append(
             {
                 "id": i,
-                "title": title,
-                "preview": preview,
-                "content": content,
+                "title": title,        # matches what CLI prints (header else preview)
+                "preview": preview,    # same preview string used in CLI list
+                "content": content,    # paragraph/section content
                 "is_truncated": is_truncated,
             }
         )
 
-    return {
-        "project_name": project_name,
-        "main_file": main_file_relpath,
-        "sections": sections,
-    }
+    return {"project_name": project_name, "main_file": main_file_relpath, "sections": sections}
 
 
 def set_main_file_contributed_sections(
@@ -90,40 +67,21 @@ def set_main_file_contributed_sections(
     project_name: str,
     selected_section_ids: list[int],
 ) -> dict:
-    """
-    Validates selection IDs against server-derived sections and persists only the IDs into uploads.state_json.
-    """
     upload = _require_upload(conn, user_id, upload_id)
     _require_status(upload, _ALLOWED_SECTION_STATUSES)
 
     state = upload.get("state") or {}
     main_file_relpath = _get_main_file_relpath_or_409(state, project_name)
 
-    zip_path = upload.get("zip_path") or (upload.get("state") or {}).get("zip_path")
+    zip_path = upload.get("zip_path") or state.get("zip_path")
     if not zip_path:
         raise HTTPException(status_code=400, detail="Upload missing zip_path")
 
     abs_path = _resolve_main_file_abs_path(zip_path, main_file_relpath)
-    if not abs_path.exists():
-        raise HTTPException(
-            status_code=404,
-            detail={"message": "Main file not found on disk", "relpath": main_file_relpath},
-        )
-
-    full_text = extract_text_file(str(abs_path), conn, user_id) or ""
-    if not full_text.strip():
-        raise HTTPException(
-            status_code=422,
-            detail={"message": "Main file could not be extracted or is empty", "relpath": main_file_relpath},
-        )
-
-    sections_raw = _extract_sections(full_text)
+    sections_raw = _derive_main_file_sections(conn, user_id, abs_path, main_file_relpath)
     n_sections = len(sections_raw)
 
-    # Allow empty selection (means 0 contribution)
     selected_section_ids = selected_section_ids or []
-
-    # Validate ids
     invalid = sorted({i for i in selected_section_ids if not isinstance(i, int) or i < 1 or i > n_sections})
     if invalid:
         raise HTTPException(
@@ -137,25 +95,46 @@ def set_main_file_contributed_sections(
 
     deduped_sorted = sorted(set(selected_section_ids))
 
-    # Persist into state_json under a contributions namespace
     contributions = dict(state.get("contributions") or {})
     proj = dict(contributions.get(project_name) or {})
     proj["main_file"] = main_file_relpath
     proj["main_section_ids"] = deduped_sorted
     contributions[project_name] = proj
 
-    # Patch (safe even if patch is shallow)
     new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
 
-    return {
-        "upload_id": upload["upload_id"],
-        "status": upload["status"],
-        "zip_name": upload.get("zip_name"),
-        "state": new_state,
-    }
+    return {"upload_id": upload["upload_id"], "status": upload["status"], "zip_name": upload.get("zip_name"), "state": new_state}
 
 
-# Helpers
+# -----------------------
+# Core shared derivation
+# -----------------------
+def _derive_main_file_sections(
+    conn: sqlite3.Connection,
+    user_id: int,
+    abs_path: Path,
+    relpath: str,
+) -> list[dict]:
+    if not abs_path.exists():
+        raise HTTPException(status_code=404, detail={"message": "Main file not found on disk", "relpath": relpath})
+
+    raw = extract_text_file(str(abs_path), conn, user_id) or ""
+    if not raw.strip():
+        raise HTTPException(
+            status_code=422,
+            detail={"message": "Main file could not be extracted or is empty", "relpath": relpath},
+        )
+
+    # ✅ EXACTLY what CLI does before extract_document_sections()
+    normalized_paragraphs = normalize_pdf_paragraphs(raw) or []
+    normalized_text = "\n\n".join(normalized_paragraphs).strip()
+
+    return extract_document_sections(normalized_text) or []
+
+
+# -----------------------
+# Existing helpers
+# -----------------------
 def _require_upload(conn: sqlite3.Connection, user_id: int, upload_id: int) -> dict:
     upload = get_upload_by_id(conn, upload_id)
     if not upload or upload["user_id"] != user_id:
@@ -187,86 +166,16 @@ def _get_main_file_relpath_or_409(state: dict, project_name: str) -> str:
 
 
 def _resolve_main_file_abs_path(zip_path: str, relpath: str) -> Path:
-    """
-    relpath is upload-extract-dir-relative (POSIX), not ZIP_DATA_DIR-relative.
-
-    Real file lives at:
-      ZIP_DATA_DIR / <zip_stem> / relpath
-
-    where zip_stem == Path(zip_path).stem (e.g. "1_text_projects_og")
-    """
     base = Path(ZIP_DATA_DIR).resolve()
     extract_dir = (base / Path(zip_path).stem).resolve()
 
     rel = Path(relpath)
 
-    # If someone already stored "1_text_projects_og/..." as relpath, avoid double-prefixing
     if rel.parts and rel.parts[0] == Path(zip_path).stem:
         p = (base / rel).resolve()
     else:
         p = (extract_dir / rel).resolve()
 
-    # hard safety: ensure under ZIP_DATA_DIR
     if base not in p.parents and p != base:
         raise HTTPException(status_code=422, detail="Invalid relpath (escapes ZIP_DATA_DIR)")
     return p
-
-
-def _extract_sections(full_text: str) -> list[dict]:
-    """
-    Split into sections by simple header detection, else fallback to paragraph chunks.
-    Returns list of {header, preview, text}.
-    """
-
-    lines = full_text.split("\n")
-    sections: list[dict] = []
-
-    # fairly permissive header line, but avoids tiny 1-2 char lines
-    header_re = re.compile(r"^[A-Z][A-Za-z0-9 ,:\-]{2,}$")
-
-    buf: list[str] = []
-    current_header: str | None = None
-
-    def flush():
-        nonlocal buf, current_header
-        text = "\n".join([x for x in buf if x.strip()]).strip()
-        buf = []
-        if not text:
-            return
-        preview = text[:60].replace("\n", " ").strip()
-        sections.append({"header": current_header, "preview": preview, "text": text})
-
-    for raw in lines:
-        s = raw.strip()
-        if not s:
-            # keep blank lines as soft separators
-            buf.append("")
-            continue
-
-        if header_re.match(s) and len(s.split()) <= 10:
-            # new header
-            if buf:
-                flush()
-            current_header = s
-            continue
-
-        buf.append(s)
-
-    if buf:
-        flush()
-
-    # If we didn't really detect headers, fallback to paragraph-ish chunks
-    if not sections or all(sec.get("header") is None for sec in sections):
-        chunks = [c.strip() for c in re.split(r"\n\s*\n+", full_text.strip()) if c.strip()]
-        sections = []
-        for c in chunks:
-            preview_words = " ".join(c.split()[:8]).strip()
-            sections.append(
-                {
-                    "header": None,
-                    "preview": (preview_words + "…") if preview_words else c[:60],
-                    "text": c,
-                }
-            )
-
-    return sections

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -78,6 +78,47 @@ def start_upload(conn: sqlite3.Connection, user_id: int, file: UploadFile) -> di
         }
 
     layout = analyze_project_layout(files_info)
+    
+    extract_dir = extract_dir_from_upload_zip(ZIP_DATA_DIR, str(zip_path))
+
+    dedup = run_deduplication_for_projects_api(conn, user_id, str(extract_dir), layout, upload_id=upload_id)
+
+    skipped_set = set(dedup.get("skipped") or set())
+    asks: dict = dedup.get("asks") or {}
+    new_versions: dict = dedup.get("new_versions") or {}
+
+    # 1) Apply auto-skip BEFORE writing parsed files to DB
+    if skipped_set:
+        files_info = [f for f in files_info if f.get("project_name") not in skipped_set]
+        layout = analyze_project_layout(files_info)
+
+    # 2) Apply auto-rename for 'new_version' suggestions
+    for old_name, existing_name in new_versions.items():
+        if existing_name and old_name != existing_name:
+            apply_project_rename_to_files_info(files_info, old_name, existing_name)
+            layout = rename_project_in_layout(layout, old_name, existing_name)
+
+    # If everything got removed, fail early
+    if not files_info:
+        state = {
+            "zip_name": zip_name,
+            "zip_path": str(zip_path),
+            "layout": layout,
+            "files_info_count": 0,
+            "dedup_skipped_projects": sorted(list(skipped_set)),
+            "dedup_asks": asks,
+            "dedup_new_versions": new_versions,
+            "project_filetype_index": {},
+            "message": "All projects were skipped by deduplication (duplicates).",
+        }
+        set_upload_state(conn, upload_id, state=state, status="failed")
+        return {"upload_id": upload_id, "status": "failed", "zip_name": zip_name, "state": state}
+
+    # Store parsed files (kept + post-rename only)
+    store_parsed_files(conn, files_info, user_id)
+
+    # IMPORTANT: build upload-scoped filetype index from CURRENT upload files_info
+    project_filetype_index = build_project_filetype_index(files_info)
 
     state = {
         "zip_name": zip_name,

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -62,22 +62,51 @@ def start_upload(conn: sqlite3.Connection, user_id: int, file: UploadFile) -> di
 
     update_upload_zip_metadata(conn, upload_id, zip_name=zip_name, zip_path=str(zip_path))
 
-    files_info = parse_zip_file(str(zip_path), user_id=user_id, conn=conn)
+    # IMPORTANT: don't persist yet, dedup needs to run first
+    files_info = parse_zip_file(str(zip_path), user_id=user_id, conn=conn, persist_to_db=False)
     if not files_info:
-        set_upload_state(
-            conn,
-            upload_id,
-            state={"error": "No valid files were processed from ZIP."},
-            status="failed",
-        )
-        return {
-            "upload_id": upload_id,
-            "status": "failed",
-            "zip_name": zip_name,
-            "state": {"error": "No valid files were processed from ZIP."},
-        }
+        set_upload_state(conn, upload_id, state={"error": "No valid files were processed from ZIP."}, status="failed")
+        return {"upload_id": upload_id, "status": "failed", "zip_name": zip_name, "state": {"error": "No valid files were processed from ZIP."}}
 
     layout = analyze_project_layout(files_info)
+
+    # --- DEDUP INTEGRATION (this is what your current file is missing) ---
+    extract_dir = extract_dir_from_upload_zip(ZIP_DATA_DIR, str(zip_path))
+    dedup = run_deduplication_for_projects_api(conn, user_id, str(extract_dir), layout, upload_id=upload_id)
+
+    skipped_set = set(dedup.get("skipped") or [])
+    asks = dedup.get("asks") or {}
+    new_versions = dedup.get("new_versions") or {}
+
+    # 1) Apply auto-skip BEFORE writing parsed files to DB
+    if skipped_set:
+        files_info = [f for f in files_info if f.get("project_name") not in skipped_set]
+        layout = analyze_project_layout(files_info)
+
+    # 2) Apply auto-rename for 'new_version' suggestions
+    for old_name, existing_name in new_versions.items():
+        if existing_name and old_name != existing_name:
+            apply_project_rename_to_files_info(files_info, old_name, existing_name)
+            layout = rename_project_in_layout(layout, old_name, existing_name)
+
+    # If everything got removed, fail early
+    if not files_info:
+        state = {
+            "zip_name": zip_name,
+            "zip_path": str(zip_path),
+            "layout": layout,
+            "files_info_count": 0,
+            "dedup_skipped_projects": sorted(list(skipped_set)),
+            "dedup_asks": asks,
+            "dedup_new_versions": new_versions,
+            "project_filetype_index": {},
+            "message": "All projects were skipped by deduplication (duplicates).",
+        }
+        set_upload_state(conn, upload_id, state=state, status="failed")
+        return {"upload_id": upload_id, "status": "failed", "zip_name": zip_name, "state": state}
+
+    # Store parsed files ONCE (post-skip/post-rename)
+    store_parsed_files(conn, files_info, user_id)
 
     project_filetype_index = build_project_filetype_index(files_info)
 
@@ -92,7 +121,6 @@ def start_upload(conn: sqlite3.Connection, user_id: int, file: UploadFile) -> di
         "project_filetype_index": project_filetype_index,
     }
 
-    # If unresolved asks exist, stop before classification (matches CLI ordering)
     if asks:
         set_upload_state(conn, upload_id, state=state, status="needs_dedup")
         return {"upload_id": upload_id, "status": "needs_dedup", "zip_name": zip_name, "state": state}

--- a/src/services/uploads_service.py
+++ b/src/services/uploads_service.py
@@ -78,46 +78,7 @@ def start_upload(conn: sqlite3.Connection, user_id: int, file: UploadFile) -> di
         }
 
     layout = analyze_project_layout(files_info)
-    
-    extract_dir = extract_dir_from_upload_zip(ZIP_DATA_DIR, str(zip_path))
 
-    dedup = run_deduplication_for_projects_api(conn, user_id, str(extract_dir), layout, upload_id=upload_id)
-
-    skipped_set = set(dedup.get("skipped") or set())
-    asks: dict = dedup.get("asks") or {}
-    new_versions: dict = dedup.get("new_versions") or {}
-
-    # 1) Apply auto-skip BEFORE writing parsed files to DB
-    if skipped_set:
-        files_info = [f for f in files_info if f.get("project_name") not in skipped_set]
-        layout = analyze_project_layout(files_info)
-
-    # 2) Apply auto-rename for 'new_version' suggestions
-    for old_name, existing_name in new_versions.items():
-        if existing_name and old_name != existing_name:
-            apply_project_rename_to_files_info(files_info, old_name, existing_name)
-            layout = rename_project_in_layout(layout, old_name, existing_name)
-
-    # If everything got removed, fail early
-    if not files_info:
-        state = {
-            "zip_name": zip_name,
-            "zip_path": str(zip_path),
-            "layout": layout,
-            "files_info_count": 0,
-            "dedup_skipped_projects": sorted(list(skipped_set)),
-            "dedup_asks": asks,
-            "dedup_new_versions": new_versions,
-            "project_filetype_index": {},
-            "message": "All projects were skipped by deduplication (duplicates).",
-        }
-        set_upload_state(conn, upload_id, state=state, status="failed")
-        return {"upload_id": upload_id, "status": "failed", "zip_name": zip_name, "state": state}
-
-    # Store parsed files (kept + post-rename only)
-    store_parsed_files(conn, files_info, user_id)
-
-    # IMPORTANT: build upload-scoped filetype index from CURRENT upload files_info
     project_filetype_index = build_project_filetype_index(files_info)
 
     state = {

--- a/tests/api/test_uploads_contribution_sections.py
+++ b/tests/api/test_uploads_contribution_sections.py
@@ -1,0 +1,157 @@
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from src.db.uploads import (
+    create_upload,
+    update_upload_zip_metadata,
+    set_upload_state,
+    get_upload_by_id,
+)
+from src.services.uploads_contribution_service import (
+    list_main_file_sections,
+    set_main_file_contributed_sections,
+)
+from src.utils.helpers import normalize_pdf_paragraphs
+from src.analysis.text_collaborative.text_sections import extract_document_sections
+
+
+def fake_extract_text_file(path: str, conn, user_id) -> str:
+    # Unit-test stub: treat the "main file" as plain text on disk.
+    return Path(path).read_text(encoding="utf-8")
+
+
+def derive_expected_sections_and_titles(raw_text: str):
+    normalized_paragraphs = normalize_pdf_paragraphs(raw_text) or []
+    normalized_text = "\n\n".join(normalized_paragraphs).strip()
+
+    sections_raw = extract_document_sections(normalized_text) or []
+
+    titles = []
+    for i, s in enumerate(sections_raw, start=1):
+        header = (s.get("header") or "").strip()
+        preview = (s.get("preview") or "").strip()
+        titles.append(header or preview or f"Section {i}")
+
+    return sections_raw, titles
+
+
+@pytest.fixture()
+def conn(tmp_path: Path):
+    db = sqlite3.connect(":memory:")
+    db.row_factory = sqlite3.Row
+
+    schema_path = Path("src/db/schema/tables.sql")
+    db.executescript(schema_path.read_text(encoding="utf-8"))
+
+    db.execute("INSERT INTO users (username) VALUES (?)", ("testuser",))
+    db.commit()
+    return db
+
+
+@pytest.fixture()
+def user_id(conn: sqlite3.Connection) -> int:
+    return conn.execute(
+        "SELECT user_id FROM users WHERE username=?",
+        ("testuser",),
+    ).fetchone()[0]
+
+
+@pytest.fixture()
+def upload_setup(tmp_path: Path, conn: sqlite3.Connection, user_id: int, monkeypatch):
+    # Patch module globals used by uploads_contribution_service
+    import src.services.uploads_contribution_service as ucs
+
+    zip_data_dir = tmp_path / "zip_data"
+    zip_data_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(ucs, "ZIP_DATA_DIR", str(zip_data_dir))
+    monkeypatch.setattr(ucs, "extract_text_file", fake_extract_text_file)
+
+    uploads_dir = zip_data_dir / "_uploads"
+    uploads_dir.mkdir(parents=True, exist_ok=True)
+
+    zip_path = uploads_dir / "1_mock_upload.zip"
+    zip_path.write_bytes(b"")  # dummy zip; only stem is used
+
+    upload_id = create_upload(conn, user_id, status="started", state={})
+    update_upload_zip_metadata(conn, upload_id, zip_name=zip_path.name, zip_path=str(zip_path))
+
+    project_name = "MockProject"
+    relpath = "mock_projects/MockProject/main_report.txt"
+
+    extract_dir = zip_data_dir / zip_path.stem
+    main_file_path = extract_dir / relpath
+    main_file_path.parent.mkdir(parents=True, exist_ok=True)
+
+    raw_text = (
+        "Title: UX Redesign Notes for Mobile App\n"
+        "Abstract: This report summarizes findings from a short usability review.\n"
+        "\n"
+        "Introduction: We reviewed navigation, content density, and accessibility.\n"
+        "The goal was to identify quick wins and longer-term design risks.\n"
+        "\n"
+        "Methods: We ran a heuristic evaluation and mapped key user flows.\n"
+        "We also reviewed analytics for drop-off points.\n"
+        "\n"
+        "Results and Discussion: Navigation labels were inconsistent across screens.\n"
+        "Several critical actions were buried under secondary menus.\n"
+        "\n"
+        "Conclusion: Prioritize clearer IA and reduce friction for primary tasks.\n"
+        "Keywords: ux, navigation, mobile\n"
+    )
+    main_file_path.write_text(raw_text, encoding="utf-8")
+
+    state = {
+        "zip_path": str(zip_path),
+        "file_roles": {project_name: {"main_file": relpath}},
+    }
+    set_upload_state(conn, upload_id, state=state, status="needs_file_roles")
+
+    return {
+        "upload_id": upload_id,
+        "project_name": project_name,
+        "relpath": relpath,
+        "raw_text": raw_text,
+    }
+
+
+def test_list_main_file_sections_derives_sections(conn, user_id, upload_setup):
+    upload_id = upload_setup["upload_id"]
+    project_name = upload_setup["project_name"]
+    raw_text = upload_setup["raw_text"]
+
+    expected_sections_raw, expected_titles = derive_expected_sections_and_titles(raw_text)
+
+    result = list_main_file_sections(conn, user_id, upload_id, project_name, max_section_chars=10_000)
+
+    assert result["project_name"] == project_name
+    assert result["main_file"]
+    assert isinstance(result["sections"], list)
+
+    assert len(result["sections"]) == len(expected_sections_raw)
+    assert [s["id"] for s in result["sections"]] == list(range(1, len(result["sections"]) + 1))
+    assert [s["title"] for s in result["sections"]] == expected_titles
+
+
+def test_set_main_file_contributed_sections_persists_ids(conn, user_id, upload_setup):
+    upload_id = upload_setup["upload_id"]
+    project_name = upload_setup["project_name"]
+    raw_text = upload_setup["raw_text"]
+
+    expected_sections_raw, _ = derive_expected_sections_and_titles(raw_text)
+    n = len(expected_sections_raw)
+    assert n > 0
+
+    selected = [1, n, 1, n]  # includes duplicates / unsorted
+
+    resp = set_main_file_contributed_sections(conn, user_id, upload_id, project_name, selected)
+
+    contrib = (resp["state"].get("contributions") or {}).get(project_name) or {}
+    assert contrib.get("main_section_ids") == sorted(set(selected))
+
+    row = get_upload_by_id(conn, upload_id)
+    persisted_state = row.get("state") or {}
+    persisted = (persisted_state.get("contributions") or {}).get(project_name) or {}
+    assert persisted.get("main_section_ids") == sorted(set(selected))


### PR DESCRIPTION
## 📝 Description
This PR adds support for selecting which sections of a collaborative text project’s main file the user contributed to.

* Added 2 new endpoints for main-file section selection:
  * `GET /projects/upload/{upload_id}/projects/{project_name}/text/sections`
    Derives and returns numbered sections from the selected main file.
  * `POST /projects/upload/{upload_id}/projects/{project_name}/text/sections`
    Validates selected section IDs against the server-derived section list and persists the selection into `uploads.state.contributions[project_name].main_section_ids`.
* Separated text section function from `text_collab_analysis.py` into a helper function so it's reusable for the api
* Fixed bugs: missing dedup and auto project type implementation (was used in an earlier PR, but not called in main branch anymore for some reason) 
* Added a test script that:
  * Creates a temporary upload + extracted main file on disk
  * Calls `list_main_file_sections()` and asserts the returned section count/IDs match what `extract_document_sections()` produces (this is what is called to print out the extracted sections in the terminal, so I made sure it matches)
  * Calls `set_main_file_contributed_sections()` and asserts selected IDs are validated, deduped/sorted, and persisted back into the upload state in the DB

**Closes:** #387

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
- [x] run `pytest tests/api/test_uploads_contribution_sections.py` and `pytest`
- [x] manually test endpoints on postman:
1. Download the zipped file below
[text_projects_collab.zip](https://github.com/user-attachments/files/25058890/text_projects_collab.zip)
2. run `uvicorn src.api.main:app --reload --env-file .env` on terminal (make sure you have JWT_SECRET in the `.env` file
3. Register and Login with these endpoints and body (raw) on Postman:
`http://localhost:8000/auth/register`
`http://localhost:8000/auth/login` (copy the access token from the response body)
```json
{
  "username": "testuser",
  "password": "Testpass123"
}
```
4. Upload zipped file at `POST http://localhost:8000/projects/upload` with additional header (Authorization: Bearer \<access token\>) and body form-data as below
<img width="674" height="156" alt="Screenshot 2026-02-03 at 3 42 55 PM" src="https://github.com/user-attachments/assets/0f1d9b9a-d9a9-4d91-b70a-2a3f30ee12a4" />
<img width="685" height="184" alt="Screenshot 2026-02-03 at 3 43 13 PM" src="https://github.com/user-attachments/assets/5bb60a3c-8612-454a-b1e9-b8d29960e74b" />

Response body should look like this (has `status` "needs_file_roles", `classifications` "collaborative", and `project_types_auto`: [project_name]:
<img width="1005" height="701" alt="Screenshot 2026-02-03 at 2 14 29 PM" src="https://github.com/user-attachments/assets/1c1bfb18-ba00-4810-bd78-69500bc5f7a8" />

5. Submit selected main-file at `POST http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/main-file` (with Authorization header) by inserting body (raw):
```json
{
"relpath": "text_projects_og/PlantGrowthStudy/main_report.pdf"
}
```

**Test 1**: Verify that `GET http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/text/sections` (with Authorization header) returns 7 sections of the main file content
<img width="1006" height="689" alt="Screenshot 2026-02-03 at 2 13 01 PM" src="https://github.com/user-attachments/assets/c0435f38-444c-4cd9-929b-512d90ee55f0" />

**Test 2**: Submit selected sections at `POST http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/text/contributions` (with Authorization header)
with this body (raw):
```json
{
  "selected_section_ids": [1, 3, 4]
}
```
Then verify that the ids get persisted to the response json (contributions.[project_name].main_section_ids):
<img width="1006" height="699" alt="Screenshot 2026-02-03 at 2 12 37 PM" src="https://github.com/user-attachments/assets/08d989e9-ad43-4909-a613-cef0b1dfb961" />

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---