### PR TITLE
Project feedback endpoint bug fix

### DIFF
--- a/src/services/project_feedback_service.py
+++ b/src/services/project_feedback_service.py
@@ -11,14 +11,15 @@ def get_project_feedback_by_project_id(conn: Connection, user_id: int, project_i
     """
     Returns a ProjectFeedbackDTO-shaped dict for one project.
 
-    Note: `{project_id}` maps to `project_summaries.project_summary_id`, while feedback is stored keyed by `project_name`.
+    Note: `{project_id}` maps to `project_summaries.project_summary_id`, while feedback is stored keyed by `project_key`.
     """
 
     project_row = get_project_summary_by_id(conn, user_id, project_id)
     if not project_row: return None
 
     project_name = project_row["project_name"]
-    feedback_rows = get_project_feedback(conn, user_id, project_name)
+    project_key = project_row["project_key"]
+    feedback_rows = get_project_feedback(conn, user_id, project_key)
 
     return {
         "project_id": project_id,

--- a/tests/api/test_feedback.py
+++ b/tests/api/test_feedback.py
@@ -1,6 +1,7 @@
 import pytest
 
 from src.db.project_feedback import upsert_project_feedback
+from src.db.projects import get_project_key
 from src.api.auth.security import create_access_token
 from tests.api.conftest import seed_project
 
@@ -19,10 +20,12 @@ def _seed_feedback(
     observed: dict | None = None,
     suggestion: str | None = None,
 ) -> None:
+    project_key = get_project_key(seed_conn, user_id, project_name)
+    assert project_key is not None, f"Project '{project_name}' not found for user {user_id}"
     upsert_project_feedback(
         seed_conn,
         user_id,
-        project_name,
+        project_key,
         project_type,
         skill_name,
         criterion_key,


### PR DESCRIPTION
## 📝 Description

Fix the feedback endpoint returning an empty array due to a `project_key` vs `project_name` type mismatch. Also fixes the test helper that had the same bug, which was masking the issue.

**Closes:** #513

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Ran `pytest tests/api/test_feedback.py -v` (all 8 tests pass)
- [x] Manually verified via Postman: `GET /projects/{project_id}/feedback` now returns feedback rows instead of an empty array

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

Before fix:
<img width="888" height="492" alt="Screenshot 2026-03-01 at 9 42 23 PM" src="https://github.com/user-attachments/assets/f17c7691-5cee-4afa-a2e0-608f7bddcf9f" />

After fix:
<img width="891" height="664" alt="Screenshot 2026-03-01 at 9 42 37 PM" src="https://github.com/user-attachments/assets/d8348130-2a12-4d51-9310-9bb1c4b3bd3a" />


</details>