### PR TITLE
Api/summaries

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -841,7 +841,6 @@ A typical flow for the first six endpoints:
     - `422 Unprocessable Entity` if any relpath is unsafe (e.g. contains `..`) or if the list includes the main file or any `.csv`
     - `404 Not Found` if any relpath does not exist for this project/upload
 
-
 - **Set Supporting CSV Files (Collaborative Text Contribution)**
     - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/supporting-csv-files`
     - **Description**: Stores which **CSV files** the user contributed to.
@@ -866,6 +865,54 @@ A typical flow for the first six endpoints:
         - `409 Conflict` if upload is not in a file-picking step (e.g. not `needs_file_roles` / `needs_summaries`)
         - `422 Unprocessable Entity` if any relpath is unsafe, or if any relpath is not a `.csv`
         - `404 Not Found` if any relpath does not exist for this project/upload
+
+- **Manual Project Summary**
+  - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/manual-project-summary`
+  - **Description**: Stores a user-provided manual project summary for this upload session.
+    - Writes to: `uploads.state.manual_project_summaries[project_name]`
+  - **Auth**: `Authorization: Bearer <access_token>`
+  - **Path Params**:
+    - `{upload_id}` (integer, required): The upload session ID
+    - `{project_name}` (string, required): The project name
+  - **Request DTO**: `ManualProjectSummaryRequestDTO`
+  - **Request Body**:
+    ```json
+    {
+      "summary_text": "Built a pipeline to ..., improved ..., shipped ..."
+    }
+    ```
+  - **Response Status**: `200 OK`
+  - **Response DTO**: `UploadDTO`
+  - **Error Responses**:
+    - `404 Not Found` if upload or project is not found / does not belong to user
+    - `409 Conflict` if upload is not in a summary-allowed status (must be `needs_summaries`, or if enabled: `analyzing`/`done`)
+
+- **Manual Contribution Summary**
+  - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/manual-contribution-summary`
+  - **Description**: Stores a user-provided manual contribution summary for this upload session.
+    - Writes to: `uploads.state.contributions[project_name].manual_contribution_summary`
+  - **Auth**: `Authorization: Bearer <access_token>`
+  - **Path Params**:
+    - `{upload_id}` (integer, required): The upload session ID
+    - `{project_name}` (string, required): The project name
+  - **Request DTO**: `ManualContributionSummaryRequestDTO`
+  - **Request Body (minimum)**:
+    ```json
+    {
+      "manual_contribution_summary": "I implemented ..., fixed ..., added tests ..."
+    }
+    ```
+  - **Request Body (with optional role)**:
+    ```json
+    {
+      "manual_contribution_summary": "I implemented ..., fixed ..., added tests ...",
+    }
+    ```
+  - **Response Status**: `200 OK`
+  - **Response DTO**: `UploadDTO`
+  - **Error Responses**:
+    - `404 Not Found` if upload or project is not found / does not belong to user
+    - `409 Conflict` if upload is not in a summary-allowed status (must be `needs_summaries`, or if enabled: `analyzing`/`done`)
 ---
 
 ## **GitHub Integration**
@@ -1848,6 +1895,11 @@ Example:
 - **SupportingFilesRequest**
     - `relpaths` (List[string], required): relpaths returned by `GET .../files`
 
+- **ManualProjectSummaryRequestDTO**
+  - `summary_text` (string, required): User-provided manual project summary text
+
+- **ManualContributionSummaryRequestDTO**
+  - `manual_contribution_summary` (string, required): User-provided manual contribution summary text (what you did)
 
 ### **Skills DTOs**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -896,16 +896,10 @@ A typical flow for the first six endpoints:
     - `{upload_id}` (integer, required): The upload session ID
     - `{project_name}` (string, required): The project name
   - **Request DTO**: `ManualContributionSummaryRequestDTO`
-  - **Request Body (minimum)**:
+  - **Request Body**:
     ```json
     {
-      "manual_contribution_summary": "I implemented ..., fixed ..., added tests ..."
-    }
-    ```
-  - **Request Body (with optional role)**:
-    ```json
-    {
-      "manual_contribution_summary": "I implemented ..., fixed ..., added tests ...",
+      "manual_contribution_summary": "I implemented ..., fixed ..., added tests ..., or keep it empty if you'd like"
     }
     ```
   - **Response Status**: `200 OK`

--- a/docs/API.md
+++ b/docs/API.md
@@ -867,7 +867,7 @@ A typical flow for the first six endpoints:
         - `404 Not Found` if any relpath does not exist for this project/upload
 
 - **Manual Project Summary**
-  - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/manual-project-summary`
+  - **Endpoint**: `POST /{upload_id}/projects/{project_name}/manual-project-summary`
   - **Description**: Stores a user-provided manual project summary for this upload session.
     - Writes to: `uploads.state.manual_project_summaries[project_name]`
   - **Auth**: `Authorization: Bearer <access_token>`
@@ -888,7 +888,7 @@ A typical flow for the first six endpoints:
     - `409 Conflict` if upload is not in a summary-allowed status (must be `needs_summaries`, or if enabled: `analyzing`/`done`)
 
 - **Manual Contribution Summary**
-  - **Endpoint**: `POST /projects/upload/{upload_id}/projects/{project_name}/manual-contribution-summary`
+  - **Endpoint**: `POST /{upload_id}/projects/{project_name}/manual-contribution-summary`
   - **Description**: Stores a user-provided manual contribution summary for this upload session.
     - Writes to: `uploads.state.contributions[project_name].manual_contribution_summary`
   - **Auth**: `Authorization: Bearer <access_token>`

--- a/src/analysis/text_collaborative/text_collab_analysis.py
+++ b/src/analysis/text_collaborative/text_collab_analysis.py
@@ -142,7 +142,7 @@ def analyze_collaborative_text_project(
     user_sections = [sections[i - 1] for i in indices]
 
     # ---------------------------------------------------------
-    # STEP 2A — Ask for contribution description (like code projects)
+    # STEP 2A — Ask for contribution description
     # ---------------------------------------------------------
     print("\nDescribe your personal contributions to this collaborative text project.")
     print("Write 1-3 sentences. Be specific about sections/content you primarily worked on.")
@@ -322,7 +322,7 @@ def analyze_collaborative_text_project(
             full_main_text, contributed_text
         )
     else:
-        contribution_summary = _manual_contribution_summary_prompt()
+        contribution_summary = contribution_desc or "[No manual contribution summary provided]"
 
     if constants.VERBOSE:
         print("\n" + "="*80)
@@ -408,24 +408,3 @@ def _load_main_text(parsed_files, main_file_name, zip_path, conn, user_id):
 
     path = os.path.join(base_path, match["file_path"])
     return extract_text_file(path, conn, user_id) or ""
-
-
-def _manual_contribution_summary_prompt():
-    """Manual first-person contribution statement."""
-    print("\nLLM consent not granted. Please describe your contributions.\n")
-    print("What types of contribution did you make?")
-    options = [
-        "Writing", "Editing", "Research", "Formatting",
-        "Proofreading", "Data Analysis", "Drafting", "Revising"
-    ]
-    for i, opt in enumerate(options, start=1):
-        print(f"{i}. {opt}")
-
-    nums = input("Enter numbers (comma-separated): ").strip()
-    selected = [options[int(n.strip()) - 1] for n in nums.split(",") if n.strip().isdigit()]
-
-    if not selected:
-        return "I contributed to the project, but did not specify the type of work."
-
-    joined = ", ".join(selected)
-    return f"I contributed by {joined.lower()}."

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -14,6 +14,8 @@ from src.api.schemas.uploads import (
     MainFileRequestDTO,
     MainFileSectionsResponseDTO,
     ContributedSectionsRequestDTO,
+    ManualProjectSummaryRequestDTO,
+    ManualContributionSummaryRequestDTO,
 )
 from src.api.schemas.git_identities import (
     GitIdentitiesResponse,
@@ -48,6 +50,10 @@ from src.services.uploads_supporting_contributions_service import (
 from src.services.uploads_contribution_service import (
     list_main_file_sections,
     set_main_file_contributed_sections,
+)
+from src.services.uploads_manual_summaries_service import (
+    set_manual_project_summary,
+    set_manual_contribution_summary,
 )
 
 router = APIRouter(prefix="/projects", tags=["projects"])
@@ -294,3 +300,39 @@ def delete_single_project(
     if not deleted:
         raise HTTPException(status_code=404, detail="Project not found")
     return ApiResponse(success=True, data=None, error=None)
+
+
+@router.post(
+    "/upload/{upload_id}/projects/{project_name}/manual-project-summary",
+    response_model=ApiResponse[UploadDTO],
+)
+def post_manual_project_summary(
+    upload_id: int,
+    project_name: str,
+    body: ManualProjectSummaryRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = set_manual_project_summary(conn, user_id, upload_id, project_name, body.summary_text)
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+
+
+@router.post(
+    "/upload/{upload_id}/projects/{project_name}/manual-contribution-summary",
+    response_model=ApiResponse[UploadDTO],
+)
+def post_manual_contribution_summary(
+    upload_id: int,
+    project_name: str,
+    body: ManualContributionSummaryRequestDTO,
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    upload = set_manual_contribution_summary(
+        conn,
+        user_id,
+        upload_id,
+        project_name,
+        body.manual_contribution_summary,    )
+    return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
+

--- a/src/api/routes/projects.py
+++ b/src/api/routes/projects.py
@@ -303,27 +303,27 @@ def delete_single_project(
 
 
 @router.post(
-    "/upload/{upload_id}/projects/{project_name}/manual-project-summary",
+    "/upload/{upload_id}/projects/{project_key:int}/manual-project-summary",
     response_model=ApiResponse[UploadDTO],
 )
 def post_manual_project_summary(
     upload_id: int,
-    project_name: str,
+    project_key: int,
     body: ManualProjectSummaryRequestDTO,
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
 ):
-    upload = set_manual_project_summary(conn, user_id, upload_id, project_name, body.summary_text)
+    upload = set_manual_project_summary(conn, user_id, upload_id, project_key, body.summary_text)
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
 
 
 @router.post(
-    "/upload/{upload_id}/projects/{project_name}/manual-contribution-summary",
+    "/upload/{upload_id}/projects/{project_key:int}/manual-contribution-summary",
     response_model=ApiResponse[UploadDTO],
 )
 def post_manual_contribution_summary(
     upload_id: int,
-    project_name: str,
+    project_key: int,
     body: ManualContributionSummaryRequestDTO,
     user_id: int = Depends(get_current_user_id),
     conn: Connection = Depends(get_db),
@@ -332,7 +332,7 @@ def post_manual_contribution_summary(
         conn,
         user_id,
         upload_id,
-        project_name,
-        body.manual_contribution_summary,    )
+        project_key,
+        body.manual_contribution_summary,
+    )
     return ApiResponse(success=True, data=UploadDTO(**upload), error=None)
-

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -70,4 +70,3 @@ class ManualProjectSummaryRequestDTO(BaseModel):
 
 class ManualContributionSummaryRequestDTO(BaseModel):
     manual_contribution_summary: str = ""
-    key_role: Optional[str] = None

--- a/src/api/schemas/uploads.py
+++ b/src/api/schemas/uploads.py
@@ -64,3 +64,10 @@ class MainFileSectionsResponseDTO(BaseModel):
 
 class ContributedSectionsRequestDTO(BaseModel):
     selected_section_ids: List[int]
+
+class ManualProjectSummaryRequestDTO(BaseModel):
+    summary_text: str = ""
+
+class ManualContributionSummaryRequestDTO(BaseModel):
+    manual_contribution_summary: str = ""
+    key_role: Optional[str] = None

--- a/src/services/uploads_manual_summaries_service.py
+++ b/src/services/uploads_manual_summaries_service.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import sqlite3
+from fastapi import HTTPException
+
+from src.db.uploads import get_upload_by_id, patch_upload_state
+
+
+_ALLOWED_STATUSES = {"needs_summaries", "analyzing", "done"}
+
+
+def set_manual_project_summary(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    summary_text: str,
+) -> dict:
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload)
+
+    state = upload.get("state") or {}
+    _require_project_in_upload(state, project_name)
+
+    text = (summary_text or "").strip() or "[No manual project summary provided]"
+
+    manual = dict(state.get("manual_project_summaries") or {})
+    manual[project_name] = text
+
+    new_state = patch_upload_state(
+        conn,
+        upload["upload_id"],
+        patch={"manual_project_summaries": manual},
+        status=upload["status"],
+    )
+
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+def set_manual_contribution_summary(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    manual_contribution_summary: str,
+    key_role: str | None = None,
+) -> dict:
+    upload = _require_upload(conn, user_id, upload_id)
+    _require_status(upload)
+
+    state = upload.get("state") or {}
+    _require_project_in_upload(state, project_name)
+
+    desc = (manual_contribution_summary or "").strip() or "[No description provided]"
+
+    contributions = dict(state.get("contributions") or {})
+    proj = dict(contributions.get(project_name) or {})
+    proj["manual_contribution_summary"] = desc
+
+    if key_role is not None:
+        kr = (key_role or "").strip()
+        if kr:
+            proj["key_role"] = kr
+
+    contributions[project_name] = proj
+
+    new_state = patch_upload_state(
+        conn,
+        upload["upload_id"],
+        patch={"contributions": contributions},
+        status=upload["status"],
+    )
+
+    return {
+        "upload_id": upload["upload_id"],
+        "status": upload["status"],
+        "zip_name": upload.get("zip_name"),
+        "state": new_state,
+    }
+
+
+# -----------------------
+# helpers
+# -----------------------
+def _require_upload(conn: sqlite3.Connection, user_id: int, upload_id: int) -> dict:
+    upload = get_upload_by_id(conn, upload_id)
+    if not upload or upload["user_id"] != user_id:
+        raise HTTPException(status_code=404, detail="Upload not found")
+    return upload
+
+
+def _require_status(upload: dict) -> None:
+    status = upload.get("status")
+    if status not in _ALLOWED_STATUSES:
+        raise HTTPException(status_code=409, detail=f"Upload not ready for summaries (status={status})")
+
+
+def _require_project_in_upload(state: dict, project_name: str) -> None:
+    layout = state.get("layout") or {}
+    known = set((layout.get("auto_assignments") or {}).keys()) | set(layout.get("pending_projects") or [])
+    if project_name not in known:
+        raise HTTPException(
+            status_code=404,
+            detail={"message": "Project not found in this upload", "project_name": project_name},
+        )

--- a/src/services/uploads_manual_summaries_service.py
+++ b/src/services/uploads_manual_summaries_service.py
@@ -48,7 +48,6 @@ def set_manual_contribution_summary(
     upload_id: int,
     project_name: str,
     manual_contribution_summary: str,
-    key_role: str | None = None,
 ) -> dict:
     upload = _require_upload(conn, user_id, upload_id)
     _require_status(upload)
@@ -61,11 +60,6 @@ def set_manual_contribution_summary(
     contributions = dict(state.get("contributions") or {})
     proj = dict(contributions.get(project_name) or {})
     proj["manual_contribution_summary"] = desc
-
-    if key_role is not None:
-        kr = (key_role or "").strip()
-        if kr:
-            proj["key_role"] = kr
 
     contributions[project_name] = proj
 

--- a/src/services/uploads_manual_summaries_service.py
+++ b/src/services/uploads_manual_summaries_service.py
@@ -13,32 +13,42 @@ def set_manual_project_summary(
     conn: sqlite3.Connection,
     user_id: int,
     upload_id: int,
-    project_name: str,
+    project_key: int,
     summary_text: str,
 ) -> dict:
     upload = _require_upload(conn, user_id, upload_id)
     _require_status(upload)
 
     state = upload.get("state") or {}
-    _require_project_in_upload(state, project_name)
+    _require_project_key_in_upload(state, project_key)
 
     text = (summary_text or "").strip() or "[No manual project summary provided]"
 
     manual = dict(state.get("manual_project_summaries") or {})
-    manual[project_name] = text
+    manual[str(project_key)] = text
 
-    new_state = patch_upload_state(
+    patched_state = patch_upload_state(
         conn,
         upload["upload_id"],
         patch={"manual_project_summaries": manual},
         status=upload["status"],
     )
 
+    new_status = _maybe_advance_status_after_summaries(upload["status"], patched_state)
+
+    if new_status != upload["status"]:
+        patched_state = patch_upload_state(
+            conn,
+            upload["upload_id"],
+            patch={},
+            status=new_status,
+        )
+
     return {
         "upload_id": upload["upload_id"],
-        "status": upload["status"],
+        "status": new_status,
         "zip_name": upload.get("zip_name"),
-        "state": new_state,
+        "state": patched_state,
     }
 
 
@@ -46,41 +56,51 @@ def set_manual_contribution_summary(
     conn: sqlite3.Connection,
     user_id: int,
     upload_id: int,
-    project_name: str,
+    project_key: int,
     manual_contribution_summary: str,
 ) -> dict:
     upload = _require_upload(conn, user_id, upload_id)
     _require_status(upload)
 
     state = upload.get("state") or {}
-    _require_project_in_upload(state, project_name)
+    _require_project_key_in_upload(state, project_key)
 
     desc = (manual_contribution_summary or "").strip() or "[No description provided]"
 
     contributions = dict(state.get("contributions") or {})
-    proj = dict(contributions.get(project_name) or {})
+    proj = dict(contributions.get(str(project_key)) or {})
     proj["manual_contribution_summary"] = desc
+    contributions[str(project_key)] = proj
 
-    contributions[project_name] = proj
-
-    new_state = patch_upload_state(
+    patched_state = patch_upload_state(
         conn,
         upload["upload_id"],
         patch={"contributions": contributions},
         status=upload["status"],
     )
 
+    new_status = _maybe_advance_status_after_summaries(upload["status"], patched_state)
+
+    if new_status != upload["status"]:
+        patched_state = patch_upload_state(
+            conn,
+            upload["upload_id"],
+            patch={},
+            status=new_status,
+        )
+
     return {
         "upload_id": upload["upload_id"],
-        "status": upload["status"],
+        "status": new_status,
         "zip_name": upload.get("zip_name"),
-        "state": new_state,
+        "state": patched_state,
     }
 
 
 # -----------------------
 # helpers
 # -----------------------
+
 def _require_upload(conn: sqlite3.Connection, user_id: int, upload_id: int) -> dict:
     upload = get_upload_by_id(conn, upload_id)
     if not upload or upload["user_id"] != user_id:
@@ -94,11 +114,41 @@ def _require_status(upload: dict) -> None:
         raise HTTPException(status_code=409, detail=f"Upload not ready for summaries (status={status})")
 
 
-def _require_project_in_upload(state: dict, project_name: str) -> None:
-    layout = state.get("layout") or {}
-    known = set((layout.get("auto_assignments") or {}).keys()) | set(layout.get("pending_projects") or [])
-    if project_name not in known:
+def _require_project_key_in_upload(state: dict, project_key: int) -> None:
+    required = state.get("summaries_required_project_keys") or []
+    required_set = set(str(x) for x in required)
+
+    # If you didn’t store the required list yet, we fail loudly so it doesn’t silently pass wrong keys.
+    if not required_set:
+        raise HTTPException(
+            status_code=409,
+            detail="Upload missing summaries_required_project_keys (wizard transition must set this).",
+        )
+
+    if str(project_key) not in required_set:
         raise HTTPException(
             status_code=404,
-            detail={"message": "Project not found in this upload", "project_name": project_name},
+            detail={"message": "Project not found in this upload summaries scope", "project_key": project_key},
         )
+
+
+def _maybe_advance_status_after_summaries(current_status: str, state: dict) -> str:
+    # Only advance from needs_summaries. If you're already analyzing/done, keep it.
+    if current_status != "needs_summaries":
+        return current_status
+
+    required = state.get("summaries_required_project_keys") or []
+    required_keys = [str(x) for x in required]
+
+    manual_projects = state.get("manual_project_summaries") or {}
+    contributions = state.get("contributions") or {}
+
+    for pk in required_keys:
+        proj_summary_ok = isinstance(manual_projects.get(pk), str) and manual_projects.get(pk).strip() != ""
+        contrib_obj = contributions.get(pk) or {}
+        contrib_summary_ok = isinstance(contrib_obj.get("manual_contribution_summary"), str) and contrib_obj.get("manual_contribution_summary").strip() != ""
+        if not (proj_summary_ok and contrib_summary_ok):
+            return current_status
+
+    # All required project keys have both summaries
+    return "analyzing"

--- a/src/services/uploads_supporting_contributions_service.py
+++ b/src/services/uploads_supporting_contributions_service.py
@@ -46,10 +46,22 @@ def set_project_supporting_text_files(
     proj["supporting_text_relpaths"] = sorted(selected)
     contributions[project_name] = proj
 
-    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+    patch = {"contributions": contributions}
+
+    next_status = _advance_to_needs_summaries(
+        conn,
+        user_id,
+        upload_id,
+        upload,
+        state=state,
+        contributions_patch=contributions,
+    )
+
+
+    new_state = patch_upload_state(conn, upload_id, patch=patch, status=next_status)
     return {
         "upload_id": upload["upload_id"],
-        "status": upload["status"],
+        "status": next_status,
         "zip_name": upload.get("zip_name"),
         "state": new_state,
     }
@@ -86,10 +98,21 @@ def set_project_supporting_csv_files(
     proj["supporting_csv_relpaths"] = sorted(selected)
     contributions[project_name] = proj
 
-    new_state = patch_upload_state(conn, upload_id, patch={"contributions": contributions}, status=upload["status"])
+    patch = {"contributions": contributions}
+
+    next_status = _advance_to_needs_summaries(
+        conn,
+        user_id,
+        upload_id,
+        upload,
+        state=state,
+        contributions_patch=contributions,
+    )
+
+    new_state = patch_upload_state(conn, upload_id, patch=patch, status=next_status)
     return {
         "upload_id": upload["upload_id"],
-        "status": upload["status"],
+        "status": next_status,
         "zip_name": upload.get("zip_name"),
         "state": new_state,
     }
@@ -149,3 +172,108 @@ def _allowed_csv_relpaths(files_payload: dict) -> set[str]:
         if rp:
             allowed.add(rp)
     return allowed
+
+def _project_type_for_upload(state: dict, project_name: str) -> str | None:
+    """
+    Prefer manual project type over auto type for this upload.
+    Returns "code" | "text" | None
+    """
+    types_manual = state.get("project_types_manual") or {}
+    t = types_manual.get(project_name)
+    if isinstance(t, str) and t:
+        return t
+
+    types_auto = state.get("project_types_auto") or {}
+    t = types_auto.get(project_name)
+    if isinstance(t, str) and t:
+        return t
+
+    return None
+
+
+def _supporting_requirements_for_project(
+    *,
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    project_name: str,
+    main_file_relpath: str,
+) -> tuple[bool, bool]:
+    """
+    Returns (needs_supporting_text_step, needs_supporting_csv_step)
+    based on whether the project actually has candidates.
+    """
+    files_payload = list_project_files(conn, user_id, upload_id, project_name)
+
+    allowed_text = _allowed_supporting_text_relpaths(files_payload, main_file_relpath)
+    allowed_csv = _allowed_csv_relpaths(files_payload)
+
+    needs_text = bool(allowed_text)   # only if there are supporting text candidates
+    needs_csv = bool(allowed_csv)     # only if there are csv candidates
+    return needs_text, needs_csv
+
+
+def _advance_to_needs_summaries(
+    conn: sqlite3.Connection,
+    user_id: int,
+    upload_id: int,
+    upload: dict,
+    *,
+    state: dict,
+    contributions_patch: dict,
+) -> str:
+    """
+    If we're currently in needs_file_roles, and all collaborative TEXT projects
+    have completed the required file-role steps, advance to needs_summaries.
+
+    Rule:
+    - If project has CSV candidates -> must complete CSV supporting selection step (key exists)
+    - If project has supporting text candidates -> must complete text supporting selection step (key exists)
+    - If no candidates for a step -> step not required
+    """
+    cur = upload.get("status")
+    if cur != "needs_file_roles":
+        return cur
+
+    layout = state.get("layout") or {}
+    classifications = state.get("classifications") or {}
+
+    known_projects = set((layout.get("auto_assignments") or {}).keys()) | set(layout.get("pending_projects") or [])
+    if not known_projects:
+        return cur
+
+    for pname in sorted(known_projects):
+        if (classifications.get(pname) or "") != "collaborative":
+            continue
+
+        ptype = _project_type_for_upload(state, pname)
+        if ptype != "text":
+            continue
+
+        # must have selected a main file
+        file_roles = (state.get("file_roles") or {}).get(pname) or {}
+        main_file = file_roles.get("main_file")
+        if not main_file:
+            return cur
+
+        proj_contrib = (contributions_patch or {}).get(pname) or {}
+
+        # must have completed section selection step (key exists; list can be empty)
+        if "main_section_ids" not in proj_contrib:
+            return cur
+
+        needs_text, needs_csv = _supporting_requirements_for_project(
+            conn=conn,
+            user_id=user_id,
+            upload_id=upload_id,
+            project_name=pname,
+            main_file_relpath=main_file,
+        )
+
+        if needs_text and ("supporting_text_relpaths" not in proj_contrib):
+            return cur
+
+        if needs_csv and ("supporting_csv_relpaths" not in proj_contrib):
+            return cur
+
+    return "needs_summaries"

--- a/src/services/uploads_supporting_contributions_service.py
+++ b/src/services/uploads_supporting_contributions_service.py
@@ -6,6 +6,7 @@ from typing import Iterable
 from fastapi import HTTPException
 
 from src.db.uploads import get_upload_by_id, patch_upload_state
+from src.db.projects import get_project_key
 from src.services.uploads_service import list_project_files
 from src.services.uploads_file_roles_util import safe_relpath
 
@@ -46,8 +47,6 @@ def set_project_supporting_text_files(
     proj["supporting_text_relpaths"] = sorted(selected)
     contributions[project_name] = proj
 
-    patch = {"contributions": contributions}
-
     next_status = _advance_to_needs_summaries(
         conn,
         user_id,
@@ -57,6 +56,11 @@ def set_project_supporting_text_files(
         contributions_patch=contributions,
     )
 
+    patch: dict = {"contributions": contributions}
+
+    # If we just advanced into needs_summaries, set required keys + copy name-keyed contributions to key-keyed buckets.
+    if upload.get("status") == "needs_file_roles" and next_status == "needs_summaries":
+        patch.update(_build_summaries_transition_patch(conn, user_id, state, contributions))
 
     new_state = patch_upload_state(conn, upload_id, patch=patch, status=next_status)
     return {
@@ -98,8 +102,6 @@ def set_project_supporting_csv_files(
     proj["supporting_csv_relpaths"] = sorted(selected)
     contributions[project_name] = proj
 
-    patch = {"contributions": contributions}
-
     next_status = _advance_to_needs_summaries(
         conn,
         user_id,
@@ -108,6 +110,12 @@ def set_project_supporting_csv_files(
         state=state,
         contributions_patch=contributions,
     )
+
+    patch: dict = {"contributions": contributions}
+
+    # If we just advanced into needs_summaries, set required keys + copy name-keyed contributions to key-keyed buckets.
+    if upload.get("status") == "needs_file_roles" and next_status == "needs_summaries":
+        patch.update(_build_summaries_transition_patch(conn, user_id, state, contributions))
 
     new_state = patch_upload_state(conn, upload_id, patch=patch, status=next_status)
     return {
@@ -140,7 +148,10 @@ def _get_main_file_relpath(state: dict, project_name: str) -> str:
     if not main_file:
         raise HTTPException(
             status_code=409,
-            detail={"message": "Main file must be selected before choosing supporting text files", "project_name": project_name},
+            detail={
+                "message": "Main file must be selected before choosing supporting text files",
+                "project_name": project_name,
+            },
         )
     return main_file
 
@@ -172,6 +183,7 @@ def _allowed_csv_relpaths(files_payload: dict) -> set[str]:
         if rp:
             allowed.add(rp)
     return allowed
+
 
 def _project_type_for_upload(state: dict, project_name: str) -> str | None:
     """
@@ -208,9 +220,59 @@ def _supporting_requirements_for_project(
     allowed_text = _allowed_supporting_text_relpaths(files_payload, main_file_relpath)
     allowed_csv = _allowed_csv_relpaths(files_payload)
 
-    needs_text = bool(allowed_text)   # only if there are supporting text candidates
-    needs_csv = bool(allowed_csv)     # only if there are csv candidates
+    needs_text = bool(allowed_text)  # only if there are supporting text candidates
+    needs_csv = bool(allowed_csv)    # only if there are csv candidates
     return needs_text, needs_csv
+
+
+def _build_summaries_transition_patch(
+    conn: sqlite3.Connection,
+    user_id: int,
+    state: dict,
+    contributions: dict,
+) -> dict:
+    """
+    When entering needs_summaries, store:
+      - summaries_required_project_keys: list[int] of project_keys that require summaries (collaborative text projects)
+      - copy name-keyed contributions into key-keyed contributions buckets so manual summaries can live there
+    """
+    layout = state.get("layout") or {}
+    classifications = state.get("classifications") or {}
+
+    known_projects = set((layout.get("auto_assignments") or {}).keys()) | set(layout.get("pending_projects") or [])
+    required_keys: list[int] = []
+
+    # Copy contributions into project_key-keyed buckets (do NOT delete old keys).
+    # This avoids breaking any UI that still reads name-keyed contributions.
+    for pname in sorted(known_projects):
+        if (classifications.get(pname) or "") != "collaborative":
+            continue
+        if _project_type_for_upload(state, pname) != "text":
+            continue
+
+        pk = get_project_key(conn, user_id, pname)
+        if pk is None:
+            # Should not happen after dedup/version registration, but keep wizard stable.
+            continue
+
+        required_keys.append(int(pk))
+
+        # Merge name-keyed contrib into key-keyed contrib
+        name_obj = dict(contributions.get(pname) or {})
+        if not name_obj:
+            continue
+
+        pk_key = str(int(pk))
+        existing_pk_obj = dict(contributions.get(pk_key) or {})
+        merged = dict(existing_pk_obj)
+        merged.update(name_obj)
+        contributions[pk_key] = merged
+
+    patch = {
+        "summaries_required_project_keys": sorted(set(required_keys)),
+        "contributions": contributions,
+    }
+    return patch
 
 
 def _advance_to_needs_summaries(

--- a/tests/api/test_uploads_manual_summaries.py
+++ b/tests/api/test_uploads_manual_summaries.py
@@ -1,0 +1,122 @@
+import pytest
+
+from .test_uploads_wizard import _make_zip_bytes
+from .test_uploads_file_roles import _advance_to_needs_file_roles, _cleanup_upload_artifacts
+
+PROJECT = "ProjectA"
+
+
+def build_zip_no_csv(project: str = PROJECT) -> bytes:
+    # No CSVs on purpose -> supporting TEXT selection should be enough to advance to needs_summaries
+    return _make_zip_bytes(
+        {
+            f"{project}/main_report.txt": "Main report content.\nIntro...\n",
+            f"{project}/reading_notes.txt": "Notes...\n",
+        }
+    )
+
+
+def get_upload_state(client, auth_headers, upload_id: int) -> dict:
+    res = client.get(f"/projects/upload/{upload_id}", headers=auth_headers)
+    assert res.status_code == 200
+    return res.json()["data"].get("state") or {}
+
+
+def get_files_payload(client, auth_headers, upload_id: int, project: str) -> dict:
+    res = client.get(
+        f"/projects/upload/{upload_id}/projects/{project}/files",
+        headers=auth_headers,
+    )
+    assert res.status_code == 200
+    return res.json()["data"]
+
+
+def pick_relpath_by_filename(files: list[dict], filename: str) -> str:
+    for f in files:
+        if (f.get("file_name") or "") == filename:
+            rp = f.get("relpath")
+            if isinstance(rp, str) and rp:
+                return rp
+    raise AssertionError(f"Could not find relpath for filename={filename}")
+
+
+def setup_upload_to_needs_summaries_no_csv(client, auth_headers, zip_bytes: bytes, project: str = PROJECT) -> int:
+    """
+    Advances the wizard to needs_summaries for a project with NO CSV files:
+    - upload -> needs_file_roles
+    - set main file
+    - set supporting text files (should transition status -> needs_summaries)
+    Returns upload_id
+    """
+    upload = _advance_to_needs_file_roles(client, auth_headers, zip_bytes)
+    upload_id = upload["upload_id"]
+
+    files_payload = get_files_payload(client, auth_headers, upload_id, project)
+
+    main_relpath = pick_relpath_by_filename(files_payload["all_files"], "main_report.txt")
+    supporting_relpath = pick_relpath_by_filename(files_payload["all_files"], "reading_notes.txt")
+
+    # set main file
+    res_main = client.post(
+        f"/projects/upload/{upload_id}/projects/{project}/main-file",
+        headers=auth_headers,
+        json={"relpath": main_relpath},
+    )
+    assert res_main.status_code == 200
+
+    # set supporting text files -> should move to needs_summaries (no CSVs exist)
+    res_support = client.post(
+        f"/projects/upload/{upload_id}/projects/{project}/supporting-text-files",
+        headers=auth_headers,
+        json={"relpaths": [supporting_relpath]},
+    )
+    assert res_support.status_code == 200
+    assert res_support.json()["data"]["status"] == "needs_summaries"
+
+    return upload_id
+
+
+def test_post_manual_project_summary_happy_path_persists(client, auth_headers):
+    upload_id = setup_upload_to_needs_summaries_no_csv(client, auth_headers, build_zip_no_csv(PROJECT), PROJECT)
+
+    text = "Built X, improved Y."
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/manual-project-summary",
+        headers=auth_headers,
+        json={"summary_text": text},
+    )
+    assert res.status_code == 200
+
+    body = res.json()
+    assert body["success"] is True
+    state = body["data"].get("state") or {}
+    assert (state.get("manual_project_summaries") or {}).get(PROJECT) == text
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    assert (persisted_state.get("manual_project_summaries") or {}).get(PROJECT) == text
+
+    _cleanup_upload_artifacts(persisted_state)
+
+
+def test_post_manual_contribution_summary_happy_path_persists(client, auth_headers):
+    upload_id = setup_upload_to_needs_summaries_no_csv(client, auth_headers, build_zip_no_csv(PROJECT), PROJECT)
+
+    desc = "I owned the API + tests."
+    res = client.post(
+        f"/projects/upload/{upload_id}/projects/{PROJECT}/manual-contribution-summary",
+        headers=auth_headers,
+        json={"manual_contribution_summary": desc},
+    )
+    assert res.status_code == 200
+
+    body = res.json()
+    assert body["success"] is True
+    state = body["data"].get("state") or {}
+    contrib = ((state.get("contributions") or {}).get(PROJECT)) or {}
+    assert contrib.get("manual_contribution_summary") == desc
+
+    persisted_state = get_upload_state(client, auth_headers, upload_id)
+    persisted_contrib = ((persisted_state.get("contributions") or {}).get(PROJECT)) or {}
+    assert persisted_contrib.get("manual_contribution_summary") == desc
+
+    _cleanup_upload_artifacts(persisted_state)

--- a/tests/api/test_uploads_manual_summaries.py
+++ b/tests/api/test_uploads_manual_summaries.py
@@ -1,7 +1,8 @@
 import pytest
 
+from src.db.projects import get_project_key
 from .test_uploads_wizard import _make_zip_bytes
-from .test_uploads_file_roles import _advance_to_needs_file_roles, _cleanup_upload_artifacts
+from .test_uploads_file_roles import _cleanup_upload_artifacts
 
 PROJECT = "ProjectA"
 
@@ -40,15 +41,75 @@ def pick_relpath_by_filename(files: list[dict], filename: str) -> str:
     raise AssertionError(f"Could not find relpath for filename={filename}")
 
 
+def _advance_to_needs_file_roles_collab_text(client, auth_headers, zip_bytes: bytes) -> dict:
+    """
+    Same as test_uploads_file_roles._advance_to_needs_file_roles, but:
+      - classify as collaborative (so summaries are required)
+      - ensure project type is text if project-types step appears
+    """
+    res = client.post(
+        "/projects/upload",
+        headers=auth_headers,
+        files={"file": ("test.zip", zip_bytes, "application/zip")},
+    )
+    assert res.status_code == 200
+    upload = res.json()["data"]
+    upload_id = upload["upload_id"]
+
+    # resolve dedup if needed
+    if upload["status"] == "needs_dedup":
+        asks = (upload.get("state") or {}).get("dedup_asks") or {}
+        decisions = {k: "new_project" for k in asks.keys()}
+        res_d = client.post(
+            f"/projects/upload/{upload_id}/dedup/resolve",
+            headers=auth_headers,
+            json={"decisions": decisions},
+        )
+        assert res_d.status_code == 200
+        upload = res_d.json()["data"]
+
+    # classify as collaborative
+    if upload["status"] == "needs_classification":
+        layout = (upload.get("state") or {}).get("layout") or {}
+        known = set(layout.get("pending_projects") or []) | set((layout.get("auto_assignments") or {}).keys())
+        assignments = {p: "collaborative" for p in known} or {"ProjectA": "collaborative"}
+
+        res2 = client.post(
+            f"/projects/upload/{upload_id}/classifications",
+            headers=auth_headers,
+            json={"assignments": assignments},
+        )
+        assert res2.status_code == 200
+        upload = res2.json()["data"]
+
+    # if it needs project types, force text
+    if upload["status"] == "needs_project_types":
+        state = upload.get("state") or {}
+        needs = set(state.get("project_types_mixed") or []) | set(state.get("project_types_unknown") or [])
+        project_types = {p: "text" for p in needs} or {"ProjectA": "text"}
+
+        res3 = client.post(
+            f"/projects/upload/{upload_id}/project-types",
+            headers=auth_headers,
+            json={"project_types": project_types},
+        )
+        assert res3.status_code == 200
+        upload = res3.json()["data"]
+
+    assert upload["status"] == "needs_file_roles"
+    return upload
+
+
 def setup_upload_to_needs_summaries_no_csv(client, auth_headers, zip_bytes: bytes, project: str = PROJECT) -> int:
     """
-    Advances the wizard to needs_summaries for a project with NO CSV files:
-    - upload -> needs_file_roles
+    Advances the wizard to needs_summaries for a collaborative text project with NO CSV files:
+    - upload -> needs_file_roles (collaborative)
     - set main file
-    - set supporting text files (should transition status -> needs_summaries)
+    - set main section ids (empty list to mark step complete)
+    - set supporting text files -> should transition status -> needs_summaries
     Returns upload_id
     """
-    upload = _advance_to_needs_file_roles(client, auth_headers, zip_bytes)
+    upload = _advance_to_needs_file_roles_collab_text(client, auth_headers, zip_bytes)
     upload_id = upload["upload_id"]
 
     files_payload = get_files_payload(client, auth_headers, upload_id, project)
@@ -64,6 +125,14 @@ def setup_upload_to_needs_summaries_no_csv(client, auth_headers, zip_bytes: byte
     )
     assert res_main.status_code == 200
 
+    # mark sections step complete (required for needs_summaries transition for collab text)
+    res_sections = client.post(
+        f"/projects/upload/{upload_id}/projects/{project}/text/contributions",
+        headers=auth_headers,
+        json={"selected_section_ids": []},
+    )
+    assert res_sections.status_code == 200
+
     # set supporting text files -> should move to needs_summaries (no CSVs exist)
     res_support = client.post(
         f"/projects/upload/{upload_id}/projects/{project}/supporting-text-files",
@@ -76,12 +145,21 @@ def setup_upload_to_needs_summaries_no_csv(client, auth_headers, zip_bytes: byte
     return upload_id
 
 
-def test_post_manual_project_summary_happy_path_persists(client, auth_headers):
+def _get_project_key_for_test(seed_conn, user_id: int, project_name: str) -> int:
+    pk = get_project_key(seed_conn, user_id, project_name)
+    assert isinstance(pk, int)
+    return pk
+
+
+def test_post_manual_project_summary_happy_path_persists(client, auth_headers, seed_conn):
     upload_id = setup_upload_to_needs_summaries_no_csv(client, auth_headers, build_zip_no_csv(PROJECT), PROJECT)
+
+    project_key = _get_project_key_for_test(seed_conn, 1, PROJECT)
+    pk_str = str(project_key)
 
     text = "Built X, improved Y."
     res = client.post(
-        f"/projects/upload/{upload_id}/projects/{PROJECT}/manual-project-summary",
+        f"/projects/upload/{upload_id}/projects/{project_key}/manual-project-summary",
         headers=auth_headers,
         json={"summary_text": text},
     )
@@ -90,20 +168,23 @@ def test_post_manual_project_summary_happy_path_persists(client, auth_headers):
     body = res.json()
     assert body["success"] is True
     state = body["data"].get("state") or {}
-    assert (state.get("manual_project_summaries") or {}).get(PROJECT) == text
+    assert (state.get("manual_project_summaries") or {}).get(pk_str) == text
 
     persisted_state = get_upload_state(client, auth_headers, upload_id)
-    assert (persisted_state.get("manual_project_summaries") or {}).get(PROJECT) == text
+    assert (persisted_state.get("manual_project_summaries") or {}).get(pk_str) == text
 
     _cleanup_upload_artifacts(persisted_state)
 
 
-def test_post_manual_contribution_summary_happy_path_persists(client, auth_headers):
+def test_post_manual_contribution_summary_happy_path_persists(client, auth_headers, seed_conn):
     upload_id = setup_upload_to_needs_summaries_no_csv(client, auth_headers, build_zip_no_csv(PROJECT), PROJECT)
+
+    project_key = _get_project_key_for_test(seed_conn, 1, PROJECT)
+    pk_str = str(project_key)
 
     desc = "I owned the API + tests."
     res = client.post(
-        f"/projects/upload/{upload_id}/projects/{PROJECT}/manual-contribution-summary",
+        f"/projects/upload/{upload_id}/projects/{project_key}/manual-contribution-summary",
         headers=auth_headers,
         json={"manual_contribution_summary": desc},
     )
@@ -112,11 +193,11 @@ def test_post_manual_contribution_summary_happy_path_persists(client, auth_heade
     body = res.json()
     assert body["success"] is True
     state = body["data"].get("state") or {}
-    contrib = ((state.get("contributions") or {}).get(PROJECT)) or {}
+    contrib = ((state.get("contributions") or {}).get(pk_str)) or {}
     assert contrib.get("manual_contribution_summary") == desc
 
     persisted_state = get_upload_state(client, auth_headers, upload_id)
-    persisted_contrib = ((persisted_state.get("contributions") or {}).get(PROJECT)) or {}
+    persisted_contrib = ((persisted_state.get("contributions") or {}).get(pk_str)) or {}
     assert persisted_contrib.get("manual_contribution_summary") == desc
 
     _cleanup_upload_artifacts(persisted_state)


### PR DESCRIPTION
## 📝 Description

This PR adds support for **manual summaries** in the uploads wizard, via two new POST-only endpoints that mirror the CLI flow (persisting into the same upload `state` fields).

Added 2 new endpoints for manual summary submission:

* **POST** `/projects/upload/{upload_id}/projects/{project_name}/manual-project-summary`
  Takes `summary_text`, normalizes it (fallback if blank), then stores it in `uploads.state.manual_project_summaries[project_name]`.
* **POST** `/projects/upload/{upload_id}/projects/{project_name}/manual-contribution-summary`
  Takes `manual_contribution_summary`, normalizes it (fallback if blank), then stores it in `uploads.state.contributions[project_name].manual_contribution_summary`.

Also added the request DTO(s) for these endpoints (`ManualProjectSummaryRequestDTO`, `ManualContributionSummaryRequestDTO`) and documented them.

Finally, this PR updates the upload wizard flow so that **after the last file-role picking step (supporting file selections)**, the upload transitions to `needs_summaries`. This handles the “CSV is optional” case correctly:

* if a project has CSV candidates, the wizard only advances after both supporting text + supporting CSV are submitted
* if a project has **no** CSV candidates, the wizard advances after supporting text is submitted

Added minimal API tests that advance an upload to `needs_summaries`, hit both new endpoints, and verify values persist into the upload state in the DB. I also refactored text_collab_analysis to reuse the existing contribution manual summary (instead of using the contribution types) and made sure it is updated in the portfolio CLI and Export outputs.

**Closes:** #388, #474

---

## 🔧 Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] 📚 Documentation added/updated
* [x] ✅ Test added/updated
* [x] ♻️ Refactoring
* [ ] ⚡ Performance improvement

---

## 🧪 Testing

* [x] ran `pytest tests/api/test_uploads_manual_summaries.py` and `pytest`
* [x] manually tested on postman

  * follow through steps 1-5 of manual testing instructions in PR #446 (upload ZIP, get to file role picking, select main file, submit supporting selections until status becomes `needs_summaries`)
  * **TEST 1**: Positive test for manual project summary: `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/manual-project-summary`
    Request body:

```json
{
  "summary_text": "This project is about abc and xyz."
}
```

→ should return `200 OK` + value stored under `state.manual_project_summaries.PlantGrowthStudy`

* **TEST 2**: Positive test for manual contribution summary: `http://localhost:8000/projects/upload/1/projects/PlantGrowthStudy/manual-contribution-summary`
  Request body:

```json
{
  "manual_contribution_summary": "I wrote the main report sections and compiled the supporting notes + datasets."
}
```

→ should return `200 OK` + value stored under `state.contributions.PlantGrowthStudy.manual_contribution_summary`

* **TEST 3**: Negative test (call before `needs_summaries`): call either summary endpoint while upload is still in `needs_file_roles`
  Request body (any):

```json
{
  "summary_text": "should fail"
}
```

→ should return `409 Conflict` (upload not ready for summaries)

---

## ✓ Checklist

* [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
* [x] 💬 I have commented my code where needed
* [x] 📖 I have made corresponding changes to the documentation
* [x] ⚠️ My changes generate no new warnings
* [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
* [x] 🔗 Any dependent changes have been merged and published in downstream modules
* [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
