### PR TITLE
Api/activity heatmap

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -34,11 +34,12 @@ http://localhost:8000
 7. [Skills](#skills)
 8. [Resume](#resume)
 9. [Portfolio](#portfolio)
-10. [Path Variables](#path-variables)
-11. [DTO References](#dto-references)
-12. [Best Practices](#best-practices)
-13. [Error Codes](#error-codes)
-14. [Example Error Response](#example-error-response)
+10. [Activity Heatmap](#activity-heatmap)
+11. [Path Variables](#path-variables)
+12. [DTO References](#dto-references)
+13. [Best Practices](#best-practices)
+14. [Error Codes](#error-codes)
+15. [Example Error Response](#example-error-response)
 
 ---
 
@@ -1954,6 +1955,72 @@ To get `project_summary_id` values for use in endpoints like `POST /resume/gener
 
 ---
 
+## **Activity Heatmap**
+Displays a heatmap of **activity type vs version** for a project.
+
+- **Notes**
+  - `mode=diff` (default): each version column shows **only files changed in that version** (added + modified vs previous version).
+  - `mode=snapshot`: each version column shows **all files present in that version**.
+  - If `normalize=true`, values are **percent per version column**:
+    - `% = (files in that activity) / (total files counted for that version) * 100`
+    - Each version column sums to ~100% (unless that version has 0 eligible files).
+
+
+### **Endpoints**
+- **Get Activity Heatmap Info**
+    - **Endpoint**: `GET /projects/{project_name}/activity-heatmap`
+    - **Description**: Generates (or reuses cached) heatmap and returns metadata + a `png_url` to fetch the image.
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Path Parameters**:
+      - `{project_name}` (string, required): Project display name
+    - **Query Parameters**:
+      - `mode` (string, optional): `"diff"` or `"snapshot"`. Defaults to `"diff"`.
+      - `normalize` (boolean, optional): Defaults to `true` (percent). If `false`, values are raw counts.
+      - `include_unclassified_text` (boolean, optional): Defaults to `true` (text projects only).
+    - **Request Body**: None
+    - **Response Status**: `200 OK`
+    - **Response DTO**: `ActivityHeatmapInfoDTO`
+    - **Response Body**:
+      ```json
+      {
+        "success": true,
+        "data": {
+          "project_name": "My Project",
+          "mode": "diff",
+          "normalize": true,
+          "include_unclassified_text": true,
+          "png_url": "/projects/My Project/activity-heatmap.png?mode=diff&normalize=true&include_unclassified_text=true"
+        },
+        "error": null
+      }
+      ```
+    - **Error Responses**:
+      - `401 Unauthorized` if missing/invalid/expired token
+      - `404 Not Found` if project doesn't exist or doesn't belong to user
+      - `400 Bad Request` if project has no versions
+
+- **Get Activity Heatmap PNG**
+    - **Endpoint**: `GET /projects/{project_name}/activity-heatmap.png`
+    - **Description**: Returns the heatmap image as a PNG (`image/png`). Uses cached artifact when available.
+    - **Auth: Bearer** means this header is required: `Authorization: Bearer <access_token>`
+    - **Path Parameters**:
+      - `{project_name}` (string, required): Project display name 
+    - **Query Parameters**:
+      - `mode` (string, optional): `"diff"` or `"snapshot"`. Defaults to `"diff"`.
+      - `normalize` (boolean, optional): Defaults to `true`.
+      - `include_unclassified_text` (boolean, optional): Defaults to `true` (text projects only).
+    - **Request Body**: None
+    - **Response Status**: `200 OK`
+    - **Response**: Binary image download with MIME type `image/png`
+    - **Response Headers**:
+      - `Content-Type: image/png`
+    - **Error Responses**:
+      - `401 Unauthorized` if missing/invalid/expired token
+      - `404 Not Found` if project doesn't exist or doesn't belong to user
+      - `400 Bad Request` if project has no versions
+
+---
+
 ## **DTO References**
 
 DTOs (Data Transfer Objects) are defined using Pydantic models in `src/api/schemas/`.
@@ -2300,6 +2367,15 @@ Example:
 - **DeleteResultDTO** (used by `DELETE /projects` and `DELETE /resume`)
   - `deleted_count` (int, required): Number of items deleted
 
+
+### **Activity Heatmap DTOs**
+
+- **ActivityHeatmapInfoDTO** (used by `GET /projects/{project_name}/activity-heatmap`)
+  - `project_name` (string, required)
+  - `mode` (string, required): `"diff"` or `"snapshot"`
+  - `normalize` (boolean, required): `true` = percent per version column, `false` = raw counts
+  - `include_unclassified_text` (boolean, required): text projects only
+  - `png_url` (string, required): relative URL to fetch the PNG
 ---
 
 ## **Best Practices**

--- a/src/api/main.py
+++ b/src/api/main.py
@@ -13,6 +13,7 @@ from src.api.routes import (
     portfolio_router,
     export_router,
     thumbnails_router,
+    activity_heatmap_router,
 )
 from src.api.auth.routes import router as auth_router
 
@@ -36,3 +37,4 @@ app.include_router(google_drive_router)
 app.include_router(portfolio_router)
 app.include_router(export_router)
 app.include_router(thumbnails_router)
+app.include_router(activity_heatmap_router)

--- a/src/api/routes/__init__.py
+++ b/src/api/routes/__init__.py
@@ -18,6 +18,7 @@ from src.api.routes.consent import router as consent_router
 from src.api.routes.portfolio import router as portfolio_router
 from src.api.routes.export import router as export_router
 from src.api.routes.thumbnails import router as thumbnails_router
+from .activity_heatmap import router as activity_heatmap_router
 
 __all__ = [
     "projects_router",
@@ -33,4 +34,5 @@ __all__ = [
     "portfolio_router",
     "export_router",
     "thumbnails_router",
+    "activity_heatmap_router",
 ]

--- a/src/api/routes/activity_heatmap.py
+++ b/src/api/routes/activity_heatmap.py
@@ -1,0 +1,84 @@
+from fastapi import APIRouter, Depends, HTTPException, Query
+from fastapi.responses import FileResponse
+from sqlite3 import Connection
+from typing import Literal
+
+from src.api.dependencies import get_db, get_current_user_id
+from src.api.schemas.common import ApiResponse
+from src.api.schemas.activity_heatmap import ActivityHeatmapInfoDTO, HeatmapMode
+from src.services.activity_heatmap_service import (
+    get_activity_heatmap_png_path,
+    build_activity_heatmap_png_url,
+)
+
+router = APIRouter(prefix="/projects", tags=["projects"])
+
+
+@router.get("/{project_name}/activity-heatmap", response_model=ApiResponse[ActivityHeatmapInfoDTO])
+def get_activity_heatmap_info(
+    project_name: str,
+    mode: HeatmapMode = Query("diff"),
+    normalize: bool = Query(True),
+    include_unclassified_text: bool = Query(True),
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    try:
+        # Generate (or reuse cached) artifact, but return a friendly URL for clients.
+        _path = get_activity_heatmap_png_path(
+            conn,
+            user_id,
+            project_name,
+            mode=mode,
+            normalize=normalize,
+            include_unclassified_text=include_unclassified_text,
+        )
+    except ValueError as e:
+        msg = str(e).lower()
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if "no versions" in msg:
+            raise HTTPException(status_code=400, detail="Project has no versions")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to generate heatmap")
+
+    dto = ActivityHeatmapInfoDTO(
+        project_name=project_name,
+        mode=mode,
+        normalize=normalize,
+        include_unclassified_text=include_unclassified_text,
+        png_url=build_activity_heatmap_png_url(project_name, mode, normalize, include_unclassified_text),
+    )
+    return ApiResponse(success=True, data=dto, error=None)
+
+
+@router.get("/{project_name}/activity-heatmap.png")
+def get_activity_heatmap_png(
+    project_name: str,
+    mode: HeatmapMode = Query("diff"),
+    normalize: bool = Query(True),
+    include_unclassified_text: bool = Query(True),
+    user_id: int = Depends(get_current_user_id),
+    conn: Connection = Depends(get_db),
+):
+    try:
+        path = get_activity_heatmap_png_path(
+            conn,
+            user_id,
+            project_name,
+            mode=mode,
+            normalize=normalize,
+            include_unclassified_text=include_unclassified_text,
+        )
+    except ValueError as e:
+        msg = str(e).lower()
+        if "not found" in msg:
+            raise HTTPException(status_code=404, detail="Project not found")
+        if "no versions" in msg:
+            raise HTTPException(status_code=400, detail="Project has no versions")
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception:
+        raise HTTPException(status_code=500, detail="Failed to generate heatmap")
+
+    return FileResponse(path, media_type="image/png")

--- a/src/api/routes/activity_heatmap.py
+++ b/src/api/routes/activity_heatmap.py
@@ -1,7 +1,6 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
 from sqlite3 import Connection
-from typing import Literal
 
 from src.api.dependencies import get_db, get_current_user_id
 from src.api.schemas.common import ApiResponse
@@ -14,9 +13,9 @@ from src.services.activity_heatmap_service import (
 router = APIRouter(prefix="/projects", tags=["projects"])
 
 
-@router.get("/{project_name}/activity-heatmap", response_model=ApiResponse[ActivityHeatmapInfoDTO])
+@router.get("/{project_id}/activity-heatmap", response_model=ApiResponse[ActivityHeatmapInfoDTO])
 def get_activity_heatmap_info(
-    project_name: str,
+    project_id: int,
     mode: HeatmapMode = Query("diff"),
     normalize: bool = Query(True),
     include_unclassified_text: bool = Query(True),
@@ -24,11 +23,10 @@ def get_activity_heatmap_info(
     conn: Connection = Depends(get_db),
 ):
     try:
-        # Generate (or reuse cached) artifact, but return a friendly URL for clients.
-        _path = get_activity_heatmap_png_path(
+        project_name, _path = get_activity_heatmap_png_path(
             conn,
             user_id,
-            project_name,
+            project_id,
             mode=mode,
             normalize=normalize,
             include_unclassified_text=include_unclassified_text,
@@ -44,18 +42,19 @@ def get_activity_heatmap_info(
         raise HTTPException(status_code=500, detail="Failed to generate heatmap")
 
     dto = ActivityHeatmapInfoDTO(
+        project_id=project_id,
         project_name=project_name,
         mode=mode,
         normalize=normalize,
         include_unclassified_text=include_unclassified_text,
-        png_url=build_activity_heatmap_png_url(project_name, mode, normalize, include_unclassified_text),
+        png_url=build_activity_heatmap_png_url(project_id, mode, normalize, include_unclassified_text),
     )
     return ApiResponse(success=True, data=dto, error=None)
 
 
-@router.get("/{project_name}/activity-heatmap.png")
+@router.get("/{project_id}/activity-heatmap.png")
 def get_activity_heatmap_png(
-    project_name: str,
+    project_id: int,
     mode: HeatmapMode = Query("diff"),
     normalize: bool = Query(True),
     include_unclassified_text: bool = Query(True),
@@ -63,10 +62,10 @@ def get_activity_heatmap_png(
     conn: Connection = Depends(get_db),
 ):
     try:
-        path = get_activity_heatmap_png_path(
+        _project_name, path = get_activity_heatmap_png_path(
             conn,
             user_id,
-            project_name,
+            project_id,
             mode=mode,
             normalize=normalize,
             include_unclassified_text=include_unclassified_text,

--- a/src/api/schemas/activity_heatmap.py
+++ b/src/api/schemas/activity_heatmap.py
@@ -5,6 +5,7 @@ HeatmapMode = Literal["diff", "snapshot"]
 
 
 class ActivityHeatmapInfoDTO(BaseModel):
+    project_id: int
     project_name: str
     mode: HeatmapMode = "diff"
     normalize: bool = True

--- a/src/api/schemas/activity_heatmap.py
+++ b/src/api/schemas/activity_heatmap.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import Literal
+
+HeatmapMode = Literal["diff", "snapshot"]
+
+
+class ActivityHeatmapInfoDTO(BaseModel):
+    project_name: str
+    mode: HeatmapMode = "diff"
+    normalize: bool = True
+    include_unclassified_text: bool = True
+    png_url: str

--- a/src/services/activity_heatmap_service.py
+++ b/src/services/activity_heatmap_service.py
@@ -1,0 +1,46 @@
+from sqlite3 import Connection
+from typing import Literal
+
+from src.db.projects import get_project_key
+from src.analysis.visualizations.activity_heatmap import write_project_activity_heatmap
+
+HeatmapMode = Literal["diff", "snapshot"]
+
+
+def get_activity_heatmap_png_path(
+    conn: Connection,
+    user_id: int,
+    project_name: str,
+    mode: HeatmapMode = "diff",
+    normalize: bool = True,
+    include_unclassified_text: bool = True,
+) -> str:
+    # Distinguish "project doesn't exist" vs "no versions"
+    project_key = get_project_key(conn, user_id, project_name)
+    if project_key is None:
+        raise ValueError("Project not found")
+
+    return write_project_activity_heatmap(
+        conn,
+        user_id,
+        project_name,
+        mode=mode,
+        normalize=normalize,
+        include_unclassified_text=include_unclassified_text,
+    )
+
+
+def build_activity_heatmap_png_url(
+    project_name: str,
+    mode: HeatmapMode,
+    normalize: bool,
+    include_unclassified_text: bool,
+) -> str:
+    # Just a convenient URL for clients.
+    # FastAPI will handle URL encoding for project_name in the path.
+    return (
+        f"/projects/{project_name}/activity-heatmap.png"
+        f"?mode={mode}"
+        f"&normalize={'true' if normalize else 'false'}"
+        f"&include_unclassified_text={'true' if include_unclassified_text else 'false'}"
+    )

--- a/src/services/activity_heatmap_service.py
+++ b/src/services/activity_heatmap_service.py
@@ -1,5 +1,5 @@
 from sqlite3 import Connection
-from typing import Literal
+from typing import Literal, Tuple
 
 from src.db.projects import get_project_key
 from src.analysis.visualizations.activity_heatmap import write_project_activity_heatmap
@@ -7,20 +7,42 @@ from src.analysis.visualizations.activity_heatmap import write_project_activity_
 HeatmapMode = Literal["diff", "snapshot"]
 
 
+def _resolve_project_name_from_project_id(
+    conn: Connection,
+    user_id: int,
+    project_id: int,
+) -> str | None:
+    row = conn.execute(
+        """
+        SELECT project_name
+        FROM project_summaries
+        WHERE user_id = ? AND project_summary_id = ?
+        LIMIT 1
+        """,
+        (user_id, project_id),
+    ).fetchone()
+    return row[0] if row and row[0] else None
+
+
 def get_activity_heatmap_png_path(
     conn: Connection,
     user_id: int,
-    project_name: str,
+    project_id: int,
     mode: HeatmapMode = "diff",
     normalize: bool = True,
     include_unclassified_text: bool = True,
-) -> str:
+) -> Tuple[str, str]:
+    project_name = _resolve_project_name_from_project_id(conn, user_id, project_id)
+    if project_name is None:
+        raise ValueError("Project not found")
+
     # Distinguish "project doesn't exist" vs "no versions"
     project_key = get_project_key(conn, user_id, project_name)
     if project_key is None:
+        # In case project_summaries exists but projects row is missing
         raise ValueError("Project not found")
 
-    return write_project_activity_heatmap(
+    path = write_project_activity_heatmap(
         conn,
         user_id,
         project_name,
@@ -28,18 +50,17 @@ def get_activity_heatmap_png_path(
         normalize=normalize,
         include_unclassified_text=include_unclassified_text,
     )
+    return project_name, path
 
 
 def build_activity_heatmap_png_url(
-    project_name: str,
+    project_id: int,
     mode: HeatmapMode,
     normalize: bool,
     include_unclassified_text: bool,
 ) -> str:
-    # Just a convenient URL for clients.
-    # FastAPI will handle URL encoding for project_name in the path.
     return (
-        f"/projects/{project_name}/activity-heatmap.png"
+        f"/projects/{project_id}/activity-heatmap.png"
         f"?mode={mode}"
         f"&normalize={'true' if normalize else 'false'}"
         f"&include_unclassified_text={'true' if include_unclassified_text else 'false'}"

--- a/tests/api/test_activity_heatmap_endpoints.py
+++ b/tests/api/test_activity_heatmap_endpoints.py
@@ -1,0 +1,67 @@
+import base64
+import sqlite3
+from unittest.mock import patch
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from src.api.dependencies import get_db, get_current_user_id
+from src.api.routes.activity_heatmap import router as activity_heatmap_router
+
+
+# 1x1 PNG (valid)
+SAMPLE_PNG_BYTES = base64.b64decode(
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB"
+    "/a7lYQAAAABJRU5ErkJggg=="
+)
+
+
+def override_get_db():
+    conn = sqlite3.connect(":memory:")
+    try:
+        yield conn
+    finally:
+        conn.close()
+
+
+def override_get_current_user_id():
+    return 1
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    app.include_router(activity_heatmap_router)
+
+    app.dependency_overrides[get_db] = override_get_db
+    app.dependency_overrides[get_current_user_id] = override_get_current_user_id
+
+    return TestClient(app)
+
+
+def test_get_activity_heatmap_png_success(client, tmp_path):
+    png_path = tmp_path / "heatmap.png"
+    png_path.write_bytes(SAMPLE_PNG_BYTES)
+
+    # Patch the symbol used by the router module (important!)
+    with patch(
+        "src.api.routes.activity_heatmap.get_activity_heatmap_png_path",
+        return_value=str(png_path),
+    ):
+        resp = client.get("/projects/MyProject/activity-heatmap.png?mode=diff&normalize=true")
+
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("image/png")
+    assert resp.content[:8] == b"\x89PNG\r\n\x1a\n"
+
+
+def test_get_activity_heatmap_png_project_not_found(client):
+    with patch(
+        "src.api.routes.activity_heatmap.get_activity_heatmap_png_path",
+        side_effect=ValueError("Project not found"),
+    ):
+        resp = client.get("/projects/Nope/activity-heatmap.png?mode=diff")
+
+    assert resp.status_code == 404
+    assert resp.json()["detail"] == "Project not found"

--- a/tests/api/test_activity_heatmap_endpoints.py
+++ b/tests/api/test_activity_heatmap_endpoints.py
@@ -44,12 +44,11 @@ def test_get_activity_heatmap_png_success(client, tmp_path):
     png_path = tmp_path / "heatmap.png"
     png_path.write_bytes(SAMPLE_PNG_BYTES)
 
-    # Patch the symbol used by the router module (important!)
     with patch(
         "src.api.routes.activity_heatmap.get_activity_heatmap_png_path",
-        return_value=str(png_path),
+        return_value=("MyProject", str(png_path)),
     ):
-        resp = client.get("/projects/MyProject/activity-heatmap.png?mode=diff&normalize=true")
+        resp = client.get("/projects/123/activity-heatmap.png?mode=diff&normalize=true")
 
     assert resp.status_code == 200
     assert resp.headers["content-type"].startswith("image/png")
@@ -61,7 +60,7 @@ def test_get_activity_heatmap_png_project_not_found(client):
         "src.api.routes.activity_heatmap.get_activity_heatmap_png_path",
         side_effect=ValueError("Project not found"),
     ):
-        resp = client.get("/projects/Nope/activity-heatmap.png?mode=diff")
+        resp = client.get("/projects/999/activity-heatmap.png?mode=diff")
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Project not found"


### PR DESCRIPTION
## 📝 Description

This PR adds API support for the Activity Heatmap so clients can fetch either:
1. a small JSON “info” payload (with a `png_url`), or
2. the actual PNG heatmap directly.

**NOTE:** this branch will be rebased onto `main` once **PR #490 and #497** are merged to `main`.

### Added endpoints

* **GET** `/projects/{project_name}/activity-heatmap`
  Generates (or reuses cached) heatmap and returns an `ActivityHeatmapInfoDTO` including a `png_url`.

* **GET** `/projects/{project_name}/activity-heatmap.png`
  Returns the PNG directly (`image/png`) using a cached artifact path when available.

Closes: #495 

---

## 🔧 Type of Change

* [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
* [x] ✨ New feature (non-breaking change that adds functionality)
* [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
* [x] 📚 Documentation added/updated
* [x] ✅ Test added/updated
* [ ] ♻️ Refactoring
* [ ] ⚡ Performance improvement

---

## 🧪 Testing

* [x] ran `python -m pytest tests/api/test_activity_heatmap_endpoints.py` and `python -m pytest`
* [x] manually test on postman
## Manual testing (Postman) — using the sample projects

### Pre-req: ingest the sample projects first (from PR #497)
Use the sample ZIPs I provided (`activity_heatmap_sample_bundle.zip`) and follow the **upload/analyze steps in PR #497 (CLI heatmap PR)** so the DB actually has versions to plot.

### TEST 1 — Heatmap Info endpoint
#### SampleCodeProject
**Request**
- `GET http://localhost:8000/projects/SampleCodeProject/activity-heatmap?mode=diff&normalize=true&include_unclassified_text=true`

**Expected**
- `200 OK`
- Response includes a `data.png_url` field

#### SampleTextProject (diff)
**Request**
- `GET http://localhost:8000/projects/SampleTextProject/activity-heatmap?mode=diff&normalize=true&include_unclassified_text=true`

**Expected**
- `200 OK`
- Response includes `data.png_url`

Try snapshot too (both projects):
- `mode=snapshot`


###  TEST 2 — Heatmap PNG endpoint 
#### SampleCodeProject PNG
**Request**
- `GET http://localhost:8000/projects/SampleCodeProject/activity-heatmap.png?mode=diff&normalize=true&include_unclassified_text=true`

**Expected**
- `200 OK`
- Response header: `Content-Type: image/png`
- Body is a PNG (use Postman “Save Response” to save the file and open it)

#### SampleTextProject PNG (diff)
**Request**
- `GET http://localhost:8000/projects/SampleTextProject/activity-heatmap.png?mode=diff&normalize=true&include_unclassified_text=true`

**Expected**
- `200 OK`
- `Content-Type: image/png`

Try snapshot too:
- `GET ...activity-heatmap.png?mode=snapshot&normalize=true&include_unclassified_text=true`

---

## ✓ Checklist

* [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
* [x] 💬 I have commented my code where needed
* [x] 📖 I have made corresponding changes to the documentation
* [x] ⚠️ My changes generate no new warnings
* [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
* [ ] 🔗 Any dependent changes have been merged and published in downstream modules
* [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots