### PR TITLE
Api/support contrib

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -594,9 +594,6 @@ A typical flow for the first six endpoints:
                     },
                     "files_info_count": 8
                 }
-            },
-            "error": null
-        }
         ```
 
 - **Resolve Dedup (Optional, New)**
@@ -702,6 +699,58 @@ A typical flow for the first six endpoints:
     - **Error Responses**:
         - `422 Unprocessable Entity` if any section IDs are out of range
         - `409 Conflict` if the main file is not selected yet for this project
+
+- **Set Supporting Text Files (Collaborative Text Contribution)**
+    - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/supporting-text-files`
+    - **Description**: Stores which **supporting TEXT files** the user contributed to (excluding the selected main file, and excluding `.csv` files).
+        - Writes to: `uploads.state.contributions[project_name].supporting_text_relpaths`
+        - Values are stored **deduplicated + sorted**
+    - **Auth**: `Authorization: Bearer <access_token>`
+    - **Path Params**:
+        - `{upload_id}` (integer, required)
+        - `{project_name}` (string, required)
+    - **Request Body**:
+        ```json
+        {
+        "relpaths": [
+            "text_projects_og/PlantGrowthStudy/reading_notes.txt",
+            "text_projects_og/PlantGrowthStudy/second_draft.docx"
+        ]
+        }
+        ```
+    - **Response Status**: `200 OK`
+    - **Response DTO**: `UploadDTO`
+    - **Error Responses**:
+
+    - `409 Conflict` if upload is not in a file-picking step (e.g. not `needs_file_roles` / `needs_summaries`), or if main file is not selected yet (service guard)
+    - `422 Unprocessable Entity` if any relpath is unsafe (e.g. contains `..`) or if the list includes the main file or any `.csv`
+    - `404 Not Found` if any relpath does not exist for this project/upload
+
+
+- **Set Supporting CSV Files (Collaborative Text Contribution)**
+    - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/supporting-csv-files`
+    - **Description**: Stores which **CSV files** the user contributed to.
+        - Writes to: `uploads.state.contributions[project_name].supporting_csv_relpaths`
+        - Values are stored **deduplicated + sorted**
+    - **Auth**: `Authorization: Bearer <access_token>`
+    - **Path Params**:
+        - `{upload_id}` (integer, required)
+        - `{project_name}` (string, required)
+    - **Request Body**:
+        ```json
+        {
+        "relpaths": [
+            "text_projects_og/PlantGrowthStudy/plant_growth_data.csv",
+            "text_projects_og/PlantGrowthStudy/plant_growth_data2.csv"
+        ]
+        }
+        ```
+    - **Response Status**: `200 OK`
+    - **Response DTO**: `UploadDTO`
+    - **Error Responses**:
+        - `409 Conflict` if upload is not in a file-picking step (e.g. not `needs_file_roles` / `needs_summaries`)
+        - `422 Unprocessable Entity` if any relpath is unsafe, or if any relpath is not a `.csv`
+        - `404 Not Found` if any relpath does not exist for this project/upload
 ---
 
 ## **GitHub Integration**
@@ -1374,6 +1423,9 @@ Example:
 
 - **SetMainFileSectionsRequestDTO**
     - `selected_section_ids` (List[int], required): IDs from `MainFileSectionsDTO.sections[*].id`
+
+- **SupportingFilesRequest**
+    - `relpaths` (List[string], required): relpaths returned by `GET .../files`
 
 
 ### **Skills DTOs**

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -27,6 +27,11 @@ from src.services.uploads_service import (
     list_project_files,
     set_project_main_file,
 )
+from src.api.schemas.uploads import SupportingFilesRequestDTO
+from src.services.uploads_supporting_contributions_service import (
+    set_project_supporting_text_files,
+    set_project_supporting_csv_files,
+)
 
 router = APIRouter(prefix="/projects", tags=["projects"])
 
@@ -123,6 +128,37 @@ def post_upload_project_main_file(
 ):
     upload = set_project_main_file(conn, user_id, upload_id, project_name, body.relpath)
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+
+
+@router.post(
+    "/upload/{upload_id}/projects/{project_name}/supporting-text-files",
+    response_model=ApiResponse[UploadDTO],
+)
+def post_upload_project_supporting_text_files(
+    upload_id: int,
+    project_name: str,
+    body: SupportingFilesRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = set_project_supporting_text_files(conn, user_id, upload_id, project_name, body.relpaths)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+
+
+@router.post(
+    "/upload/{upload_id}/projects/{project_name}/supporting-csv-files",
+    response_model=ApiResponse[UploadDTO],
+)
+def post_upload_project_supporting_csv_files(
+    upload_id: int,
+    project_name: str,
+    body: SupportingFilesRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = set_project_supporting_csv_files(conn, user_id, upload_id, project_name, body.relpaths)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+
 
 
 @router.delete("", response_model=ApiResponse[DeleteResultDTO])

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -47,3 +47,5 @@ class UploadProjectFilesDTO(BaseModel):
 class MainFileRequestDTO(BaseModel):
     relpath: str
 
+class SupportingFilesRequestDTO(BaseModel):
+    relpaths: List[str] = []

--- a/src/services/uploads_supporting_contributions_service.py
+++ b/src/services/uploads_supporting_contributions_service.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import sqlite3
+from typing import Iterable
+
+from fastapi import HTTPException
+
+from src.db.uploads import get_upload_by_id, patch_upload_state
+from src.services.uploads_service import list_project_files
+from src.services.uploads_file_roles_util import safe_relpath
+
+
+_ALLOWED_STATUSES = {"needs_file_roles", "needs_summaries", "analyzing", "done"}
+
+
+def set_project_supporting_text_files(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    relpaths: list[str],
+) -> dict:
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload)
+
+    state = upload.get("state") or {}
+    main_file = _get_main_file_relpath(state, project_name)
+
+    # Reuse existing file listing logic for validation + allowed candidates
+    files_payload = list_project_files(conn, user_id, upload_id, project_name)
+    allowed = _allowed_supporting_text_relpaths(files_payload, main_file)
+
+    selected = _normalize_relpaths(relpaths)
+    invalid = sorted([p for p in selected if p not in allowed])
+    if invalid:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "One or more relpaths are not valid supporting TEXT files for this project",
+                "invalid_relpaths": invalid,
+            },
+        )
+
+    contributions = dict(state.get("contributions") or {})
+    proj = dict(contributions.get(project_name) or {})
+    proj["supporting_text_relpaths"] = sorted(selected)
+    contributions[project_name] = proj
+
+    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+def set_project_supporting_csv_files(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    relpaths: list[str],
+) -> dict:
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload)
+
+    state = upload.get("state") or {}
+
+    files_payload = list_project_files(conn, user_id, upload_id, project_name)
+    allowed = _allowed_csv_relpaths(files_payload)
+
+    selected = _normalize_relpaths(relpaths)
+    invalid = sorted([p for p in selected if p not in allowed])
+    if invalid:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "message": "One or more relpaths are not valid CSV files for this project",
+                "invalid_relpaths": invalid,
+            },
+        )
+
+    contributions = dict(state.get("contributions") or {})
+    proj = dict(contributions.get(project_name) or {})
+    proj["supporting_csv_relpaths"] = sorted(selected)
+    contributions[project_name] = proj
+
+    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+def _require_upload(conn: sqlite3.Connection, user_id: int, upload_id: int) -> dict:
+    upload = get_upload_by_id(conn, upload_id)
+    if not upload or upload["user_id"] != user_id:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    return upload
+
+
+def _require_status(upload: dict) -> None:
+    if upload.get("status") not in _ALLOWED_STATUSES:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Upload not ready for supporting file selection (status={upload.get('status')})",
+        )
+
+
+def _get_main_file_relpath(state: dict, project_name: str) -> str:
+    file_roles = state.get("file_roles") or {}
+    proj = file_roles.get(project_name) or {}
+    main_file = proj.get("main_file")
+    if not main_file:
+        raise HTTPException(
+            status_code=409,
+            detail={"message": "Main file must be selected before choosing supporting text files", "project_name": project_name},
+        )
+    return main_file
+
+
+def _normalize_relpaths(relpaths: Iterable[str]) -> set[str]:
+    relpaths = relpaths or []
+    out: set[str] = set()
+    for p in relpaths:
+        try:
+            out.add(safe_relpath(p))
+        except ValueError as e:
+            raise HTTPException(status_code=422, detail=str(e))
+    return out
+
+
+def _allowed_supporting_text_relpaths(files_payload: dict, main_file_relpath: str) -> set[str]:
+    allowed: set[str] = set()
+    for item in (files_payload.get("text_files") or []):
+        rp = (item.get("relpath") or "").strip()
+        if rp and rp != main_file_relpath:
+            allowed.add(rp)
+    return allowed
+
+
+def _allowed_csv_relpaths(files_payload: dict) -> set[str]:
+    allowed: set[str] = set()
+    for item in (files_payload.get("csv_files") or []):
+        rp = (item.get("relpath") or "").strip()
+        if rp:
+            allowed.add(rp)
+    return allowed

--- a/tests/api/test_uploads_supporting_files.py
+++ b/tests/api/test_uploads_supporting_files.py
@@ -1,0 +1,265 @@
+import pytest
+
+from .test_uploads_wizard import _make_zip_bytes
+from .test_uploads_file_roles import _advance_to_needs_file_roles, _cleanup_upload_artifacts
+
+PROJECT = "ProjectA"
+
+
+def build_zip_for_supporting_files(project: str = PROJECT) -> bytes:
+    return _make_zip_bytes(
+        {
+            f"{project}/main_report.txt": "Main report content.\nIntro...\n",
+            f"{project}/reading_notes.txt": "Notes...\n",
+            f"{project}/outline.txt": "Outline...\n",
+            f"{project}/data1.csv": "a,b\n1,2\n",
+            f"{project}/data2.csv": "x,y\n3,4\n",
+        }
+    )
+
+
+def get_upload_state(client, auth_headers, upload_id: int) -> dict:
+    res = client.get(f"/projects/upload/{upload_id}", headers=auth_headers)
+    assert res.status_code == 200
+    return res.json()["data"].get("state") or {}
+
+
+def get_files_payload(client, auth_headers, upload_id: int, project: str) -> dict:
+    res = client.get(
+        f"/projects/upload/{upload_id}/projects/{project}/files",
+        headers=auth_headers,
+    )
+    assert res.status_code == 200
+    return res.json()["data"]
+
+
+def pick_relpath_by_filename(files: list[dict], filename: str) -> str:
+    for f in files:
+        if (f.get("file_name") or "") == filename:
+            rp = f.get("relpath")
+            if isinstance(rp, str) and rp:
+                return rp
+    raise AssertionError(f"Could not find relpath for filename={filename}")
+
+
+def get_project_contrib(state: dict, project: str) -> dict:
+    return ((state.get("contributions") or {}).get(project)) or {}
+
+
+def post_set_main_file(client, auth_headers, upload_id: int, project: str, main_relpath: str) -> dict:
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{project}/main-file",
+        headers=auth_headers,
+        json={"relpath": main_relpath},
+    )
+    assert res.status_code == 200
+    return res.json()["data"].get("state") or {}
+
+
+def setup_upload_and_set_main(client, auth_headers, zip_bytes: bytes, project: str = PROJECT):
+    """
+    Shared setup so supporting-file endpoints are actually reachable (avoids 409).
+    Returns: (upload_id, files_payload, main_relpath)
+    """
+    upload = _advance_to_needs_file_roles(client, auth_headers, zip_bytes)
+    upload_id = upload["upload_id"]
+
+    files_payload = get_files_payload(client, auth_headers, upload_id, project)
+    main_relpath = pick_relpath_by_filename(files_payload["all_files"], "main_report.txt")
+
+    post_set_main_file(client, auth_headers, upload_id, project, main_relpath)
+    return upload_id, files_payload, main_relpath
+
+
+def supporting_text_candidates(files_payload: dict, main_relpath: str) -> list[str]:
+    out: list[str] = []
+    for f in (files_payload.get("text_files") or []):
+        rp = f.get("relpath")
+        ext = (f.get("extension") or "").lower()
+        if not isinstance(rp, str) or not rp:
+            continue
+        if rp == main_relpath:
+            continue
+        if ext == ".csv" or (f.get("file_name") or "").lower().endswith(".csv"):
+            continue
+        out.append(rp)
+    return out
+
+
+def supporting_csv_candidates(files_payload: dict) -> list[str]:
+    out: list[str] = []
+    for f in (files_payload.get("csv_files") or []):
+        rp = f.get("relpath")
+        if isinstance(rp, str) and rp:
+            out.append(rp)
+    return out
+
+
+def test_post_supporting_text_files_happy_path_persists_and_dedupes(client, auth_headers):
+    upload_id, files_payload, main_relpath = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    candidates = supporting_text_candidates(files_payload, main_relpath)
+    assert len(candidates) >= 2
+
+    selected = [candidates[0], candidates[1], candidates[0]]  # duplicates on purpose
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": selected},
+    )
+    assert res.status_code == 200
+    state = res.json()["data"].get("state") or {}
+    contrib = get_project_contrib(state, PROJECT)
+
+    stored = contrib.get("supporting_text_relpaths") or []
+    assert sorted(stored) == sorted(set(selected))
+    assert main_relpath not in stored
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    persisted_contrib = get_project_contrib(persisted_state, PROJECT)
+    assert sorted(persisted_contrib.get("supporting_text_relpaths") or []) == sorted(set(selected))
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_supporting_text_files_rejects_main_file(client, auth_headers):
+    upload_id, files_payload, main_relpath = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    candidates = supporting_text_candidates(files_payload, main_relpath)
+    assert candidates
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": [candidates[0], main_relpath]},
+    )
+    assert res.status_code == 422
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    contrib = get_project_contrib(persisted_state, PROJECT)
+    assert "supporting_text_relpaths" not in contrib
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_supporting_text_files_invalid_relpath_is_atomic(client, auth_headers):
+    upload_id, files_payload, main_relpath = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    candidates = supporting_text_candidates(files_payload, main_relpath)
+    assert candidates
+
+    valid_one = candidates[0]
+    invalid_one = valid_one + "__does_not_exist"
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": [valid_one, invalid_one]},
+    )
+    assert res.status_code in (404, 422)
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    contrib = get_project_contrib(persisted_state, PROJECT)
+    assert "supporting_text_relpaths" not in contrib
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_supporting_text_files_rejects_unsafe_relpath(client, auth_headers):
+    # set main file first so we reach safe_relpath validation (422)
+    upload_id, _, _ = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": ["../evil.txt"]},
+    )
+    assert res.status_code == 422
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_supporting_csv_files_happy_path_persists_and_dedupes(client, auth_headers):
+    upload_id, files_payload, _ = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    csvs = supporting_csv_candidates(files_payload)
+    assert len(csvs) >= 2
+
+    selected = [csvs[0], csvs[1], csvs[0]]
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-csv-files",
+        headers=auth_headers,
+        json={"relpaths": selected},
+    )
+    assert res.status_code == 200
+
+    state = res.json()["data"].get("state") or {}
+    contrib = get_project_contrib(state, PROJECT)
+    stored = contrib.get("supporting_csv_relpaths") or []
+    assert sorted(stored) == sorted(set(selected))
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    persisted_contrib = get_project_contrib(persisted_state, PROJECT)
+    assert sorted(persisted_contrib.get("supporting_csv_relpaths") or []) == sorted(set(selected))
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_supporting_csv_files_rejects_non_csv(client, auth_headers):
+    upload_id, files_payload, _ = setup_upload_and_set_main(
+        client, auth_headers, build_zip_for_supporting_files(PROJECT), PROJECT
+    )
+
+    non_csv_text = pick_relpath_by_filename(files_payload["all_files"], "reading_notes.txt")
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/supporting-csv-files",
+        headers=auth_headers,
+        json={"relpaths": [non_csv_text]},
+    )
+    assert res.status_code == 422
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    contrib = get_project_contrib(persisted_state, PROJECT)
+    assert "supporting_csv_relpaths" not in contrib
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_supporting_files_requires_needs_file_roles(client, auth_headers):
+    zip_bytes = _make_zip_bytes(
+        {
+            "ProjectA/main_report.txt": "hi",
+            "ProjectB/main_report.txt": "hi",
+        }
+    )
+    start = client.post(
+        "/projects/upload",
+        headers=auth_headers,
+        files={"file": ("two_projects.zip", zip_bytes, "application/zip")},
+    )
+    assert start.status_code == 200
+    upload = start.json()["data"]
+    upload_id = upload["upload_id"]
+
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/ProjectA/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": ["ProjectA/reading_notes.txt"]},
+    )
+    assert res.status_code == 409
+
+    _cleanup_upload_artifacts((upload.get("state") or {}))


### PR DESCRIPTION
## 📝 Description

This PR adds support for selecting which supporting files (text + CSV) the user contributed to for collaborative text projects (stored separately from main-file section selection).

Added 2 new endpoints for supporting file selection:

* **POST** `/projects/upload/{upload_id}/projects/{project_name}/supporting-text-files`
  Takes a list of relpaths, validates they belong to this project/upload, filters out the selected main file + any `.csv`, dedupes/sorts, then stores them in `uploads.state.contributions[project_name].supporting_text_relpaths`.
* **POST** `/projects/upload/{upload_id}/projects/{project_name}/supporting-csv-files`
  Takes a list of relpaths, validates they belong to this project/upload and are actually `.csv`, dedupes/sorts, then stores them in `uploads.state.contributions[project_name].supporting_csv_relpaths`.

Also added the request DTO(s) for these endpoints.

Added a test script that spins up a minimal upload ZIP (main report + a couple text + a couple CSV), advances to `needs_file_roles`, sets the main file, then hits both endpoints and checks the relpaths are deduped/sorted + persisted back into the upload state in the DB. It also covers the expected error cases (unsafe relpath, relpath not in the project, trying to include the main file as supporting text, passing non-csv to the csv endpoint, and calling the endpoints before `needs_file_roles` / `needs_summaries`).

NOTE: the actual LOC contributed by this branch is ~500, will be rebased once #446 is merged to main

**Closes:** #441 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] ran `pytest tests/api/test_uploads_supporting_files.py` and `pytest`
- [x] manually tested on postman
  - follow through steps 1-5 of manual testing instructions in PR #446
  - **TEST 1**: Positive test for supporting text file selection: `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/supporting-text-files`
  Request body:
```json
{
  "relpaths": [
    "text_projects_og/PlantGrowthStudy/reading_notes.txt",
    "text_projects_og/PlantGrowthStudy/second_draft.docx"  
    ]
}
```
→ should return a `200 OK` status code + relpaths stored under "supporting_text_relpaths"

  - **TEST 2**: Negative test for supporting text file selection (include main file path): `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/supporting-text-files`
  Request body:
```json
{
  "relpaths": [
    "text_projects_og/PlantGrowthStudy/reading_notes.txt",
    "text_projects_og/PlantGrowthStudy/second_draft.docx",
    "text_projects_og/PlantGrowthStudy/main_report.pdf"   
    ]
}
```
→ should return a `422 Unprocessable Entity` status code + message includes invalid relpaths

  - **TEST 3**: Positive test for supporting CSV file selection: `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/supporting-csv-files`
  Request body:
```json
{
  "relpaths": [
    "text_projects_og/PlantGrowthStudy/plant_growth_data.csv",
    "text_projects_og/PlantGrowthStudy/plant_growth_data2.csv"  
    ]
}
```
→ should return a `200 OK` status code + relpaths stored under "supporting_csv_relpaths"

  - **TEST 4**: Negative test for supporting CSV file selection (include non csv and main file): `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/supporting-csv-files`
  Request body:
```json
{
  "relpaths": [
    "text_projects_og/PlantGrowthStudy/reading_notes.txt",
    "text_projects_og/PlantGrowthStudy/main_report.pdf"   
    ]
}
```
→ should return a `422 Unprocessable Entity` status code + message includes invalid relpaths

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots