### PR TITLE
Thumbnail API Endpoint

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -536,6 +536,70 @@ Handles project ingestion, analysis, classification, and metadata updates.
         }
         ```
 
+- **Project Thumbnails**
+    - **Description**: Upload, view, and delete thumbnail images for projects. Thumbnails are standardized to PNG format and resized to a maximum of 800x800 px.
+
+    - **Upload Thumbnail**
+        - **Endpoint**: `POST /projects/{project_id}/thumbnail`
+        - **Description**: Upload or replace a project's thumbnail image. Accepts PNG, JPG, JPEG, and WEBP formats. Images are automatically converted to PNG and resized if larger than 800x800 px.
+        - **Path Parameters**:
+            - `{project_id}` (integer, required): The `project_summary_id` of the project
+        - **Auth**: `Authorization: Bearer <access_token>`
+        - **Request Body**: `multipart/form-data`
+            - `file` (file, required): Image file (PNG, JPG, JPEG, or WEBP)
+        - **Response Status**: `200 OK`
+        - **Response DTO**: `ThumbnailUploadDTO`
+        - **Response Body**:
+            ```json
+            {
+                "success": true,
+                "data": {
+                    "project_id": 9,
+                    "project_name": "My Project",
+                    "message": "Thumbnail uploaded successfully"
+                },
+                "error": null
+            }
+            ```
+        - **Error Responses**:
+            - `401 Unauthorized`: Missing or invalid Bearer token
+            - `404 Not Found`: Project not found or doesn't belong to user
+            - `422 Unprocessable Entity`: Invalid image file (unsupported format or corrupt image)
+
+    - **Get Thumbnail**
+        - **Endpoint**: `GET /projects/{project_id}/thumbnail`
+        - **Description**: Download the thumbnail image for a project. Returns the image as a PNG file.
+        - **Path Parameters**:
+            - `{project_id}` (integer, required): The `project_summary_id` of the project
+        - **Auth**: `Authorization: Bearer <access_token>`
+        - **Response Status**: `200 OK`
+        - **Response**: Binary image download with MIME type `image/png`
+        - **Response Headers**:
+            - `Content-Type: image/png`
+        - **Error Responses**:
+            - `401 Unauthorized`: Missing or invalid Bearer token
+            - `404 Not Found`: Project not found, or thumbnail not found
+
+    - **Delete Thumbnail**
+        - **Endpoint**: `DELETE /projects/{project_id}/thumbnail`
+        - **Description**: Remove a project's thumbnail image. Deletes both the database record and the image file on disk.
+        - **Path Parameters**:
+            - `{project_id}` (integer, required): The `project_summary_id` of the project
+        - **Auth**: `Authorization: Bearer <access_token>`
+        - **Request Body**: None
+        - **Response Status**: `200 OK`
+        - **Response Body**:
+            ```json
+            {
+                "success": true,
+                "data": null,
+                "error": null
+            }
+            ```
+        - **Error Responses**:
+            - `401 Unauthorized`: Missing or invalid Bearer token
+            - `404 Not Found`: Project not found, or thumbnail not found
+
 ---
 
 ## **Uploads Wizard**
@@ -2023,6 +2087,11 @@ Example:
 
 - **DriveLinkRequest**
     - `links` (List[DriveLinkItem], required)
+
+- **ThumbnailUploadDTO** (used by `POST /projects/{project_id}/thumbnail`)
+    - `project_id` (int, required): The project_summary_id
+    - `project_name` (string, required): Display name of the project
+    - `message` (string, required): Status message (e.g. "Thumbnail uploaded successfully")
 
 - **DeleteResultDTO** (used by `DELETE /projects` and `DELETE /resume`)
   - `deleted_count` (int, required): Number of items deleted

--- a/docs/API.md
+++ b/docs/API.md
@@ -541,7 +541,7 @@ Handles project ingestion, analysis, classification, and metadata updates.
 
     - **Upload Thumbnail**
         - **Endpoint**: `POST /projects/{project_id}/thumbnail`
-        - **Description**: Upload or replace a project's thumbnail image. Accepts PNG, JPG, JPEG, and WEBP formats. Images are automatically converted to PNG and resized if larger than 800x800 px.
+        - **Description**: Upload or replace a project's thumbnail image. If a thumbnail already exists for the project, it is overwritten (no separate edit/replace endpoint needed). Accepts PNG, JPG, JPEG, and WEBP formats. Images are automatically converted to PNG and resized if larger than 800x800 px.
         - **Path Parameters**:
             - `{project_id}` (integer, required): The `project_summary_id` of the project
         - **Auth**: `Authorization: Bearer <access_token>`

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -12,6 +12,7 @@ from src.api.routes import (
     consent_router,
     portfolio_router,
     export_router,
+    thumbnails_router,
 )
 from src.api.auth.routes import router as auth_router
 
@@ -34,3 +35,4 @@ app.include_router(github_router)
 app.include_router(google_drive_router)
 app.include_router(portfolio_router)
 app.include_router(export_router)
+app.include_router(thumbnails_router)

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -17,6 +17,7 @@ from src.api.routes.google_drive import router as google_drive_router
 from src.api.routes.consent import router as consent_router
 from src.api.routes.portfolio import router as portfolio_router
 from src.api.routes.export import router as export_router
+from src.api.routes.thumbnails import router as thumbnails_router
 
 __all__ = [
     "projects_router",
@@ -31,4 +32,5 @@ __all__ = [
     "consent_router",
     "portfolio_router",
     "export_router",
+    "thumbnails_router",
 ]

--- a/src/api/routes/thumbnails.py
+++ b/src/api/routes/thumbnails.py
@@ -1,0 +1,72 @@
+from fastapi import APIRouter, Depends, File, HTTPException, UploadFile
+from fastapi.responses import FileResponse
+from sqlite3 import Connection
+
+from src.api.dependencies import get_current_user_id, get_db
+from src.api.schemas.common import ApiResponse
+from src.api.schemas.thumbnails import ThumbnailUploadDTO
+from src.services.thumbnails_service import (
+    get_thumbnail,
+    remove_thumbnail,
+    upload_thumbnail,
+)
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.post(
+    "/{project_id:int}/thumbnail",
+    response_model=ApiResponse[ThumbnailUploadDTO],
+)
+def post_thumbnail(
+    project_id: int,
+    file: UploadFile = File(...),
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    try:
+        result = upload_thumbnail(conn, user_id, project_id, file)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc))
+
+    if result is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+
+    return ApiResponse(
+        success=True,
+        data=ThumbnailUploadDTO(**result),
+        error=None,
+    )
+
+
+@router.get("/{project_id:int}/thumbnail")
+def get_project_thumbnail(
+    project_id: int,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    result = get_thumbnail(conn, user_id, project_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if result is False:
+        raise HTTPException(status_code=404, detail="Thumbnail not found")
+
+    return FileResponse(result, media_type="image/png")
+
+
+@router.delete(
+    "/{project_id:int}/thumbnail",
+    response_model=ApiResponse[None],
+)
+def delete_thumbnail(
+    project_id: int,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    result = remove_thumbnail(conn, user_id, project_id)
+    if result is None:
+        raise HTTPException(status_code=404, detail="Project not found")
+    if result is False:
+        raise HTTPException(status_code=404, detail="Thumbnail not found")
+
+    return ApiResponse(success=True, data=None, error=None)

--- a/src/api/schemas/thumbnails.py
+++ b/src/api/schemas/thumbnails.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class ThumbnailUploadDTO(BaseModel):
+    project_id: int
+    project_name: str
+    message: str

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -238,6 +238,8 @@ from .project_thumbnails import (
     get_project_thumbnail_path,
     delete_project_thumbnail,
     list_thumbnail_projects,
+    store_thumbnail,
+    delete_thumbnail_and_file,
 )
 
 from src.db.project_feedback import (
@@ -354,6 +356,8 @@ __all__ = [
     "get_project_thumbnail_path",
     "delete_project_thumbnail",
     "list_thumbnail_projects",
+    "store_thumbnail",
+    "delete_thumbnail_and_file",
     "upsert_project_feedback",
     "get_project_summary_by_id",
     "get_user_skill_preferences",

--- a/src/db/project_thumbnails.py
+++ b/src/db/project_thumbnails.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 import sqlite3
 from datetime import datetime
+from pathlib import Path
 from typing import Optional
+
+from src.utils.image_utils import save_standardized_thumbnail, validate_image_path
 
 
 def upsert_project_thumbnail(
@@ -74,3 +77,42 @@ def list_thumbnail_projects(
         (user_id,),
     )
     return [r[0] for r in cur.fetchall()]
+
+
+def store_thumbnail(
+    conn: sqlite3.Connection,
+    user_id: int,
+    project_key: int,
+    project_name: str,
+    image_path: Path,
+    images_dir: Path,
+) -> Path:
+    """Validate, standardize, and persist a thumbnail image.
+
+    Returns the destination path of the stored PNG.
+    Raises ValueError on invalid image.
+    """
+    src = validate_image_path(str(image_path))
+    dst = save_standardized_thumbnail(src, images_dir, user_id, project_name)
+    upsert_project_thumbnail(conn, user_id, project_key, str(dst))
+    return dst
+
+
+def delete_thumbnail_and_file(
+    conn: sqlite3.Connection,
+    user_id: int,
+    project_key: int,
+    images_dir: Path,
+) -> bool:
+    """Delete thumbnail DB record and remove the file from disk.
+
+    Returns True if a record was deleted, False if nothing to delete.
+    """
+    image_path = get_project_thumbnail_path(conn, user_id, project_key)
+    if image_path is None:
+        return False
+    delete_project_thumbnail(conn, user_id, project_key)
+    p = Path(image_path)
+    if p.exists() and p.parent.resolve() == images_dir.resolve():
+        p.unlink(missing_ok=True)
+    return True

--- a/src/export/portfolio_docx.py
+++ b/src/export/portfolio_docx.py
@@ -31,7 +31,7 @@ from docx.shared import Inches
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 
 from src.insights.rank_projects.rank_project_importance import collect_project_data
-from src.db import get_project_summary_row, get_project_thumbnail_path
+from src.db import get_project_summary_row, get_project_thumbnail_path, get_project_key
 from src.insights.portfolio import (
     format_duration,
     format_activity_line,
@@ -136,7 +136,8 @@ def export_portfolio_to_docx(
         doc.add_heading(str(display_name), level=1)
 
         # Thumbnail right after title (left aligned)
-        thumb = get_project_thumbnail_path(conn, user_id, project_name)
+        pkey = get_project_key(conn, user_id, project_name)
+        thumb = get_project_thumbnail_path(conn, user_id, pkey) if pkey else None
         if thumb:
             p = Path(thumb)
             if p.exists():

--- a/src/export/portfolio_pdf.py
+++ b/src/export/portfolio_pdf.py
@@ -37,7 +37,7 @@ from reportlab.platypus.flowables import HRFlowable
 from reportlab.lib import utils
 
 from src.insights.rank_projects.rank_project_importance import collect_project_data
-from src.db import get_project_summary_row, get_project_thumbnail_path
+from src.db import get_project_summary_row, get_project_thumbnail_path, get_project_key
 from src.insights.portfolio import (
     format_duration,
     format_activity_line,
@@ -282,7 +282,8 @@ def export_portfolio_to_pdf(
         # ---------------------------
         story.append(Paragraph(str(display_name), ProjectTitleStyle))
 
-        thumb = get_project_thumbnail_path(conn, user_id, project_name)
+        pkey = get_project_key(conn, user_id, project_name)
+        thumb = get_project_thumbnail_path(conn, user_id, pkey) if pkey else None
         if thumb:
             img = _load_image_preserve_aspect(thumb, max_width=2.6 * inch)
             if img:

--- a/src/services/thumbnails_service.py
+++ b/src/services/thumbnails_service.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+import os
+import tempfile
+from pathlib import Path
+from sqlite3 import Connection
+
+from fastapi import UploadFile
+from PIL import UnidentifiedImageError
+
+from src.db.project_summaries import get_project_summary_by_id
+from src.db.project_thumbnails import (
+    delete_project_thumbnail,
+    get_project_thumbnail_path,
+    upsert_project_thumbnail,
+)
+from src.utils.image_utils import save_standardized_thumbnail, validate_image_path
+
+IMAGES_DIR = Path("./images")
+
+
+def upload_thumbnail(
+    conn: Connection,
+    user_id: int,
+    project_id: int,
+    file: UploadFile,
+) -> dict | None:
+    """Upload or replace a project thumbnail.
+
+    Returns result dict on success, None if project not found.
+    Raises ValueError on invalid image.
+    """
+    project = get_project_summary_by_id(conn, user_id, project_id)
+    if project is None:
+        return None
+
+    project_key = project["project_key"]
+    project_name = project["project_name"]
+
+    suffix = Path(file.filename or "upload.png").suffix or ".png"
+    tmp_fd, tmp_path = tempfile.mkstemp(suffix=suffix)
+    try:
+        with os.fdopen(tmp_fd, "wb") as f:
+            f.write(file.file.read())
+
+        try:
+            validate_image_path(tmp_path)
+        except UnidentifiedImageError as exc:
+            raise ValueError(str(exc)) from exc
+        dst = save_standardized_thumbnail(
+            Path(tmp_path), IMAGES_DIR, user_id, project_name
+        )
+        upsert_project_thumbnail(conn, user_id, project_key, str(dst))
+    finally:
+        if os.path.exists(tmp_path):
+            os.unlink(tmp_path)
+
+    return {
+        "project_id": project_id,
+        "project_name": project_name,
+        "message": "Thumbnail uploaded successfully",
+    }
+
+
+def get_thumbnail(
+    conn: Connection,
+    user_id: int,
+    project_id: int,
+) -> str | None | bool:
+    """Return the file path for a project's thumbnail.
+
+    Returns None if project not found, False if no thumbnail, or the path string.
+    """
+    project = get_project_summary_by_id(conn, user_id, project_id)
+    if project is None:
+        return None
+
+    path = get_project_thumbnail_path(conn, user_id, project["project_key"])
+    if path is None or not Path(path).is_file():
+        return False
+
+    return path
+
+
+def remove_thumbnail(
+    conn: Connection,
+    user_id: int,
+    project_id: int,
+) -> bool | None:
+    """Remove a project's thumbnail.
+
+    Returns None if project not found, False if no thumbnail, True if deleted.
+    """
+    project = get_project_summary_by_id(conn, user_id, project_id)
+    if project is None:
+        return None
+
+    project_key = project["project_key"]
+    image_path = get_project_thumbnail_path(conn, user_id, project_key)
+    if image_path is None:
+        return False
+
+    delete_project_thumbnail(conn, user_id, project_key)
+
+    p = Path(image_path)
+    if p.exists() and p.parent.resolve() == IMAGES_DIR.resolve():
+        p.unlink(missing_ok=True)
+
+    return True

--- a/tests/api/test_export.py
+++ b/tests/api/test_export.py
@@ -13,8 +13,8 @@ import json
 import pytest
 
 from src.db.resumes import insert_resume_snapshot
-from src.db.project_summaries import save_project_summary
 from src.api.auth.security import create_access_token
+from tests.api.conftest import seed_project
 
 
 TEST_JWT_SECRET = "test-secret-key-for-testing"
@@ -46,19 +46,6 @@ def _seed_resume(seed_conn, user_id: int, name: str = "Test Resume") -> int:
         },
     })
     return insert_resume_snapshot(seed_conn, user_id, name, resume_json)
-
-
-def _seed_project(seed_conn, user_id: int, name: str = "Test Project") -> None:
-    """Create a minimal project summary for portfolio export."""
-    summary_json = json.dumps({
-        "project_name": name,
-        "project_type": "code",
-        "project_mode": "individual",
-        "summary_text": "A test project for portfolio.",
-        "languages": ["Python 80%"],
-        "frameworks": ["FastAPI"],
-    })
-    save_project_summary(seed_conn, user_id, name, summary_json)
 
 
 # ------------------------------------------------------------------------------
@@ -158,7 +145,7 @@ def test_portfolio_export_pdf_no_projects(client, auth_headers, consent_user_id_
 
 def test_portfolio_export_docx_with_project(client, auth_headers, seed_conn, consent_user_id_1):
     """Portfolio export includes seeded project."""
-    _seed_project(seed_conn, consent_user_id_1, "My Portfolio Project")
+    seed_project(seed_conn, consent_user_id_1, "My Portfolio Project")
 
     res = client.get("/portfolio/export/docx", headers=auth_headers)
     assert res.status_code == 200
@@ -168,7 +155,7 @@ def test_portfolio_export_docx_with_project(client, auth_headers, seed_conn, con
 
 def test_portfolio_export_pdf_with_project(client, auth_headers, seed_conn, consent_user_id_1):
     """Portfolio export includes seeded project."""
-    _seed_project(seed_conn, consent_user_id_1, "My Portfolio Project")
+    seed_project(seed_conn, consent_user_id_1, "My Portfolio Project")
 
     res = client.get("/portfolio/export/pdf", headers=auth_headers)
     assert res.status_code == 200

--- a/tests/api/test_thumbnails.py
+++ b/tests/api/test_thumbnails.py
@@ -1,0 +1,222 @@
+import io
+
+import pytest
+from PIL import Image
+
+from src.api.auth.security import create_access_token
+from tests.api.conftest import seed_project
+import src.services.thumbnails_service as thumbnails_service
+
+
+def _create_test_image(fmt: str = "PNG", size: tuple = (100, 100)) -> io.BytesIO:
+    img = Image.new("RGB", size, color=(255, 0, 0))
+    buf = io.BytesIO()
+    img.save(buf, format=fmt)
+    buf.seek(0)
+    return buf
+
+
+@pytest.fixture(autouse=True)
+def _patch_images_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(thumbnails_service, "IMAGES_DIR", tmp_path / "images")
+
+
+# ── Auth required ────────────────────────────────────────────────────
+
+def test_upload_requires_auth(client):
+    res = client.post("/projects/1/thumbnail")
+    assert res.status_code == 401
+
+
+def test_get_requires_auth(client):
+    res = client.get("/projects/1/thumbnail")
+    assert res.status_code == 401
+
+
+def test_delete_requires_auth(client):
+    res = client.delete("/projects/1/thumbnail")
+    assert res.status_code == 401
+
+
+# ── Project not found ────────────────────────────────────────────────
+
+def test_upload_project_not_found(client, auth_headers):
+    buf = _create_test_image()
+    res = client.post(
+        "/projects/999999/thumbnail",
+        headers=auth_headers,
+        files={"file": ("test.png", buf, "image/png")},
+    )
+    assert res.status_code == 404
+    assert "Project not found" in res.json()["detail"]
+
+
+def test_get_project_not_found(client, auth_headers):
+    res = client.get("/projects/999999/thumbnail", headers=auth_headers)
+    assert res.status_code == 404
+    assert "Project not found" in res.json()["detail"]
+
+
+def test_delete_project_not_found(client, auth_headers):
+    res = client.delete("/projects/999999/thumbnail", headers=auth_headers)
+    assert res.status_code == 404
+    assert "Project not found" in res.json()["detail"]
+
+
+# ── Invalid image upload ─────────────────────────────────────────────
+
+def test_upload_invalid_image(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "InvalidImgProject")
+    bad_bytes = io.BytesIO(b"not an image at all")
+    res = client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("bad.png", bad_bytes, "image/png")},
+    )
+    assert res.status_code == 422
+
+
+# ── Upload success ───────────────────────────────────────────────────
+
+def test_upload_png_success(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "PngProject")
+    buf = _create_test_image("PNG")
+    res = client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("photo.png", buf, "image/png")},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["project_id"] == project_id
+    assert body["data"]["project_name"] == "PngProject"
+
+
+def test_upload_jpg_success(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "JpgProject")
+    buf = _create_test_image("JPEG")
+    res = client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("photo.jpg", buf, "image/jpeg")},
+    )
+    assert res.status_code == 200
+    body = res.json()
+    assert body["success"] is True
+    assert body["data"]["project_name"] == "JpgProject"
+
+
+def test_upload_replaces_existing(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "ReplaceProject")
+
+    buf1 = _create_test_image("PNG", (50, 50))
+    client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("v1.png", buf1, "image/png")},
+    )
+
+    buf2 = _create_test_image("PNG", (80, 80))
+    res = client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("v2.png", buf2, "image/png")},
+    )
+    assert res.status_code == 200
+
+    get_res = client.get(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert get_res.status_code == 200
+
+
+# ── GET success ──────────────────────────────────────────────────────
+
+def test_get_thumbnail_success(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "GetProject")
+    buf = _create_test_image("PNG")
+    client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("img.png", buf, "image/png")},
+    )
+
+    res = client.get(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert res.status_code == 200
+    assert res.headers["content-type"] == "image/png"
+    # PNG magic bytes
+    assert res.content[:4] == b"\x89PNG"
+
+
+def test_get_thumbnail_not_exists(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "NoThumbProject")
+    res = client.get(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert res.status_code == 404
+    assert "Thumbnail not found" in res.json()["detail"]
+
+
+# ── DELETE ───────────────────────────────────────────────────────────
+
+def test_delete_thumbnail_success(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "DelProject")
+    buf = _create_test_image("PNG")
+    client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=auth_headers,
+        files={"file": ("img.png", buf, "image/png")},
+    )
+
+    res = client.delete(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert res.status_code == 200
+    assert res.json()["success"] is True
+
+    # GET should now 404
+    get_res = client.get(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert get_res.status_code == 404
+
+
+def test_delete_thumbnail_not_exists(client, auth_headers, seed_conn):
+    project_id = seed_project(seed_conn, 1, "NoThumbDel")
+    res = client.delete(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert res.status_code == 404
+    assert "Thumbnail not found" in res.json()["detail"]
+
+
+# ── Cross-user isolation ─────────────────────────────────────────────
+
+def test_cross_user_isolation(client, auth_headers, seed_conn, consent_user_id_2):
+    # User 2 creates a project with a thumbnail
+    project_id = seed_project(seed_conn, consent_user_id_2, "User2Project")
+
+    token2 = create_access_token(
+        secret="test-secret-key-for-testing",
+        user_id=consent_user_id_2,
+        username="new-user",
+        expires_minutes=60,
+    )
+    headers2 = {"Authorization": f"Bearer {token2}"}
+
+    buf = _create_test_image("PNG")
+    upload_res = client.post(
+        f"/projects/{project_id}/thumbnail",
+        headers=headers2,
+        files={"file": ("img.png", buf, "image/png")},
+    )
+    assert upload_res.status_code == 200
+
+    # User 1 cannot see user 2's thumbnail
+    res = client.get(
+        f"/projects/{project_id}/thumbnail", headers=auth_headers
+    )
+    assert res.status_code == 404

--- a/tests/test_portfolio_docx.py
+++ b/tests/test_portfolio_docx.py
@@ -159,6 +159,7 @@ def test_export_portfolio_docx_with_thumbnail_does_not_crash(monkeypatch, tmp_pa
         b"\x00\x00\x00\x00IEND\xaeB`\x82"
     )
 
+    monkeypatch.setattr(mod, "get_project_key", lambda *_args, **_kwargs: 1)
     monkeypatch.setattr(mod, "get_project_thumbnail_path", lambda *_args, **_kwargs: str(thumb_path))
 
     # UPDATED: exporter uses resolvers
@@ -215,6 +216,7 @@ def test_export_portfolio_docx_thumbnail_removed_still_exports(monkeypatch, tmp_
     monkeypatch.setattr(mod, "resolve_portfolio_contribution_bullets", lambda *_args, **_kwargs: ["ok"])
 
     # 1) With thumbnail
+    monkeypatch.setattr(mod, "get_project_key", lambda *_args, **_kwargs: 1)
     thumb_path = tmp_path / "thumb.png"
     thumb_path.write_bytes(
         b"\x89PNG\r\n\x1a\n"

--- a/tests/test_portfolio_pdf.py
+++ b/tests/test_portfolio_pdf.py
@@ -179,6 +179,7 @@ def test_export_portfolio_pdf_with_thumbnail_does_not_crash(monkeypatch, tmp_pat
     monkeypatch.setattr(mod, "get_project_summary_row", lambda *_args, **_kwargs: fake_row)
 
     # Pretend a thumbnail exists
+    monkeypatch.setattr(mod, "get_project_key", lambda *_args, **_kwargs: 1)
     thumb_path = tmp_path / "thumb.png"
     thumb_path.write_text("not-a-real-image")  # doesn't matter; we won't decode it
     monkeypatch.setattr(mod, "get_project_thumbnail_path", lambda *_args, **_kwargs: str(thumb_path))
@@ -257,6 +258,7 @@ def test_export_portfolio_pdf_thumbnail_removed_still_exports(monkeypatch, tmp_p
     monkeypatch.setattr(mod, "_load_image_preserve_aspect", fake_loader)
 
     # 1) With thumbnail
+    monkeypatch.setattr(mod, "get_project_key", lambda *_args, **_kwargs: 1)
     thumb_path = tmp_path / "thumb.png"
     thumb_path.write_text("not-a-real-image")
     monkeypatch.setattr(mod, "get_project_thumbnail_path", lambda *_args, **_kwargs: str(thumb_path))


### PR DESCRIPTION
## 📝 Description

Adds REST API endpoints for managing project thumbnails (upload, view, delete) and fixes a bug where thumbnails were not appearing in portfolio exports (DOCX/PDF).

The thumbnail system already existed for CLI and DB layers but had no API surface. This wires up the existing DB helpers and image utilities through a service layer and FastAPI routes. Also extracts a shared `seed_project()` test helper to eliminate duplication across 4 test files.

**Closes:** #479

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring

---

## 🧪 Testing

Automated: `pytest tests/ -v` (1021 tests passing, 15 new thumbnail API tests)

**API thumbnail endpoints:**

1. Register and login:
```bash
curl -s -X POST http://localhost:8000/auth/register \
  -H "Content-Type: application/json" \
  -d '{"username":"thumbtest","password":"ThumbTest1"}'

TOKEN=$(curl -s -X POST http://localhost:8000/auth/login \
  -H "Content-Type: application/json" \
  -d '{"username":"thumbtest","password":"ThumbTest1"}' | python3 -c "import sys,json; print(json.load(sys.stdin)['access_token'])")
```

**Setup (CLI):** Analyze a project through the CLI so you have at least one project in the system. Add a thumbnail to it via main menu option 10 ("Manage project thumbnails").

2. Upload a thumbnail (replace `{project_id}` with a real ID from `GET /projects`):
```bash
curl -s -X POST "http://localhost:8000/projects/{project_id}/thumbnail" \
  -H "Authorization: Bearer $TOKEN" \
  -F "file=@path/to/image.png" | python3 -m json.tool
```
Expected: `200` with `{"success": true, "data": {"project_id": ..., "project_name": ..., "message": "Thumbnail uploaded successfully"}}`

Note: POST acts as an upsert, so calling it again with a different image replaces the existing thumbnail. No separate edit/replace endpoint is needed.

3. Get the thumbnail:
```bash
curl -i "http://localhost:8000/projects/{project_id}/thumbnail" \
  -H "Authorization: Bearer $TOKEN"
```
Expected: `200` with `content-type: image/png`

4. Delete the thumbnail:
```bash
curl -s -X DELETE "http://localhost:8000/projects/{project_id}/thumbnail" \
  -H "Authorization: Bearer $TOKEN" | python3 -m json.tool
```
Expected: `200` with `{"success": true, "data": null}`

Verify portfolio DOCX/PDF exports now include thumbnails

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

POST thumbnail:
<img width="590" height="611" alt="Screenshot 2026-02-11 at 8 48 43 PM" src="https://github.com/user-attachments/assets/e8fd994b-c41a-4f80-8091-d11b9a7425a1" />

GET thumbnail: 
<img width="873" height="624" alt="Screenshot 2026-02-11 at 8 49 04 PM" src="https://github.com/user-attachments/assets/10f9b729-1232-4bb9-953f-ee8c49723c74" />

Export portfolio:
<img width="1083" height="702" alt="Screenshot 2026-02-11 at 8 58 38 PM" src="https://github.com/user-attachments/assets/2a4f630c-a3ad-45f0-ba2f-d571fca57041" />

</details>