### PR TITLE
Remove project from resume API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1555,6 +1555,42 @@ Manages résumé-specific representations of projects.
     }
     ```
 
+- **Remove Project from Resume**
+  - **Endpoint**: `DELETE /resume/{resume_id}/projects?project_name=<name>`
+  - **Description**: Removes a single project from a résumé snapshot. Recomputes aggregated skills from the remaining projects. If no projects remain after removal, the résumé is deleted entirely.
+  - **Path Parameters**:
+    - `{resume_id}` (integer, required): The ID of the résumé snapshot
+  - **Query Parameters**:
+    - `project_name` (string, required): The name of the project to remove
+  - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+  - **Response Status**: `200 OK` on success, `404 Not Found` if résumé doesn't exist or project isn't in the résumé
+  - **Response Body** (project removed, résumé still has other projects):
+    ```json
+    {
+      "success": true,
+      "data": {
+        "id": 1,
+        "name": "My Resume",
+        "projects": [...],
+        "aggregated_skills": {...},
+        "rendered_text": "..."
+      },
+      "error": null
+    }
+    ```
+  - **Response Body** (last project removed, résumé deleted):
+    ```json
+    {
+      "success": true,
+      "data": null,
+      "error": null
+    }
+    ```
+  - **Error Responses**:
+    - `401 Unauthorized`: Missing or invalid Bearer token
+    - `404 Not Found`: `"Resume not found"` or `"Project not found in resume"` (distinct messages)
+    - `422 Unprocessable Entity`: Missing `project_name` query parameter
+
 - **Export Resume to DOCX**
     - **Endpoint**: `GET /resume/{resume_id}/export/docx`
     - **Description**: Exports a résumé snapshot to a Word document (.docx) file.

--- a/src/menu/resume/helpers.py
+++ b/src/menu/resume/helpers.py
@@ -646,6 +646,53 @@ def _aggregate_skills(summaries: List[ProjectSummary], highlighted_skills: List[
         "writing_skills": sorted(writing_skills),
     }
 
+# Display-name labels for writing skills.  Used to partition already-mapped
+# skill labels (from resume snapshot JSON) into writing vs technical buckets.
+WRITING_SKILL_LABELS = {
+    "Clear communication",
+    "Structured writing",
+    "Strong vocabulary",
+    "Analytical writing",
+    "Critical thinking",
+    "Revision & editing",
+    "Planning & organization",
+    "Research integration",
+    "Data collection",
+    "Data analysis",
+}
+
+
+def recompute_aggregated_skills(projects: List[Dict[str, Any]]) -> Dict[str, List[str]]:
+    """Rebuild aggregated_skills from a list of snapshot project dicts.
+
+    Unlike ``_aggregate_skills`` (which works on ``ProjectSummary`` objects and
+    maps raw skill keys to display names), this operates on resume-snapshot
+    project entries where skills are already display-name strings.
+    """
+    langs: set[str] = set()
+    frameworks: set[str] = set()
+    tech_skills: set[str] = set()
+    writing_skills: set[str] = set()
+
+    for p in projects:
+        for lang in p.get("languages") or []:
+            langs.add(lang)
+        for fw in p.get("frameworks") or []:
+            frameworks.add(fw)
+        for skill in p.get("skills") or []:
+            if skill in WRITING_SKILL_LABELS:
+                writing_skills.add(skill)
+            else:
+                tech_skills.add(skill)
+
+    return {
+        "languages": sorted(langs),
+        "frameworks": sorted(frameworks),
+        "technical_skills": sorted(tech_skills),
+        "writing_skills": sorted(writing_skills),
+    }
+
+
 def enrich_snapshot_with_contributions(conn, user_id: int, snapshot: Dict[str, Any]) -> Dict[str, Any]:
     snapshot = enrich_snapshot_with_dates(conn, user_id, snapshot)
 

--- a/src/menu/resume/menu.py
+++ b/src/menu/resume/menu.py
@@ -12,6 +12,7 @@ from .flow import (
     _handle_edit_resume_wording,
     _handle_export_resume_pdf,
     _handle_manage_resume_skills,
+    _handle_remove_project_from_resume,
 )
 
 
@@ -28,8 +29,9 @@ def view_resume_items(conn, user_id: int, username: str):
         print("4. Export a resume snapshot to PDF (.pdf)")
         print("5. Edit wording in an existing resume")
         print("6. Manage skill highlighting for a resume")
-        print("7. Back to main menu")
-        choice = input("Select an option (1-7): ").strip()
+        print("7. Remove a project from a resume")
+        print("8. Back to main menu")
+        choice = input("Select an option (1-8): ").strip()
 
         if choice == "1":
             _handle_create_resume(conn, user_id, username)
@@ -62,7 +64,12 @@ def view_resume_items(conn, user_id: int, username: str):
                 print("")
                 continue
         elif choice == "7":
+            handled = _handle_remove_project_from_resume(conn, user_id)
+            if handled:
+                print("")
+                continue
+        elif choice == "8":
             print("")
             return
         else:
-            print("Invalid choice, please enter 1, 2, 3, 4, 5, 6, or 7.")
+            print("Invalid choice, please enter 1, 2, 3, 4, 5, 6, 7, or 8.")

--- a/tests/api/test_resume_remove_project.py
+++ b/tests/api/test_resume_remove_project.py
@@ -1,0 +1,159 @@
+"""Tests for DELETE /resume/{resume_id}/projects endpoint (remove project from resume)."""
+import json
+from src.db.resumes import insert_resume_snapshot, list_resumes, get_resume_snapshot
+from src.menu.resume.helpers import recompute_aggregated_skills
+
+
+# ============================================================================
+# Helper Functions
+# ============================================================================
+
+def create_resume_with_projects(conn, user_id, name, project_entries):
+    """Create a test resume with detailed project entries. Returns resume ID."""
+    resume_json = json.dumps({
+        "projects": project_entries,
+        "aggregated_skills": recompute_aggregated_skills(project_entries),
+    })
+    resume_id = insert_resume_snapshot(conn, user_id, name, resume_json)
+    conn.commit()
+    return resume_id
+
+
+def make_project_entry(name, languages=None, frameworks=None, skills=None):
+    """Build a minimal project entry dict."""
+    return {
+        "project_name": name,
+        "languages": languages or [],
+        "frameworks": frameworks or [],
+        "skills": skills or [],
+    }
+
+
+def assert_success(response, expected_status=200):
+    assert response.status_code == expected_status
+    body = response.json()
+    assert body["success"] is True
+    assert body["error"] is None
+    return body
+
+
+# ============================================================================
+# Tests
+# ============================================================================
+
+def test_remove_project_from_multi_project_resume(client, auth_headers, seed_conn):
+    """Removing a project from a multi-project resume returns the updated resume."""
+    entries = [
+        make_project_entry("ProjectA", languages=["Python"], skills=["OOP"]),
+        make_project_entry("ProjectB", languages=["JavaScript"], skills=["Testing"]),
+    ]
+    resume_id = create_resume_with_projects(seed_conn, 1, "MyResume", entries)
+
+    res = client.delete(
+        f"/resume/{resume_id}/projects?project_name=ProjectA",
+        headers=auth_headers,
+    )
+    body = assert_success(res)
+
+    # Should return updated resume with only ProjectB
+    assert body["data"] is not None
+    projects = body["data"]["projects"]
+    project_names = [p["project_name"] for p in projects]
+    assert "ProjectA" not in project_names
+    assert "ProjectB" in project_names
+
+
+def test_remove_last_project_deletes_resume(client, auth_headers, seed_conn):
+    """Removing the only project from a resume deletes the resume entirely."""
+    entries = [make_project_entry("OnlyProject")]
+    resume_id = create_resume_with_projects(seed_conn, 1, "SingleResume", entries)
+
+    # Verify resume exists
+    assert any(r["id"] == resume_id for r in list_resumes(seed_conn, 1))
+
+    res = client.delete(
+        f"/resume/{resume_id}/projects?project_name=OnlyProject",
+        headers=auth_headers,
+    )
+    body = assert_success(res)
+    assert body["data"] is None  # Resume was deleted
+
+    # Verify resume is gone
+    assert not any(r["id"] == resume_id for r in list_resumes(seed_conn, 1))
+
+
+def test_remove_project_not_in_resume_returns_404(client, auth_headers, seed_conn):
+    """Removing a project that isn't in the resume returns 404 with specific message."""
+    entries = [make_project_entry("ProjectA")]
+    resume_id = create_resume_with_projects(seed_conn, 1, "MyResume", entries)
+
+    res = client.delete(
+        f"/resume/{resume_id}/projects?project_name=NonExistent",
+        headers=auth_headers,
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "Project not found in resume"
+
+
+def test_remove_project_from_nonexistent_resume_returns_404(client, auth_headers):
+    """Removing a project from a resume that doesn't exist returns 404 with specific message."""
+    res = client.delete(
+        "/resume/999/projects?project_name=Anything",
+        headers=auth_headers,
+    )
+    assert res.status_code == 404
+    assert res.json()["detail"] == "Resume not found"
+
+
+def test_aggregated_skills_recomputed_after_removal(client, auth_headers, seed_conn):
+    """After removal, aggregated_skills should only reflect remaining projects."""
+    entries = [
+        make_project_entry("ProjectA", languages=["Python"], skills=["OOP"]),
+        make_project_entry("ProjectB", languages=["JavaScript"], frameworks=["React"], skills=["Testing"]),
+    ]
+    resume_id = create_resume_with_projects(seed_conn, 1, "SkillResume", entries)
+
+    res = client.delete(
+        f"/resume/{resume_id}/projects?project_name=ProjectA",
+        headers=auth_headers,
+    )
+    body = assert_success(res)
+
+    agg = body["data"]["aggregated_skills"]
+    # Python and OOP came from ProjectA, should be gone
+    assert "Python" not in agg["languages"]
+    assert "OOP" not in agg["technical_skills"]
+    # JavaScript, React, Testing came from ProjectB, should remain
+    assert "JavaScript" in agg["languages"]
+    assert "React" in agg["frameworks"]
+    assert "Testing" in agg["technical_skills"]
+
+
+def test_remove_project_does_not_affect_other_resumes(client, auth_headers, seed_conn):
+    """Removing a project from one resume does not affect other resumes."""
+    entries = [
+        make_project_entry("SharedProject", languages=["Python"]),
+        make_project_entry("OtherProject", languages=["Go"]),
+    ]
+    resume_id_1 = create_resume_with_projects(seed_conn, 1, "Resume1", entries)
+    resume_id_2 = create_resume_with_projects(seed_conn, 1, "Resume2", entries)
+
+    # Remove SharedProject from Resume1 only
+    res = client.delete(
+        f"/resume/{resume_id_1}/projects?project_name=SharedProject",
+        headers=auth_headers,
+    )
+    assert_success(res)
+
+    # Resume2 should still have both projects
+    snap = get_resume_snapshot(seed_conn, 1, resume_id_2)
+    data = json.loads(snap["resume_json"])
+    project_names = [p["project_name"] for p in data["projects"]]
+    assert "SharedProject" in project_names
+    assert "OtherProject" in project_names
+
+
+def test_remove_project_requires_auth(client):
+    """DELETE /resume/{id}/projects requires authentication."""
+    res = client.delete("/resume/1/projects?project_name=Foo")
+    assert res.status_code == 401


### PR DESCRIPTION
## 📝 Description

Adds the ability to remove a single project from a specific resume without deleting the project itself or the entire resume. After removal, aggregated skills are recomputed from the remaining projects. If the last project is removed, the resume is deleted entirely.

This addresses the gap identified in PR #440: when a user deletes a project with `refresh_resumes=false` (the default), the deleted project stays as a stale entry in their resume snapshots with no way to remove it short of creating a new resume from scratch.

CLI Change:
- Resume menu option 7: "Remove a project from a resume" (Back to main menu shifted to 8)

Endpoint Added:
| Endpoint | Description | Response |
|----------|-------------|----------|
| `DELETE /resume/{resume_id}/projects?project_name=<name>` | Remove a project from a resume | Updated resume, `null` if resume deleted, or 404 |

Refactoring:
- Extracted `recompute_aggregated_skills()` into `helpers.py` to eliminate a 25-line block that was copy-pasted in 3 files
- Consolidated `WRITING_SKILL_LABELS` constant into a single definition in `helpers.py` (was duplicated in 3 files)

Closes: #478
---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests
```bash
# New API tests (7 tests)
pytest tests/api/test_resume_remove_project.py -v

# New CLI tests (4 tests)
pytest tests/test_resume_snapshot.py -k cli_remove -v

# Full suite (1017 passed)
pytest tests/ -v
```

### Manual Testing - API

1. Start the server: `uvicorn src.api.main:app --reload`
2. Register and login to get a token
3. Create a resume with 2+ projects via `POST /resume/generate`
4. `GET /resume/{id}`, confirm the projects are listed
5. `DELETE /resume/{id}/projects?project_name=<name>`, confirm project is removed and skills recomputed
6. `GET /resume/{id}`, confirm the change persisted
7. `DELETE /resume/{id}/projects?project_name=NonExistent`, confirm `404` with `"Project not found in resume"`
8. `DELETE /resume/999/projects?project_name=Anything`, confirm `404` with `"Resume not found"`

### Manual Testing - CLI

1. Run `python -m src.main` and create a resume with 2+ projects
2. Select Resume menu > option 7 "Remove a project from a resume"
3. Select a resume, select a project, confirm with "y"
4. Verify the project is removed and the resume is updated
5. Repeat to remove the last project, verify the resume is deleted

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile (N/A — API + CLI only)

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

Screenshots for CLI:
Original Resume:
<img width="1059" height="659" alt="Screenshot 2026-02-11 at 6 05 43 PM" src="https://github.com/user-attachments/assets/9a93602c-350c-44dc-b5c1-76d1a706b770" />
Delete project from resume:
<img width="899" height="598" alt="Screenshot 2026-02-11 at 6 06 22 PM" src="https://github.com/user-attachments/assets/fcba2462-8d54-445d-ab56-54e1e877447e" />
Revised Resume
<img width="1065" height="625" alt="Screenshot 2026-02-11 at 6 06 32 PM" src="https://github.com/user-attachments/assets/0e462fac-b7e4-4624-80a4-396d309b8e40" />


</details>