### PR TITLE
Fix resume contribution bullets for projects without .git

### DIFF
--- a/src/analysis/activity_type/code/summary.py
+++ b/src/analysis/activity_type/code/summary.py
@@ -186,9 +186,11 @@ def build_activity_summary(
     ]
 
     if scope == Scope.COLLABORATIVE:
-        # Restrict to files the user actually contributed to
+        # Restrict to files the user actually contributed to.
+        # Normalize backslashes (Windows) to forward slashes before extracting
+        # the basename so the comparison works on all platforms.
         contributed_filenames = set(
-            p.split("/")[-1]  # safety in case path appears
+            p.replace("\\", "/").split("/")[-1]
             for p in get_user_contributed_files(conn, user_id, project_name)
         )
 

--- a/src/analysis/skills/flows/skill_extraction.py
+++ b/src/analysis/skills/flows/skill_extraction.py
@@ -43,10 +43,15 @@ def extract_skills(conn: sqlite3.Connection, user_id: int, project_name: str):
             # Filter files to only include those the user contributed to
             original_count = len(files)
 
-            # Match by filename (basename) since file_path formats might differ
+            # Match by filename (basename) since file_path formats might differ.
+            # Normalize backslashes (Windows) before extracting basename so
+            # the comparison works on all platforms.
+            def _basename(p: str) -> str:
+                return p.replace("\\", "/").split("/")[-1]
+
             files = [
                 f for f in files
-                if any(os.path.basename(f.get("file_path", "")) == os.path.basename(contrib_path)
+                if any(_basename(f.get("file_path", "")) == _basename(contrib_path)
                        for contrib_path in contributed_files)
             ]
 

--- a/src/menu/resume/helpers.py
+++ b/src/menu/resume/helpers.py
@@ -405,18 +405,6 @@ def build_contribution_bullets(
         metrics = get_normalized_code_metrics(conn, user_id, project_name, is_collab)
         activities = get_code_activity_percents(conn, user_id, project_name, source="combined") or {}
 
-        if not metrics:
-            return ["(no metrics found in code_collaborative_metrics / git_individual_metrics)"]
-
-        # Guard against missing keys
-        total_commits = int(metrics.get("total_commits") or 0)
-        your_commits = int(metrics.get("your_commits") or 0)
-        loc_added = int(metrics.get("loc_added") or 0)
-        loc_deleted = int(metrics.get("loc_deleted") or 0)
-        loc_net = int(metrics.get("loc_net") or 0)
-
-        share = (your_commits / total_commits * 100.0) if total_commits > 0 else 0.0
-
         activity_label = {
             "feature_coding": "feature implementation",
             "refactoring": "refactoring",
@@ -433,6 +421,46 @@ def build_contribution_bullets(
         )
         top_acts = [(k, v) for k, v in ranked if v > 0.0][:3]
         workflows = ", ".join(activity_label.get(k, k.replace("_", " ")) for k, _ in top_acts) if top_acts else "core development"
+
+        if not metrics:
+            # No git metrics (project uploaded without .git directory).
+            # Use activity breakdown from file-based analysis instead.
+            if activities and top_acts:
+                bullets.append(
+                    f"Developed across {workflows} workflows based on file-level analysis."
+                )
+            feat = float(activities.get("feature_coding") or 0.0)
+            refac = float(activities.get("refactoring") or 0.0)
+            debug = float(activities.get("debugging") or 0.0)
+            test = float(activities.get("testing") or 0.0)
+            doc = float(activities.get("documentation") or 0.0)
+
+            if feat > 0.0:
+                bullets.append(
+                    f"Focused {feat:.1f}% of development effort on feature implementation, translating requirements into production-ready code."
+                )
+            if refac > 0.0:
+                bullets.append(
+                    f"Allocated {refac:.1f}% of contributions to refactoring, improving readability, modularity, and long-term maintainability."
+                )
+            if debug > 0.0:
+                bullets.append(
+                    f"Dedicated {debug:.1f}% of activity to debugging, identifying root causes and resolving runtime and logic issues."
+                )
+            if (test + doc) > 0.0:
+                bullets.append(
+                    f"Contributed to testing and documentation ({(test + doc):.1f}% combined), supporting code reliability and team onboarding."
+                )
+            return bullets
+
+        # Guard against missing keys
+        total_commits = int(metrics.get("total_commits") or 0)
+        your_commits = int(metrics.get("your_commits") or 0)
+        loc_added = int(metrics.get("loc_added") or 0)
+        loc_deleted = int(metrics.get("loc_deleted") or 0)
+        loc_net = int(metrics.get("loc_net") or 0)
+
+        share = (your_commits / total_commits * 100.0) if total_commits > 0 else 0.0
 
         if is_collab:
             bullets.append(

--- a/tests/test_code_activity_type.py
+++ b/tests/test_code_activity_type.py
@@ -363,3 +363,67 @@ def test_build_activity_summary_collaborative_uses_contributed_files_only(monkey
     # Only 1 file should be counted (main.py), not ignore_me.py
     assert summary.total_file_events == 1
     assert summary.total_events == 1
+
+
+def test_build_activity_summary_collaborative_backslash_paths(monkeypatch):
+    """
+    On Windows, get_user_contributed_files may return paths with backslashes.
+    build_activity_summary should still match them to file_name via basename.
+    """
+    fake_classification = ("collaborative", "code")
+
+    fake_files = [
+        {
+            "file_id": 1,
+            "file_name": "main.py",
+            "file_path": "proj\\src\\main.py",
+            "extension": ".py",
+            "file_type": "code",
+            "created": "2024-01-01",
+            "modified": "2024-01-02",
+            "size_bytes": 100,
+        },
+        {
+            "file_id": 2,
+            "file_name": "utils.py",
+            "file_path": "proj\\src\\utils.py",
+            "extension": ".py",
+            "file_type": "code",
+            "created": "2024-01-01",
+            "modified": "2024-01-02",
+            "size_bytes": 100,
+        },
+    ]
+
+    monkeypatch.setattr(
+        summary_mod, "get_project_metadata",
+        lambda conn, user_id, project_name: fake_classification,
+    )
+    monkeypatch.setattr(
+        summary_mod, "get_files_for_project",
+        lambda conn, user_id, project_name, only_text=False: fake_files,
+    )
+    # Simulate Windows-style backslash paths from DB
+    monkeypatch.setattr(
+        summary_mod, "get_user_contributed_files",
+        lambda conn, user_id, project_name: ["proj\\src\\main.py"],
+    )
+    monkeypatch.setattr(
+        summary_mod, "has_github_account",
+        lambda conn, user_id: False,
+    )
+    monkeypatch.setattr(
+        summary_mod, "get_project_repo",
+        lambda conn, user_id, project_name: None,
+    )
+    monkeypatch.setattr(
+        summary_mod, "get_pull_requests_for_project",
+        lambda conn, user_id, project_name: [],
+    )
+
+    conn = object()
+    summary = summary_mod.build_activity_summary(conn, user_id=1, project_name="proj")
+
+    # main.py should match despite backslash paths; utils.py should be filtered out
+    assert summary.total_file_events == 1
+    assert summary.total_events == 1

--- a/tests/test_resume_snapshot.py
+++ b/tests/test_resume_snapshot.py
@@ -927,3 +927,75 @@ def test_cli_remove_project_no_resumes(monkeypatch, capsys):
 
     out = capsys.readouterr().out
     assert "No saved resumes" in out
+
+
+# ---------- No-git fallback bullets ----------
+
+def test_build_contribution_bullets_no_git_uses_activity_fallback(monkeypatch):
+    """When code_collaborative_metrics has no data (no .git), bullets use activity breakdown."""
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    user_id = 1
+
+    # Seed a collaborative code project summary
+    save_project_summary(conn, user_id, "no_git_proj", _make_summary(
+        "no_git_proj", project_type="code", project_mode="collaborative",
+    ))
+
+    # get_normalized_code_metrics returns None (no git metrics)
+    monkeypatch.setattr(
+        helpers, "get_normalized_code_metrics", lambda c, u, p, collab: None,
+    )
+    # get_code_activity_percents returns file-level activity data
+    monkeypatch.setattr(
+        helpers, "get_code_activity_percents",
+        lambda c, u, p, source="combined": {
+            "feature_coding": 66.7,
+            "testing": 33.3,
+            "refactoring": 0.0,
+            "debugging": 0.0,
+            "documentation": 0.0,
+        },
+    )
+
+    project = {
+        "project_name": "no_git_proj",
+        "project_type": "code",
+        "project_mode": "collaborative",
+    }
+    bullets = helpers.build_contribution_bullets(conn, user_id, project)
+
+    assert len(bullets) >= 2
+    assert "file-level analysis" in bullets[0]
+    assert "feature implementation" in bullets[1]
+    # Should NOT contain the old debug error message
+    assert not any("no metrics found" in b for b in bullets)
+
+
+def test_build_contribution_bullets_no_git_no_activity_returns_empty(monkeypatch):
+    """When there are no git metrics AND no activity data, returns empty list."""
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    user_id = 1
+
+    save_project_summary(conn, user_id, "empty_proj", _make_summary(
+        "empty_proj", project_type="code", project_mode="collaborative",
+    ))
+
+    monkeypatch.setattr(
+        helpers, "get_normalized_code_metrics", lambda c, u, p, collab: None,
+    )
+    monkeypatch.setattr(
+        helpers, "get_code_activity_percents",
+        lambda c, u, p, source="combined": {},
+    )
+
+    project = {
+        "project_name": "empty_proj",
+        "project_type": "code",
+        "project_mode": "collaborative",
+    }
+    bullets = helpers.build_contribution_bullets(conn, user_id, project)
+
+    assert bullets == []
+    assert not any("no metrics found" in b for b in bullets)


### PR DESCRIPTION
## 📝 Description

When a code project is uploaded without a `.git` directory, creating a resume showed a debug error message `(no metrics found in code_collaborative_metrics / git_individual_metrics)` instead of meaningful contribution bullets.

The fix makes `build_contribution_bullets()` fall back to file-level activity breakdown data (which is always populated) when git-based metrics are unavailable. Also adds two tests that call the real `build_contribution_bullets` function — existing tests all mocked this function entirely, so the bug was never caught.

**Closes:** #504

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests
```bash
# Full resume test suite (44 tests, 42 existing + 2 new)
pytest tests/test_resume_snapshot.py -v

# Just the new tests
pytest tests/test_resume_snapshot.py -k "no_git" -v
```

### Manual Testing — CLI

1. Run `python -m src.main`
2. Upload a zip without `.git`
3. Classify as collaborative code, complete analysis
4. Create a resume from the main menu
5. Check the contributions section shows activity-based bullets instead of the debug error

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile (N/A — CLI only)

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

**Before (debug error message):**
<img width="473" height="104" alt="Screenshot 2026-02-25 at 7 27 42 AM" src="https://github.com/user-attachments/assets/c920424e-0803-4ce5-8a9f-ba764ddc5f26" />


**After (activity-based bullets):**
<img width="545" height="162" alt="Screenshot 2026-02-25 at 7 27 47 AM" src="https://github.com/user-attachments/assets/4246a22f-d1a1-49a6-9a4c-6aaf94438fd8" />

</details>