### PR TITLE
Feature/profile CLI backend

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -265,6 +265,7 @@ from src.db.user_profile import (
     get_contact_parts,
     get_visible_profile_text,
     get_user_profile,
+    get_resume_name
 )
 __all__ = [
     "connect",
@@ -401,5 +402,6 @@ __all__ = [
     "get_contact_parts",
     "get_visible_profile_text",
     "get_user_profile",
+    "get_resume_name",
 ]
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -263,7 +263,8 @@ from src.db.project_feedback import (
 
 from src.db.user_profile import (
     build_contact_line,
-    get_visible_profile_text
+    get_visible_profile_text,
+    get_user_profile,
 )
 __all__ = [
     "connect",
@@ -399,5 +400,6 @@ __all__ = [
     "has_skill_preferences",
     "build_contact_line",
     "get_visible_profile_text",
+    "get_user_profile",
 ]
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -260,6 +260,11 @@ from .project_thumbnails import (
 from src.db.project_feedback import (
     upsert_project_feedback,
 )
+
+from src.db.user_profile import (
+    build_contact_line,
+    get_visible_profile_text
+)
 __all__ = [
     "connect",
     "init_schema",
@@ -392,4 +397,7 @@ __all__ = [
     "clear_skill_preferences",
     "get_all_user_skills",
     "has_skill_preferences",
+    "build_contact_line",
+    "get_visible_profile_text",
 ]
+

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -262,7 +262,7 @@ from src.db.project_feedback import (
 )
 
 from src.db.user_profile import (
-    build_contact_line,
+    get_contact_parts,
     get_visible_profile_text,
     get_user_profile,
 )
@@ -398,7 +398,7 @@ __all__ = [
     "clear_skill_preferences",
     "get_all_user_skills",
     "has_skill_preferences",
-    "build_contact_line",
+    "get_contact_parts",
     "get_visible_profile_text",
     "get_user_profile",
 ]

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -749,6 +749,7 @@ CREATE TABLE IF NOT EXISTS user_profiles (
     user_id       INTEGER PRIMARY KEY,
     phone         TEXT,
     linkedin      TEXT,
+    github        TEXT,
     location      TEXT,
     profile_text  TEXT,
     updated_at    TEXT NOT NULL DEFAULT (datetime('now')),

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -747,6 +747,7 @@ CREATE INDEX IF NOT EXISTS idx_skill_preferences_user_context
 
 CREATE TABLE IF NOT EXISTS user_profiles (
     user_id       INTEGER PRIMARY KEY,
+    full_name     TEXT,
     phone         TEXT,
     linkedin      TEXT,
     github        TEXT,

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -743,3 +743,14 @@ CREATE TABLE IF NOT EXISTS user_skill_preferences (
 
 CREATE INDEX IF NOT EXISTS idx_skill_preferences_user_context
     ON user_skill_preferences(user_id, context, context_id, project_key);
+
+
+CREATE TABLE IF NOT EXISTS user_profiles (
+    user_id       INTEGER PRIMARY KEY,
+    phone         TEXT,
+    linkedin      TEXT,
+    location      TEXT,
+    profile_text  TEXT,
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);

--- a/src/db/user_profile.py
+++ b/src/db/user_profile.py
@@ -31,6 +31,7 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
             u.email,
             p.phone,
             p.linkedin,
+            p.github,
             p.location,
             p.profile_text
         FROM users u
@@ -47,6 +48,7 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
             "email": None,
             "phone": None,
             "linkedin": None,
+            "github": None,
             "location": None,
             "profile_text": None,
         }
@@ -56,8 +58,9 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
         "email": row[1],
         "phone": row[2],
         "linkedin": row[3],
-        "location": row[4],
-        "profile_text": row[5],
+        "github": row[4],
+        "location": row[5],
+        "profile_text": row[6],
     }
 
 
@@ -68,6 +71,7 @@ def upsert_user_profile(
     email: Optional[str],
     phone: Optional[str],
     linkedin: Optional[str],
+    github: Optional[str],
     location: Optional[str],
     profile_text: Optional[str],
 ) -> None:
@@ -78,6 +82,7 @@ def upsert_user_profile(
     clean_email = _clean_optional_text(email)
     clean_phone = _clean_optional_text(phone)
     clean_linkedin = _clean_optional_text(linkedin)
+    clean_github = _clean_optional_text(github)
     clean_location = _clean_optional_text(location)
     clean_profile_text = _clean_optional_text(profile_text)
 
@@ -93,40 +98,34 @@ def upsert_user_profile(
     conn.execute(
         """
         INSERT INTO user_profiles
-        (user_id, phone, linkedin, location, profile_text, updated_at)
-        VALUES (?, ?, ?, ?, ?, datetime('now'))
+        (user_id, phone, linkedin, github, location, profile_text, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(user_id) DO UPDATE SET
             phone = excluded.phone,
             linkedin = excluded.linkedin,
+            github = excluded.github,
             location = excluded.location,
             profile_text = excluded.profile_text,
             updated_at = datetime('now')
         """,
-        (user_id, clean_phone, clean_linkedin, clean_location, clean_profile_text),
+        (user_id, clean_phone, clean_linkedin, clean_github, clean_location, clean_profile_text),
     )
 
     conn.commit()
 
 
-def build_contact_line(profile: Dict[str, Any]) -> Optional[str]:
-    """
-    Build a single contact line from the populated fields only.
-    Returns None if all contact fields are empty.
-    """
-    parts = []
-    for key in ("phone", "email", "linkedin", "location"):
-        value = _clean_optional_text(profile.get(key))
-        if value:
-            parts.append(value)
-
-    if not parts:
-        return None
-
-    return " | ".join(parts)
-
-
 def get_visible_profile_text(profile: Dict[str, Any]) -> Optional[str]:
-    """
-    Return the profile paragraph if populated, otherwise None.
-    """
     return _clean_optional_text(profile.get("profile_text"))
+
+
+def get_contact_parts(profile: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    """
+    Returns cleaned contact parts for rendering.
+    """
+    return {
+        "phone": _clean_optional_text(profile.get("phone")),
+        "email": _clean_optional_text(profile.get("email")),
+        "linkedin": _clean_optional_text(profile.get("linkedin")),
+        "github": _clean_optional_text(profile.get("github")),
+        "location": _clean_optional_text(profile.get("location")),
+    }

--- a/src/db/user_profile.py
+++ b/src/db/user_profile.py
@@ -1,0 +1,132 @@
+"""
+src/db/user_profile.py
+
+Helpers for storing and retrieving standalone user profile information.
+Email is stored on users.email.
+Other profile fields live in user_profiles.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, Optional
+
+
+def _clean_optional_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
+    """
+    Return the current profile data for a user.
+    Email comes from users.email.
+    """
+    row = conn.execute(
+        """
+        SELECT
+            u.user_id,
+            u.email,
+            p.phone,
+            p.linkedin,
+            p.location,
+            p.profile_text
+        FROM users u
+        LEFT JOIN user_profiles p
+            ON u.user_id = p.user_id
+        WHERE u.user_id = ?
+        """,
+        (user_id,),
+    ).fetchone()
+
+    if not row:
+        return {
+            "user_id": user_id,
+            "email": None,
+            "phone": None,
+            "linkedin": None,
+            "location": None,
+            "profile_text": None,
+        }
+
+    return {
+        "user_id": row[0],
+        "email": row[1],
+        "phone": row[2],
+        "linkedin": row[3],
+        "location": row[4],
+        "profile_text": row[5],
+    }
+
+
+def upsert_user_profile(
+    conn: sqlite3.Connection,
+    user_id: int,
+    *,
+    email: Optional[str],
+    phone: Optional[str],
+    linkedin: Optional[str],
+    location: Optional[str],
+    profile_text: Optional[str],
+) -> None:
+    """
+    Update users.email plus the per-user profile row.
+    Blank strings are normalized to NULL.
+    """
+    clean_email = _clean_optional_text(email)
+    clean_phone = _clean_optional_text(phone)
+    clean_linkedin = _clean_optional_text(linkedin)
+    clean_location = _clean_optional_text(location)
+    clean_profile_text = _clean_optional_text(profile_text)
+
+    conn.execute(
+        """
+        UPDATE users
+        SET email = ?
+        WHERE user_id = ?
+        """,
+        (clean_email, user_id),
+    )
+
+    conn.execute(
+        """
+        INSERT INTO user_profiles
+        (user_id, phone, linkedin, location, profile_text, updated_at)
+        VALUES (?, ?, ?, ?, ?, datetime('now'))
+        ON CONFLICT(user_id) DO UPDATE SET
+            phone = excluded.phone,
+            linkedin = excluded.linkedin,
+            location = excluded.location,
+            profile_text = excluded.profile_text,
+            updated_at = datetime('now')
+        """,
+        (user_id, clean_phone, clean_linkedin, clean_location, clean_profile_text),
+    )
+
+    conn.commit()
+
+
+def build_contact_line(profile: Dict[str, Any]) -> Optional[str]:
+    """
+    Build a single contact line from the populated fields only.
+    Returns None if all contact fields are empty.
+    """
+    parts = []
+    for key in ("phone", "email", "linkedin", "location"):
+        value = _clean_optional_text(profile.get(key))
+        if value:
+            parts.append(value)
+
+    if not parts:
+        return None
+
+    return " | ".join(parts)
+
+
+def get_visible_profile_text(profile: Dict[str, Any]) -> Optional[str]:
+    """
+    Return the profile paragraph if populated, otherwise None.
+    """
+    return _clean_optional_text(profile.get("profile_text"))

--- a/src/db/user_profile.py
+++ b/src/db/user_profile.py
@@ -29,6 +29,7 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
         SELECT
             u.user_id,
             u.email,
+            p.full_name,
             p.phone,
             p.linkedin,
             p.github,
@@ -46,6 +47,7 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
         return {
             "user_id": user_id,
             "email": None,
+            "full_name": None,
             "phone": None,
             "linkedin": None,
             "github": None,
@@ -56,11 +58,12 @@ def get_user_profile(conn: sqlite3.Connection, user_id: int) -> Dict[str, Any]:
     return {
         "user_id": row[0],
         "email": row[1],
-        "phone": row[2],
-        "linkedin": row[3],
-        "github": row[4],
-        "location": row[5],
-        "profile_text": row[6],
+        "full_name": row[2],
+        "phone": row[3],
+        "linkedin": row[4],
+        "github": row[5],
+        "location": row[6],
+        "profile_text": row[7],
     }
 
 
@@ -69,6 +72,7 @@ def upsert_user_profile(
     user_id: int,
     *,
     email: Optional[str],
+    full_name: Optional[str],
     phone: Optional[str],
     linkedin: Optional[str],
     github: Optional[str],
@@ -80,6 +84,7 @@ def upsert_user_profile(
     Blank strings are normalized to NULL.
     """
     clean_email = _clean_optional_text(email)
+    clean_full_name = _clean_optional_text(full_name)
     clean_phone = _clean_optional_text(phone)
     clean_linkedin = _clean_optional_text(linkedin)
     clean_github = _clean_optional_text(github)
@@ -98,9 +103,10 @@ def upsert_user_profile(
     conn.execute(
         """
         INSERT INTO user_profiles
-        (user_id, phone, linkedin, github, location, profile_text, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+        (user_id, full_name, phone, linkedin, github, location, profile_text, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
         ON CONFLICT(user_id) DO UPDATE SET
+            full_name = excluded.full_name,
             phone = excluded.phone,
             linkedin = excluded.linkedin,
             github = excluded.github,
@@ -108,7 +114,15 @@ def upsert_user_profile(
             profile_text = excluded.profile_text,
             updated_at = datetime('now')
         """,
-        (user_id, clean_phone, clean_linkedin, clean_github, clean_location, clean_profile_text),
+        (
+            user_id,
+            clean_full_name,
+            clean_phone,
+            clean_linkedin,
+            clean_github,
+            clean_location,
+            clean_profile_text,
+        ),
     )
 
     conn.commit()
@@ -129,3 +143,11 @@ def get_contact_parts(profile: Dict[str, Any]) -> Dict[str, Optional[str]]:
         "github": _clean_optional_text(profile.get("github")),
         "location": _clean_optional_text(profile.get("location")),
     }
+
+
+def get_resume_name(profile: Dict[str, Any], username: str) -> str:
+    """
+    Return the display name for resume export.
+    Falls back to username if full_name is not set.
+    """
+    return _clean_optional_text(profile.get("full_name")) or username

--- a/src/export/portfolio_docx.py
+++ b/src/export/portfolio_docx.py
@@ -31,7 +31,13 @@ from docx.shared import Inches
 from docx.enum.text import WD_ALIGN_PARAGRAPH
 
 from src.insights.rank_projects.rank_project_importance import collect_project_data
-from src.db import get_project_summary_row, get_project_thumbnail_path, get_project_key
+from src.db import (
+    get_project_summary_row,
+    get_project_thumbnail_path,
+    get_project_key,
+    get_user_profile,
+)
+
 from src.insights.portfolio import (
     format_duration,
     format_activity_line,
@@ -100,11 +106,13 @@ def export_portfolio_to_docx(
     filepath = out_path / filename
 
     project_scores: List[Tuple[str, float]] = collect_project_data(conn, user_id)
+    user_profile = get_user_profile(conn, user_id)
+    display_name = (user_profile.get("full_name") or username).strip()
 
     doc = Document()
 
     # Header
-    doc.add_heading(f"Portfolio - {username}", level=0)
+    doc.add_heading(f"Portfolio - {display_name}", level=0)
     doc.add_paragraph(f"Generated on {stamp_display}")
 
     if not project_scores:

--- a/src/export/portfolio_pdf.py
+++ b/src/export/portfolio_pdf.py
@@ -62,7 +62,6 @@ from src.export.shared_helpers import (
 )
 from src.export.portfolio_helpers import reformat_duration_line, _skills_one_line,  _frameworks_clean, _languages_clean
 from src.insights.portfolio.formatters import _clean_bullets
-from tests.test_db_skills import conn
 
 # -------------------------
 # Local helpers (PDF-only)

--- a/src/export/portfolio_pdf.py
+++ b/src/export/portfolio_pdf.py
@@ -37,7 +37,13 @@ from reportlab.platypus.flowables import HRFlowable
 from reportlab.lib import utils
 
 from src.insights.rank_projects.rank_project_importance import collect_project_data
-from src.db import get_project_summary_row, get_project_thumbnail_path, get_project_key
+from src.db import (
+    get_project_summary_row,
+    get_project_thumbnail_path,
+    get_project_key,
+    get_user_profile,
+)
+
 from src.insights.portfolio import (
     format_duration,
     format_activity_line,
@@ -56,6 +62,7 @@ from src.export.shared_helpers import (
 )
 from src.export.portfolio_helpers import reformat_duration_line, _skills_one_line,  _frameworks_clean, _languages_clean
 from src.insights.portfolio.formatters import _clean_bullets
+from tests.test_db_skills import conn
 
 # -------------------------
 # Local helpers (PDF-only)
@@ -115,6 +122,8 @@ def export_portfolio_to_pdf(
     filepath = out_path / filename
 
     project_scores: List[Tuple[str, float]] = collect_project_data(conn, user_id)
+    user_profile = get_user_profile(conn, user_id)
+    display_name = (user_profile.get("full_name") or username).strip()
 
     doc = SimpleDocTemplate(
         str(filepath),
@@ -123,8 +132,8 @@ def export_portfolio_to_pdf(
         rightMargin=0.85 * inch,
         topMargin=0.85 * inch,
         bottomMargin=0.85 * inch,
-        title=f"Portfolio - {username}",
-        author=username,
+        title=f"Portfolio - {display_name}",
+        author=display_name,
     )
 
     styles = getSampleStyleSheet()
@@ -201,7 +210,7 @@ def export_portfolio_to_pdf(
     story: List[Any] = []
 
     # Header
-    story.append(Paragraph(f"Portfolio - {username}", TitleStyle))
+    story.append(Paragraph(f"Portfolio - {display_name}", TitleStyle))
     story.append(_rule())
     story.append(Paragraph(f"Generated on {stamp_display}", MetaStyle))
 

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -35,6 +35,11 @@ from src.export.resume_helpers import (
     filter_skills_by_highlighted,
 )
 
+from src.db import (
+    build_contact_line,
+    get_visible_profile_text,
+)
+
 def _clean_str(value: Any) -> str | None:
     if not isinstance(value, str):
         return None
@@ -117,6 +122,7 @@ def export_resume_record_to_docx(
     out_dir: str = "./out",
     highlighted_skills: Optional[List[str]] = None,
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
+    user_profile: Optional[Dict[str, Any]] = None,
 ) -> Path:
     """
     record is the dict returned by get_resume_snapshot(...).
@@ -136,8 +142,12 @@ def export_resume_record_to_docx(
     # doc.add_heading(f"Resume — {username}", level=0)
     # doc.add_paragraph(f"Generated on {stamp_display}")
 
+    profile = user_profile or {}
     doc.add_heading(username.upper(), level=0)
-    doc.add_paragraph("Phone | Email | LinkedIn | Location")
+
+    contact_line = build_contact_line(profile)
+    if contact_line:
+        doc.add_paragraph(contact_line)
 
     resume_json = record.get("resume_json")
     rendered_text = record.get("rendered_text")
@@ -168,8 +178,10 @@ def export_resume_record_to_docx(
     # ---------------------------
 
     # PROFILE (placeholder)
-    add_section_heading(doc, "Profile")
-    add_placeholder(doc, "To be updated later.")
+    profile_text = get_visible_profile_text(profile)
+    if profile_text:
+        add_section_heading(doc, "Profile")
+        doc.add_paragraph(profile_text)
 
     # SKILLS (same logic as before)
     add_section_heading(doc, "Skills")

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 import json
-from pydoc import doc
 import re
 from typing import Any, Dict, List, Optional
 

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -23,6 +23,8 @@ import re
 from typing import Any, Dict, List, Optional
 
 from docx import Document
+from docx.oxml import OxmlElement
+from docx.oxml.ns import qn
 
 from src.export.resume_helpers import (
     format_date_range,
@@ -36,7 +38,7 @@ from src.export.resume_helpers import (
 )
 
 from src.db import (
-    build_contact_line,
+    get_contact_parts,
     get_visible_profile_text,
 )
 
@@ -113,6 +115,41 @@ def _safe_slug(s: str) -> str:
 def _add_bullet(doc: Document, text: str) -> None:
     p = doc.add_paragraph(text, style="List Bullet")
     p.paragraph_format.space_after = 0
+    
+
+def _add_hyperlink(paragraph, url: str, text: str) -> None:
+    """
+    Add a clickable hyperlink to a python-docx paragraph.
+    """
+    part = paragraph.part
+    r_id = part.relate_to(
+        url,
+        "http://schemas.openxmlformats.org/officeDocument/2006/relationships/hyperlink",
+        is_external=True,
+    )
+
+    hyperlink = OxmlElement("w:hyperlink")
+    hyperlink.set(qn("r:id"), r_id)
+
+    new_run = OxmlElement("w:r")
+    r_pr = OxmlElement("w:rPr")
+
+    color = OxmlElement("w:color")
+    color.set(qn("w:val"), "0563C1")
+    r_pr.append(color)
+
+    underline = OxmlElement("w:u")
+    underline.set(qn("w:val"), "single")
+    r_pr.append(underline)
+
+    new_run.append(r_pr)
+
+    text_elem = OxmlElement("w:t")
+    text_elem.text = text
+    new_run.append(text_elem)
+
+    hyperlink.append(new_run)
+    paragraph._p.append(hyperlink)
 
 
 def export_resume_record_to_docx(
@@ -143,11 +180,33 @@ def export_resume_record_to_docx(
     # doc.add_paragraph(f"Generated on {stamp_display}")
 
     profile = user_profile or {}
+    contact_parts = get_contact_parts(profile)
+
     doc.add_heading(username.upper(), level=0)
 
-    contact_line = build_contact_line(profile)
-    if contact_line:
-        doc.add_paragraph(contact_line)
+    contact_bits = []
+    if contact_parts["phone"]:
+        contact_bits.append(("text", contact_parts["phone"]))
+    if contact_parts["email"]:
+        contact_bits.append(("text", contact_parts["email"]))
+    if contact_parts["linkedin"]:
+        contact_bits.append(("link", "LinkedIn", contact_parts["linkedin"]))
+    if contact_parts["github"]:
+        contact_bits.append(("link", "GitHub", contact_parts["github"]))
+    if contact_parts["location"]:
+        contact_bits.append(("text", contact_parts["location"]))
+
+    if contact_bits:
+        p = doc.add_paragraph()
+        for i, item in enumerate(contact_bits):
+            if i > 0:
+                p.add_run(" | ")
+
+            if item[0] == "text":
+                p.add_run(item[1])
+            else:
+                _, label, url = item
+                _add_hyperlink(p, url, label)
 
     resume_json = record.get("resume_json")
     rendered_text = record.get("rendered_text")

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 import json
+from pydoc import doc
 import re
 from typing import Any, Dict, List, Optional
 
@@ -40,6 +41,7 @@ from src.export.resume_helpers import (
 from src.db import (
     get_contact_parts,
     get_visible_profile_text,
+    get_resume_name,
 )
 
 def _clean_str(value: Any) -> str | None:
@@ -182,7 +184,8 @@ def export_resume_record_to_docx(
     profile = user_profile or {}
     contact_parts = get_contact_parts(profile)
 
-    doc.add_heading(username.upper(), level=0)
+    display_name = get_resume_name(profile, username)
+    doc.add_heading(display_name.upper(), level=0)
 
     contact_bits = []
     if contact_parts["phone"]:

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -50,6 +50,7 @@ from src.export.resume_helpers import (
 from src.db import (
     get_contact_parts,
     get_visible_profile_text,
+    get_resume_name,
 )
 
 def _safe_slug(s: str) -> str:
@@ -244,7 +245,8 @@ def export_resume_record_to_pdf(
     # ---------------------------
     profile = user_profile or {}
 
-    story.append(Paragraph(username.upper(), NameStyle))
+    display_name = get_resume_name(profile, username)
+    story.append(Paragraph(display_name.upper(), NameStyle))
     story.append(rule())
 
     contact_html = _pdf_contact_html(profile)

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -45,6 +45,10 @@ from src.export.resume_helpers import (
     filter_skills_by_highlighted,
 )
 
+from src.db import (
+    build_contact_line,
+    get_visible_profile_text,
+)
 
 def _safe_slug(s: str) -> str:
     s = (s or "").strip().lower()
@@ -104,6 +108,7 @@ def export_resume_record_to_pdf(
     out_dir: str = "./out",
     highlighted_skills: Optional[List[str]] = None,
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
+    user_profile: Optional[Dict[str, Any]] = None,
 ) -> Path:
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
@@ -214,9 +219,14 @@ def export_resume_record_to_pdf(
     # ---------------------------
     # Header
     # ---------------------------
+    profile = user_profile or {}
+
     story.append(Paragraph(username.upper(), NameStyle))
-    story.append(rule())  # line between name and contact
-    story.append(Paragraph("Phone | Email | LinkedIn | Location", ContactStyle))
+    story.append(rule())
+
+    contact_line = build_contact_line(profile)
+    if contact_line:
+        story.append(Paragraph(contact_line, ContactStyle))
 
     # If JSON is broken, dump rendered_text as paragraphs
     if snapshot is None:
@@ -238,9 +248,11 @@ def export_resume_record_to_pdf(
     # ---------------------------
     # PROFILE
     # ---------------------------
-    story.append(section_gap())
-    story.append(Paragraph("PROFILE", SectionStyle))
-    story.append(Paragraph("To be updated later.", PlaceholderItalic))
+    profile_text = get_visible_profile_text(profile)
+    if profile_text:
+        story.append(section_gap())
+        story.append(Paragraph("PROFILE", SectionStyle))
+        story.append(Paragraph(profile_text, Body))
 
     # ---------------------------
     # SKILLS

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -2,7 +2,7 @@
 """
 Export a saved resume snapshot (stored JSON) directly to a PDF using ReportLab (Platypus).
 
-Layout (requested):
+Layout:
 - Name (largest)
 - line between name and contact
 - Contact line
@@ -25,6 +25,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+from xml.sax.saxutils import escape
+
 from reportlab.lib.pagesizes import LETTER
 from reportlab.lib.units import inch
 from reportlab.lib.enums import TA_LEFT
@@ -46,7 +48,7 @@ from src.export.resume_helpers import (
 )
 
 from src.db import (
-    build_contact_line,
+    get_contact_parts,
     get_visible_profile_text,
 )
 
@@ -99,6 +101,27 @@ def _resume_key_role(p: Dict[str, Any]) -> str | None:
     if manual_role:
         return manual_role
     return _clean_str(p.get("key_role"))
+
+
+def _pdf_contact_html(profile: Dict[str, Any]) -> str | None:
+    parts = get_contact_parts(profile)
+    chunks: List[str] = []
+
+    if parts["phone"]:
+        chunks.append(escape(parts["phone"]))
+    if parts["email"]:
+        chunks.append(escape(parts["email"]))
+    if parts["linkedin"]:
+        chunks.append(f'<link href="{escape(parts["linkedin"])}">LinkedIn</link>')
+    if parts["github"]:
+        chunks.append(f'<link href="{escape(parts["github"])}">GitHub</link>')
+    if parts["location"]:
+        chunks.append(escape(parts["location"]))
+
+    if not chunks:
+        return None
+
+    return " | ".join(chunks)
 
 
 def export_resume_record_to_pdf(
@@ -224,9 +247,9 @@ def export_resume_record_to_pdf(
     story.append(Paragraph(username.upper(), NameStyle))
     story.append(rule())
 
-    contact_line = build_contact_line(profile)
-    if contact_line:
-        story.append(Paragraph(contact_line, ContactStyle))
+    contact_html = _pdf_contact_html(profile)
+    if contact_html:
+        story.append(Paragraph(contact_html, ContactStyle))
 
     # If JSON is broken, dump rendered_text as paragraphs
     if snapshot is None:
@@ -252,7 +275,7 @@ def export_resume_record_to_pdf(
     if profile_text:
         story.append(section_gap())
         story.append(Paragraph("PROFILE", SectionStyle))
-        story.append(Paragraph(profile_text, Body))
+        story.append(Paragraph(escape(profile_text), Body))
 
     # ---------------------------
     # SKILLS

--- a/src/main.py
+++ b/src/main.py
@@ -25,7 +25,8 @@ from src.menu import (
     view_ranked_projects,
     manage_project_thumbnails,
     edit_project_dates_menu,
-    view_activity_heatmap
+    view_activity_heatmap,
+    edit_user_profile
 )
 from src.consent.consent import CONSENT_TEXT, get_user_consent, record_consent
 from src.consent.external_consent import get_external_consent, record_external_consent
@@ -93,6 +94,8 @@ def prompt_and_store():
         elif menu_choice == 12:
             project_list(conn, user_id, username)
         elif menu_choice == 13:
+            edit_user_profile(conn, user_id, username)
+        elif menu_choice == 14:
             print("\nThank you for using the system. Goodbye!")
             return None
         elif menu_choice == 1:

--- a/src/menu/__init__.py
+++ b/src/menu/__init__.py
@@ -17,6 +17,7 @@ from .project_dates import edit_project_dates_menu
 from .delete import delete_old_insights
 from .thumbnails import manage_project_thumbnails
 from .heatmap import view_activity_heatmap
+from .profile import edit_user_profile
 
 __all__ = [
     "show_start_menu",
@@ -32,4 +33,5 @@ __all__ = [
     "edit_project_dates_menu",
     "delete_old_insights",
     "manage_project_thumbnails",
+    "edit_user_profile",
 ]

--- a/src/menu/display.py
+++ b/src/menu/display.py
@@ -22,10 +22,10 @@ def show_start_menu(username: str) -> int:
     print("10. Edit project dates")
     print("11. Manage project thumbnails")
     print("12. View all projects")
-    print("13. Exit")
+    print("13. Edit profile")
+    print("14. Exit")
     while True:
-        choice = input("\nPlease select an option (1-13): ").strip()
-        if choice in {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13"}:
+        choice = input("\nPlease select an option (1-14): ").strip()
+        if choice in {"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14"}:
             return int(choice)
-        print("Invalid choice. Please enter a number between 1 and 13.")
-
+        print("Invalid choice. Please enter a number between 1 and 14.")

--- a/src/menu/profile.py
+++ b/src/menu/profile.py
@@ -38,6 +38,7 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
     current = get_user_profile(conn, user_id)
 
     print(f"\nProfile settings for {username}:")
+    print(f"Full name: {_display_value(current.get('full_name'))}")
     print(f"Email: {_display_value(current.get('email'))}")
     print(f"Phone: {_display_value(current.get('phone'))}")
     print(f"LinkedIn: {_display_value(current.get('linkedin'))}")
@@ -48,6 +49,7 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
     print("\nPress Enter to keep the current value.")
     print("Type '-' to clear/delete a value.\n")
 
+    full_name = _prompt_field("Full name", current.get("full_name"))
     email = _prompt_field("Email", current.get("email"))
     phone = _prompt_field("Phone", current.get("phone"))
     linkedin = _prompt_field("LinkedIn URL", current.get("linkedin"))
@@ -59,6 +61,7 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
         conn,
         user_id,
         email=email,
+        full_name=full_name,
         phone=phone,
         linkedin=linkedin,
         github=github,

--- a/src/menu/profile.py
+++ b/src/menu/profile.py
@@ -1,6 +1,9 @@
 """
 src/menu/profile.py
-Menu for editing user profile information used in resume export.
+
+Standalone profile menu/handler.
+This is intentionally separate from resume editing because the frontend
+will eventually expose profile and resume on different pages.
 """
 
 from __future__ import annotations
@@ -38,6 +41,7 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
     print(f"Email: {_display_value(current.get('email'))}")
     print(f"Phone: {_display_value(current.get('phone'))}")
     print(f"LinkedIn: {_display_value(current.get('linkedin'))}")
+    print(f"GitHub: {_display_value(current.get('github'))}")
     print(f"Location: {_display_value(current.get('location'))}")
     print(f"Profile paragraph: {_display_value(current.get('profile_text'))}")
 
@@ -46,7 +50,8 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
 
     email = _prompt_field("Email", current.get("email"))
     phone = _prompt_field("Phone", current.get("phone"))
-    linkedin = _prompt_field("LinkedIn", current.get("linkedin"))
+    linkedin = _prompt_field("LinkedIn URL", current.get("linkedin"))
+    github = _prompt_field("GitHub URL", current.get("github"))
     location = _prompt_field("Location", current.get("location"))
     profile_text = _prompt_field("Profile paragraph", current.get("profile_text"))
 
@@ -56,6 +61,7 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
         email=email,
         phone=phone,
         linkedin=linkedin,
+        github=github,
         location=location,
         profile_text=profile_text,
     )

--- a/src/menu/profile.py
+++ b/src/menu/profile.py
@@ -1,0 +1,63 @@
+"""
+src/menu/profile.py
+Menu for editing user profile information used in resume export.
+"""
+
+from __future__ import annotations
+
+from src.db.user_profile import get_user_profile, upsert_user_profile
+
+
+def _display_value(value: str | None) -> str:
+    return value if value else "(not set)"
+
+
+def _prompt_field(label: str, current: str | None) -> str | None:
+    """
+    Enter -> keep existing value
+    '-'   -> clear/delete value
+    text  -> update value
+    """
+    suffix = f" [{current}]" if current else ""
+    raw = input(f"{label}{suffix}: ").strip()
+
+    if raw == "":
+        return current
+    if raw == "-":
+        return None
+    return raw
+
+
+def edit_user_profile(conn, user_id: int, username: str) -> None:
+    """
+    Edit standalone user profile fields used by resume export.
+    """
+    current = get_user_profile(conn, user_id)
+
+    print(f"\nProfile settings for {username}:")
+    print(f"Email: {_display_value(current.get('email'))}")
+    print(f"Phone: {_display_value(current.get('phone'))}")
+    print(f"LinkedIn: {_display_value(current.get('linkedin'))}")
+    print(f"Location: {_display_value(current.get('location'))}")
+    print(f"Profile paragraph: {_display_value(current.get('profile_text'))}")
+
+    print("\nPress Enter to keep the current value.")
+    print("Type '-' to clear/delete a value.\n")
+
+    email = _prompt_field("Email", current.get("email"))
+    phone = _prompt_field("Phone", current.get("phone"))
+    linkedin = _prompt_field("LinkedIn", current.get("linkedin"))
+    location = _prompt_field("Location", current.get("location"))
+    profile_text = _prompt_field("Profile paragraph", current.get("profile_text"))
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email=email,
+        phone=phone,
+        linkedin=linkedin,
+        location=location,
+        profile_text=profile_text,
+    )
+
+    print("\nProfile saved.")

--- a/src/menu/resume/flow.py
+++ b/src/menu/resume/flow.py
@@ -15,6 +15,7 @@ from src.db import (
     get_resume_snapshot,
     update_resume_snapshot,
     delete_resume_snapshot,
+    get_user_profile
 )
 from src.insights.rank_projects.rank_project_importance import collect_project_data
 from .helpers import (
@@ -306,12 +307,14 @@ def _handle_export_resume_docx(conn, user_id: int, username: str) -> bool:
     highlighted_skills = get_highlighted_skills_for_display(
         conn, user_id, context="resume", context_id=resume_id
     )
-
+    
+    user_profile = get_user_profile(conn, user_id)
     out_file = export_resume_record_to_docx(
         username=username,
         record=record,
         out_dir="./out",
         highlighted_skills=highlighted_skills,
+        user_profile=user_profile,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")
@@ -434,12 +437,14 @@ def _handle_export_resume_pdf(conn, user_id: int, username: str) -> bool:
     highlighted_skills = get_highlighted_skills_for_display(
         conn, user_id, context="resume", context_id=resume_id
     )
-
+    
+    user_profile = get_user_profile(conn, user_id)
     out_file = export_resume_record_to_pdf(
         username=username,
         record=record,
         out_dir="./out",
         highlighted_skills=highlighted_skills,
+        user_profile=user_profile,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")

--- a/tests/test_framework_detector.py
+++ b/tests/test_framework_detector.py
@@ -121,7 +121,7 @@ def test_missing_config_file_is_skipped(conn):
         conn.commit()
 
         frameworks = fd.detect_frameworks(conn, "projB", 2, zip_name + ".zip")
-        assert frameworks == set()
+        assert frameworks == []
     finally:
         _cleanup_zip_data(zip_name)
 
@@ -145,7 +145,7 @@ def test_unreadable_config_entry_is_handled_gracefully(conn):
 
         # Should not raise, and should simply return empty set
         frameworks = fd.detect_frameworks(conn, "projD", 4, zip_name + ".zip")
-        assert frameworks == set()
+        assert frameworks == []
     finally:
         _cleanup_zip_data(zip_name)
 
@@ -170,7 +170,7 @@ def test_no_frameworks_present_returns_empty(conn):
         conn, "no_frameworks_zip", "requirements.txt", "requests==2.31.0\nnumpy==1.24.0\n",
         "emptyProj", 12, []
     )
-    assert frameworks == set()
+    assert frameworks == []
 
 def test_detects_python_web_frameworks(conn):
     """Detects multiple Python web frameworks from requirements.txt"""

--- a/tests/test_menu_display.py
+++ b/tests/test_menu_display.py
@@ -6,9 +6,9 @@ from src.menu.display import show_start_menu
 class TestShowStartMenu:
     """Tests for the main menu display functionality."""
 
-    @pytest.mark.parametrize("choice", [str(i) for i in range(1, 14)])
+    @pytest.mark.parametrize("choice", [str(i) for i in range(1, 15)])
     def test_valid_menu_choices(self, choice):
-        """Test that valid menu choices (1-13) are accepted and returned as integers."""
+        """Test that valid menu choices (1-14) are accepted and returned as integers."""
         username = "testuser"
 
         with patch("builtins.input", return_value=choice):
@@ -17,7 +17,7 @@ class TestShowStartMenu:
 
     @pytest.mark.parametrize("invalid_input,valid_input", [
         ("0", "1"),     # Number out of range (too low)
-        ("14", "2"),    # Number out of range (too high)
+        ("15", "2"),    # Number out of range (too high)
         ("99", "3"),    # Number out of range (way too high)
         ("-1", "4"),    # Negative number
     ])
@@ -91,7 +91,8 @@ class TestShowStartMenu:
             "10. Edit project dates",
             "11. Manage project thumbnails",
             "12. View all projects",
-            "13. Exit",
+            "13. Edit profile",
+            "14. Exit",
         ]
 
         with patch("builtins.input", return_value="1"):

--- a/tests/test_portfolio_docx.py
+++ b/tests/test_portfolio_docx.py
@@ -391,3 +391,34 @@ def test_export_portfolio_docx_before_after_edit_display_name_summary_and_contri
 
     assert "Did X" not in t3
     assert "Did Y" in t3
+
+
+def test_export_portfolio_docx_uses_full_name_from_profile(monkeypatch, tmp_path, conn):
+    """
+    Portfolio DOCX header should use full_name when profile data exists.
+    """
+    from src.export import portfolio_docx as mod
+
+    conn.execute(
+        "INSERT INTO users (user_id, username) VALUES (?, ?)",
+        (1, "Jordan"),
+    )
+    conn.execute(
+        "INSERT INTO user_profiles (user_id, full_name) VALUES (?, ?)",
+        (1, "Jordan Lee"),
+    )
+    conn.commit()
+
+    monkeypatch.setattr(mod, "collect_project_data", lambda _conn, _user_id: [])
+    monkeypatch.setattr(mod, "get_project_summary_row", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "get_project_thumbnail_path", lambda *_args, **_kwargs: None)
+
+    docx_path = mod.export_portfolio_to_docx(
+        conn=conn,
+        user_id=1,
+        username="Jordan",
+        out_dir=str(tmp_path),
+    )
+
+    text = _extract_docx_text(docx_path)
+    assert "Portfolio - Jordan Lee" in text

--- a/tests/test_portfolio_pdf.py
+++ b/tests/test_portfolio_pdf.py
@@ -427,3 +427,34 @@ def test_export_portfolio_pdf_before_after_edit_display_name_summary_and_contrib
 
     assert "Did X" not in t3
     assert "Did Y" in t3
+
+
+def test_export_portfolio_pdf_uses_full_name_from_profile(monkeypatch, tmp_path, conn):
+    """
+    Portfolio PDF header should use full_name when profile data exists.
+    """
+    from src.export import portfolio_pdf as mod
+
+    conn.execute(
+        "INSERT INTO users (user_id, username) VALUES (?, ?)",
+        (1, "Salma"),
+    )
+    conn.execute(
+        "INSERT INTO user_profiles (user_id, full_name) VALUES (?, ?)",
+        (1, "Salma Yusuf"),
+    )
+    conn.commit()
+
+    monkeypatch.setattr(mod, "collect_project_data", lambda _conn, _user_id: [])
+    monkeypatch.setattr(mod, "get_project_summary_row", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(mod, "get_project_thumbnail_path", lambda *_args, **_kwargs: None)
+
+    pdf_path = mod.export_portfolio_to_pdf(
+        conn=conn,
+        user_id=1,
+        username="Salma",
+        out_dir=str(tmp_path),
+    )
+
+    text = _extract_pdf_text(pdf_path)
+    assert "Portfolio - Salma Yusuf" in text

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -3,9 +3,7 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import zipfile
 
-import pytest
 import src.export.resume_docx as exp
-import src.menu.resume.flow as flow
 
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -38,59 +36,45 @@ def _docx_hyperlink_targets(path: Path) -> list[str]:
     return targets
 
 
-def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
-    """
-    Covers:
-    - deterministic filename via frozen datetime
-    - structure/order:
-      Name -> Contact -> PROFILE -> SKILLS -> PROJECTS -> EDUCATION & CERTIFICATES
-    - projects sorted by most-recent end_date/start_date first
-    - LinkedIn/GitHub shown as labels, with real hyperlink targets in the docx
-    """
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    if fmt == "%Y-%m-%d at %H:%M:%S":
-                        return "2026-01-10 at 15:36:58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
+class _FakeDatetime:
+    @staticmethod
+    def now():
+        class _DT:
+            def strftime(self, fmt: str) -> str:
+                return "2026-01-10_15-36-58"
+        return _DT()
 
+
+def test_resume_docx_profile_happy_path(monkeypatch, tmp_path):
+    """
+    Covers PR 1 happy path:
+    - full_name is used instead of username
+    - profile/contact info render
+    - LinkedIn/GitHub render as labels with hyperlink targets
+    - profile section shows when populated
+    """
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
         "aggregated_skills": {
-            "languages": ["Python 88%", "SQL 12%"],
+            "languages": ["Python 88%"],
             "frameworks": ["FastAPI"],
             "technical_skills": ["Algorithms"],
-            "writing_skills": ["Clear communication"],
+            "writing_skills": [],
         },
         "projects": [
             {
-                "project_name": "older_project",
-                "role": "[Role]",
-                "start_date": "2024-12-01",
-                "end_date": "2024-12-31",
-                "contribution_bullets": ["Old bullet A"],
-            },
-            {
-                "project_name": "newer_project",
-                "role": "[Role]",
-                "start_date": "2025-08-01",
-                "end_date": "2025-11-01",
-                "contribution_bullets": ["New bullet A", "New bullet B"],
+                "project_name": "test_project",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Built API endpoints"],
             },
         ],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
-    out_dir = tmp_path / "out"
-
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
     user_profile = {
-        "full_name": None,
+        "full_name": "John Tan",
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -100,118 +84,45 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     }
 
     path = exp.export_resume_record_to_docx(
-        username="john",
+        username="john123",
         record=record,
-        out_dir=str(out_dir),
+        out_dir=str(tmp_path / "out"),
         user_profile=user_profile,
     )
-
-    assert out_dir.exists()
-    assert path.exists()
-    assert path.name == "resume_john_2026-01-10_15-36-58.docx"
 
     txt = _doc_text(path)
     hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "john" in txt.lower()
-
-    # Contact line pieces appear as visible text
-    assert "1234567890" in txt
+    assert "JOHN TAN" in txt
     assert "john@example.com" in txt
+    assert "1234567890" in txt
     assert "LinkedIn" in txt
     assert "GitHub" in txt
     assert "Kelowna, BC" in txt
+    assert "PROFILE" in txt
+    assert "Software and data student building practical tools." in txt
 
-    # URLs should be hyperlink targets, not visible text
     assert "https://linkedin.com/in/john" in hyperlink_targets
     assert "https://github.com/john" in hyperlink_targets
     assert "https://linkedin.com/in/john" not in txt
     assert "https://github.com/john" not in txt
 
-    # Required sections exist
-    assert "PROFILE" in txt
-    assert "SKILLS" in txt
-    assert "PROJECTS" in txt
-    assert "EDUCATION & CERTIFICATES" in txt
 
-    # Order: PROFILE -> SKILLS -> PROJECTS -> EDUCATION
-    idx_profile = txt.find("PROFILE")
-    idx_skills = txt.find("SKILLS")
-    idx_projects = txt.find("PROJECTS")
-    idx_edu = txt.find("EDUCATION & CERTIFICATES")
-    assert -1 not in (idx_profile, idx_skills, idx_projects, idx_edu)
-    assert idx_profile < idx_skills < idx_projects < idx_edu
-
-    # Profile paragraph rendered
-    assert "Software and data student building practical tools." in txt
-
-    # Skills lines rendered
-    assert "Languages:" in txt
-    assert ("Python" in txt) and ("SQL" in txt)
-    assert "Frameworks:" in txt
-    assert "FastAPI" in txt
-    assert "Technical skills:" in txt
-    assert "Algorithms" in txt
-    assert "Writing skills:" in txt
-    assert "Clear communication" in txt
-
-    # Projects content
-    assert "newer_project" in txt
-    assert "older_project" in txt
-    assert "[Role]" in txt
-
-    # Contributions bullets appear
-    assert "New bullet A" in txt
-    assert "New bullet B" in txt
-    assert "Old bullet A" in txt
-
-    # Sorting check: newer should appear before older
-    assert txt.find("newer_project") < txt.find("older_project")
-
-    # Optional: verify years appear somewhere
-    assert "2025" in txt and "2024" in txt
-
-
-def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty(monkeypatch, tmp_path):
+def test_resume_docx_profile_omits_empty_fields(monkeypatch, tmp_path):
     """
-    Covers:
-    - empty standalone profile should not render contact info
-    - PROFILE section should be omitted when profile_text is empty
+    Covers PR 1 omission behavior:
+    - falls back to username when full_name missing
+    - contact line is omitted when fields are empty
+    - profile section is omitted when profile_text is empty
     """
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    if fmt == "%Y-%m-%d at %H:%M:%S":
-                        return "2026-01-10 at 15:36:58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
-        "aggregated_skills": {
-            "languages": ["Python 88%"],
-            "frameworks": [],
-            "technical_skills": [],
-            "writing_skills": [],
-        },
-        "projects": [
-            {
-                "project_name": "projA",
-                "start_date": "2025-08-01",
-                "end_date": "2025-11-01",
-                "contribution_bullets": ["Bullet A"],
-            }
-        ],
+        "aggregated_skills": {},
+        "projects": [],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
-    out_dir = tmp_path / "out"
-
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
     empty_profile = {
         "full_name": None,
         "email": None,
@@ -223,20 +134,16 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
     }
 
     path = exp.export_resume_record_to_docx(
-        username="john",
+        username="john123",
         record=record,
-        out_dir=str(out_dir),
+        out_dir=str(tmp_path / "out"),
         user_profile=empty_profile,
     )
 
     txt = _doc_text(path)
     hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "john" in txt.lower()
-    assert "SKILLS" in txt
-    assert "PROJECTS" in txt
-    assert "EDUCATION & CERTIFICATES" in txt
-
+    assert "JOHN123" in txt
     assert "PROFILE" not in txt
     assert "john@example.com" not in txt
     assert "1234567890" not in txt
@@ -246,231 +153,3 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
 
     assert all("linkedin.com" not in target for target in hyperlink_targets)
     assert all("github.com" not in target for target in hyperlink_targets)
-
-
-def test_resume_export_nonhappy_no_saved_resumes(monkeypatch, capsys):
-    """
-    Covers: R2 (flow handler: list_resumes empty)
-    """
-    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: [])
-    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-    assert ok is False
-    assert "No saved resumes yet" in out
-
-
-def test_resume_export_nonhappy_cancel_invalid_selection(monkeypatch, capsys):
-    """
-    Covers: R3 + R4 (cancel, invalid index)
-    """
-    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
-    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
-    monkeypatch.setattr(
-        flow,
-        "get_resume_snapshot",
-        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
-    )
-    monkeypatch.setattr(flow, "export_resume_record_to_docx", lambda **k: Path("./out/fake.docx"))
-
-    # cancel (Enter)
-    monkeypatch.setattr("builtins.input", lambda _: "")
-    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-    assert ok is False
-    assert "Cancelled" in out
-
-    # invalid index (999)
-    monkeypatch.setattr("builtins.input", lambda _: "999")
-    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-    assert ok is False
-    assert "Invalid selection" in out
-
-
-def test_resume_export_nonhappy_record_missing(monkeypatch, capsys):
-    """
-    Covers: R5 (get_resume_snapshot returns None)
-    """
-    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
-    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
-    monkeypatch.setattr(flow, "get_resume_snapshot", lambda conn, user_id, rid: None)
-    monkeypatch.setattr("builtins.input", lambda _: "1")
-
-    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-    assert ok is False
-    assert "Unable to load the selected resume" in out
-
-
-def test_resume_export_fallback_to_rendered_text(monkeypatch, tmp_path):
-    """
-    Covers: R6 + R7 (malformed JSON -> fallback; missing rendered_text -> message)
-    """
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    if fmt == "%Y-%m-%d at %H:%M:%S":
-                        return "2026-01-10 at 15:36:58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    out_dir = tmp_path / "out"
-
-    # R6: bad JSON + good rendered_text
-    record = {"resume_json": "{not json", "rendered_text": "LINE1\nLINE2\n"}
-    path = exp.export_resume_record_to_docx(username="john", record=record, out_dir=str(out_dir))
-    txt = _doc_text(path)
-    assert "Resume Snapshot" in txt
-    assert "LINE1" in txt and "LINE2" in txt
-
-    # R7: bad JSON + missing rendered_text
-    record2 = {"resume_json": "{not json", "rendered_text": ""}
-    path2 = exp.export_resume_record_to_docx(username="john", record=record2, out_dir=str(out_dir))
-    txt2 = _doc_text(path2)
-    assert "Resume data is missing or unreadable" in txt2
-
-
-def test_resume_export_uses_key_role(monkeypatch, tmp_path):
-    """Test that export uses resolved key_role instead of [Role] placeholder."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {},
-        "projects": [
-            {
-                "project_name": "test_project",
-                "key_role": "Backend Developer",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Built API endpoints"],
-            },
-        ],
-    }
-
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
-
-    txt = _doc_text(path)
-    assert "Backend Developer" in txt
-    assert "[Role]" not in txt
-
-
-def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
-    """Test that resume_key_role_override takes priority over base key_role."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {},
-        "projects": [
-            {
-                "project_name": "test_project",
-                "key_role": "Developer",
-                "manual_key_role": "Senior Developer",
-                "resume_key_role_override": "Lead Developer",
-                "contribution_bullets": ["Led team"],
-            },
-        ],
-    }
-
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
-
-    txt = _doc_text(path)
-    assert "Lead Developer" in txt
-    assert "Senior Developer" not in txt
-    assert "[Role]" not in txt
-
-
-def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
-    """Test that export falls back to [Role] when no key_role is set."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {},
-        "projects": [
-            {
-                "project_name": "test_project",
-                "contribution_bullets": ["Did stuff"],
-            },
-        ],
-    }
-
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
-
-    txt = _doc_text(path)
-    assert "[Role]" in txt
-    
-
-def test_resume_export_uses_full_name_when_present(monkeypatch, tmp_path):
-    """Test that DOCX export uses full_name instead of username when present."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {},
-        "projects": [],
-    }
-
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-
-    user_profile = {
-        "full_name": "John Tan",
-        "email": None,
-        "phone": None,
-        "linkedin": None,
-        "github": None,
-        "location": None,
-        "profile_text": None,
-    }
-
-    path = exp.export_resume_record_to_docx(
-        username="john123",
-        record=record,
-        out_dir=str(out_dir),
-        user_profile=user_profile,
-    )
-
-    txt = _doc_text(path)
-    assert "JOHN TAN" in txt

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -90,6 +90,7 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     out_dir = tmp_path / "out"
 
     user_profile = {
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -212,6 +213,7 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
     out_dir = tmp_path / "out"
 
     empty_profile = {
+        "full_name": None,
         "email": None,
         "phone": None,
         "linkedin": None,
@@ -431,3 +433,44 @@ def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
 
     txt = _doc_text(path)
     assert "[Role]" in txt
+    
+
+def test_resume_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that DOCX export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    path = exp.export_resume_record_to_docx(
+        username="john123",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
+
+    txt = _doc_text(path)
+    assert "JOHN TAN" in txt

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import zipfile
 
+import pytest
 import src.export.resume_docx as exp
+import src.menu.resume.flow as flow
 
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -36,45 +38,59 @@ def _docx_hyperlink_targets(path: Path) -> list[str]:
     return targets
 
 
-class _FakeDatetime:
-    @staticmethod
-    def now():
-        class _DT:
-            def strftime(self, fmt: str) -> str:
-                return "2026-01-10_15-36-58"
-        return _DT()
-
-
-def test_resume_docx_profile_happy_path(monkeypatch, tmp_path):
+def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     """
-    Covers PR 1 happy path:
-    - full_name is used instead of username
-    - profile/contact info render
-    - LinkedIn/GitHub render as labels with hyperlink targets
-    - profile section shows when populated
+    Covers:
+    - deterministic filename via frozen datetime
+    - structure/order:
+      Name -> Contact -> PROFILE -> SKILLS -> PROJECTS -> EDUCATION & CERTIFICATES
+    - projects sorted by most-recent end_date/start_date first
+    - LinkedIn/GitHub shown as labels, with real hyperlink targets in the docx
     """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
         "aggregated_skills": {
-            "languages": ["Python 88%"],
+            "languages": ["Python 88%", "SQL 12%"],
             "frameworks": ["FastAPI"],
             "technical_skills": ["Algorithms"],
-            "writing_skills": [],
+            "writing_skills": ["Clear communication"],
         },
         "projects": [
             {
-                "project_name": "test_project",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Built API endpoints"],
+                "project_name": "older_project",
+                "role": "[Role]",
+                "start_date": "2024-12-01",
+                "end_date": "2024-12-31",
+                "contribution_bullets": ["Old bullet A"],
+            },
+            {
+                "project_name": "newer_project",
+                "role": "[Role]",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["New bullet A", "New bullet B"],
             },
         ],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+    out_dir = tmp_path / "out"
+
     user_profile = {
-        "full_name": "John Tan",
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -84,45 +100,118 @@ def test_resume_docx_profile_happy_path(monkeypatch, tmp_path):
     }
 
     path = exp.export_resume_record_to_docx(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=user_profile,
     )
+
+    assert out_dir.exists()
+    assert path.exists()
+    assert path.name == "resume_john_2026-01-10_15-36-58.docx"
 
     txt = _doc_text(path)
     hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "JOHN TAN" in txt
-    assert "john@example.com" in txt
+    assert "john" in txt.lower()
+
+    # Contact line pieces appear as visible text
     assert "1234567890" in txt
+    assert "john@example.com" in txt
     assert "LinkedIn" in txt
     assert "GitHub" in txt
     assert "Kelowna, BC" in txt
-    assert "PROFILE" in txt
-    assert "Software and data student building practical tools." in txt
 
+    # URLs should be hyperlink targets, not visible text
     assert "https://linkedin.com/in/john" in hyperlink_targets
     assert "https://github.com/john" in hyperlink_targets
     assert "https://linkedin.com/in/john" not in txt
     assert "https://github.com/john" not in txt
 
+    # Required sections exist
+    assert "PROFILE" in txt
+    assert "SKILLS" in txt
+    assert "PROJECTS" in txt
+    assert "EDUCATION & CERTIFICATES" in txt
 
-def test_resume_docx_profile_omits_empty_fields(monkeypatch, tmp_path):
+    # Order: PROFILE -> SKILLS -> PROJECTS -> EDUCATION
+    idx_profile = txt.find("PROFILE")
+    idx_skills = txt.find("SKILLS")
+    idx_projects = txt.find("PROJECTS")
+    idx_edu = txt.find("EDUCATION & CERTIFICATES")
+    assert -1 not in (idx_profile, idx_skills, idx_projects, idx_edu)
+    assert idx_profile < idx_skills < idx_projects < idx_edu
+
+    # Profile paragraph rendered
+    assert "Software and data student building practical tools." in txt
+
+    # Skills lines rendered
+    assert "Languages:" in txt
+    assert ("Python" in txt) and ("SQL" in txt)
+    assert "Frameworks:" in txt
+    assert "FastAPI" in txt
+    assert "Technical skills:" in txt
+    assert "Algorithms" in txt
+    assert "Writing skills:" in txt
+    assert "Clear communication" in txt
+
+    # Projects content
+    assert "newer_project" in txt
+    assert "older_project" in txt
+    assert "[Role]" in txt
+
+    # Contributions bullets appear
+    assert "New bullet A" in txt
+    assert "New bullet B" in txt
+    assert "Old bullet A" in txt
+
+    # Sorting check: newer should appear before older
+    assert txt.find("newer_project") < txt.find("older_project")
+
+    # Optional: verify years appear somewhere
+    assert "2025" in txt and "2024" in txt
+
+
+def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty(monkeypatch, tmp_path):
     """
-    Covers PR 1 omission behavior:
-    - falls back to username when full_name missing
-    - contact line is omitted when fields are empty
-    - profile section is omitted when profile_text is empty
+    Covers:
+    - empty standalone profile should not render contact info
+    - PROFILE section should be omitted when profile_text is empty
     """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
-        "aggregated_skills": {},
-        "projects": [],
+        "aggregated_skills": {
+            "languages": ["Python 88%"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+    out_dir = tmp_path / "out"
+
     empty_profile = {
         "full_name": None,
         "email": None,
@@ -134,16 +223,20 @@ def test_resume_docx_profile_omits_empty_fields(monkeypatch, tmp_path):
     }
 
     path = exp.export_resume_record_to_docx(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=empty_profile,
     )
 
     txt = _doc_text(path)
     hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "JOHN123" in txt
+    assert "john" in txt.lower()
+    assert "SKILLS" in txt
+    assert "PROJECTS" in txt
+    assert "EDUCATION & CERTIFICATES" in txt
+
     assert "PROFILE" not in txt
     assert "john@example.com" not in txt
     assert "1234567890" not in txt
@@ -153,3 +246,231 @@ def test_resume_docx_profile_omits_empty_fields(monkeypatch, tmp_path):
 
     assert all("linkedin.com" not in target for target in hyperlink_targets)
     assert all("github.com" not in target for target in hyperlink_targets)
+
+
+def test_resume_export_nonhappy_no_saved_resumes(monkeypatch, capsys):
+    """
+    Covers: R2 (flow handler: list_resumes empty)
+    """
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: [])
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "No saved resumes yet" in out
+
+
+def test_resume_export_nonhappy_cancel_invalid_selection(monkeypatch, capsys):
+    """
+    Covers: R3 + R4 (cancel, invalid index)
+    """
+    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(
+        flow,
+        "get_resume_snapshot",
+        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
+    )
+    monkeypatch.setattr(flow, "export_resume_record_to_docx", lambda **k: Path("./out/fake.docx"))
+
+    # cancel (Enter)
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Cancelled" in out
+
+    # invalid index (999)
+    monkeypatch.setattr("builtins.input", lambda _: "999")
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Invalid selection" in out
+
+
+def test_resume_export_nonhappy_record_missing(monkeypatch, capsys):
+    """
+    Covers: R5 (get_resume_snapshot returns None)
+    """
+    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(flow, "get_resume_snapshot", lambda conn, user_id, rid: None)
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Unable to load the selected resume" in out
+
+
+def test_resume_export_fallback_to_rendered_text(monkeypatch, tmp_path):
+    """
+    Covers: R6 + R7 (malformed JSON -> fallback; missing rendered_text -> message)
+    """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    out_dir = tmp_path / "out"
+
+    # R6: bad JSON + good rendered_text
+    record = {"resume_json": "{not json", "rendered_text": "LINE1\nLINE2\n"}
+    path = exp.export_resume_record_to_docx(username="john", record=record, out_dir=str(out_dir))
+    txt = _doc_text(path)
+    assert "Resume Snapshot" in txt
+    assert "LINE1" in txt and "LINE2" in txt
+
+    # R7: bad JSON + missing rendered_text
+    record2 = {"resume_json": "{not json", "rendered_text": ""}
+    path2 = exp.export_resume_record_to_docx(username="john", record=record2, out_dir=str(out_dir))
+    txt2 = _doc_text(path2)
+    assert "Resume data is missing or unreadable" in txt2
+
+
+def test_resume_export_uses_key_role(monkeypatch, tmp_path):
+    """Test that export uses resolved key_role instead of [Role] placeholder."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Backend Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Built API endpoints"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "Backend Developer" in txt
+    assert "[Role]" not in txt
+
+
+def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
+    """Test that resume_key_role_override takes priority over base key_role."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Developer",
+                "manual_key_role": "Senior Developer",
+                "resume_key_role_override": "Lead Developer",
+                "contribution_bullets": ["Led team"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "Lead Developer" in txt
+    assert "Senior Developer" not in txt
+    assert "[Role]" not in txt
+
+
+def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
+    """Test that export falls back to [Role] when no key_role is set."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "contribution_bullets": ["Did stuff"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "[Role]" in txt
+    
+
+def test_resume_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that DOCX export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    path = exp.export_resume_record_to_docx(
+        username="john123",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
+
+    txt = _doc_text(path)
+    assert "JOHN TAN" in txt

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -1,29 +1,52 @@
 import json
 from pathlib import Path
+import xml.etree.ElementTree as ET
+import zipfile
 
 import pytest
-from docx import Document
+import src.export.resume_docx as exp
+import src.menu.resume.flow as flow
+
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+R_NS = "http://schemas.openxmlformats.org/package/2006/relationships"
 
 
 def _doc_text(path: Path) -> str:
-    doc = Document(str(path))
-    return "\n".join(p.text for p in doc.paragraphs if p.text is not None)
+    with zipfile.ZipFile(path, "r") as zf:
+        xml_bytes = zf.read("word/document.xml")
+
+    root = ET.fromstring(xml_bytes)
+    paragraphs = []
+    for p in root.iter(f"{{{W_NS}}}p"):
+        text = "".join(node.text or "" for node in p.iter(f"{{{W_NS}}}t")).strip()
+        if text:
+            paragraphs.append(text)
+    return "\n".join(paragraphs)
+
+
+def _docx_hyperlink_targets(path: Path) -> list[str]:
+    with zipfile.ZipFile(path, "r") as zf:
+        rels_bytes = zf.read("word/_rels/document.xml.rels")
+
+    root = ET.fromstring(rels_bytes)
+    targets = []
+    for rel in root.iter(f"{{{R_NS}}}Relationship"):
+        target = rel.attrib.get("Target")
+        if target:
+            targets.append(target)
+    return targets
 
 
 def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     """
-    Covers: deterministic filename via frozen datetime + structure/order:
-    Name -> Contact -> (PROFILE, SKILLS, PROJECTS, EDUCATION & CERTIFICATES)
-    Projects are sorted by most-recent end_date/start_date first.
+    Covers:
+    - deterministic filename via frozen datetime
+    - structure/order:
+      Name -> Contact -> PROFILE -> SKILLS -> PROJECTS -> EDUCATION & CERTIFICATES
+    - projects sorted by most-recent end_date/start_date first
+    - LinkedIn/GitHub shown as labels, with real hyperlink targets in the docx
     """
-    import src.export.resume_docx as exp
-    from docx import Document
-
-    def _doc_text(path: Path) -> str:
-        doc = Document(str(path))
-        return "\n".join(p.text for p in doc.paragraphs if p.text is not None)
-
-    # Freeze datetime.now() used by exporter
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -38,19 +61,14 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
 
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
-    # New-format snapshot (sections + projects w/ role + dates + bullets)
     snapshot = {
-        "contact_line": "Phone | Email | LinkedIn | Location",
-        "profile_text": "To be updated later.",
-        "education_text": "To be updated later.",
         "aggregated_skills": {
-            "languages": ["Python 88%", "SQL 12%"], 
+            "languages": ["Python 88%", "SQL 12%"],
             "frameworks": ["FastAPI"],
             "technical_skills": ["Algorithms"],
             "writing_skills": ["Clear communication"],
         },
         "projects": [
-            # INTENTIONALLY unsorted input (older first) so we can assert sorting.
             {
                 "project_name": "older_project",
                 "role": "[Role]",
@@ -71,17 +89,43 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
     out_dir = tmp_path / "out"
 
-    path = exp.export_resume_record_to_docx(username="john", record=record, out_dir=str(out_dir))
+    user_profile = {
+        "email": "john@example.com",
+        "phone": "1234567890",
+        "linkedin": "https://linkedin.com/in/john",
+        "github": "https://github.com/john",
+        "location": "Kelowna, BC",
+        "profile_text": "Software and data student building practical tools.",
+    }
+
+    path = exp.export_resume_record_to_docx(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
 
     assert out_dir.exists()
     assert path.exists()
     assert path.name == "resume_john_2026-01-10_15-36-58.docx"
 
     txt = _doc_text(path)
+    hyperlink_targets = _docx_hyperlink_targets(path)
 
-    # Name should appear (exact heading string depends on your implementation;
-    # this assertion is flexible and just ensures "john" is present early)
     assert "john" in txt.lower()
+
+    # Contact line pieces appear as visible text
+    assert "1234567890" in txt
+    assert "john@example.com" in txt
+    assert "LinkedIn" in txt
+    assert "GitHub" in txt
+    assert "Kelowna, BC" in txt
+
+    # URLs should be hyperlink targets, not visible text
+    assert "https://linkedin.com/in/john" in hyperlink_targets
+    assert "https://github.com/john" in hyperlink_targets
+    assert "https://linkedin.com/in/john" not in txt
+    assert "https://github.com/john" not in txt
 
     # Required sections exist
     assert "PROFILE" in txt
@@ -97,6 +141,9 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     assert -1 not in (idx_profile, idx_skills, idx_projects, idx_edu)
     assert idx_profile < idx_skills < idx_projects < idx_edu
 
+    # Profile paragraph rendered
+    assert "Software and data student building practical tools." in txt
+
     # Skills lines rendered
     assert "Languages:" in txt
     assert ("Python" in txt) and ("SQL" in txt)
@@ -107,7 +154,7 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     assert "Writing skills:" in txt
     assert "Clear communication" in txt
 
-    # Projects content: role/date line should show up (format may vary slightly)
+    # Projects content
     assert "newer_project" in txt
     assert "older_project" in txt
     assert "[Role]" in txt
@@ -120,16 +167,89 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     # Sorting check: newer should appear before older
     assert txt.find("newer_project") < txt.find("older_project")
 
-    # Optional: verify date range text appears somewhere (don’t overfit formatting)
+    # Optional: verify years appear somewhere
     assert "2025" in txt and "2024" in txt
+
+
+def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty(monkeypatch, tmp_path):
+    """
+    Covers:
+    - empty standalone profile should not render contact info
+    - PROFILE section should be omitted when profile_text is empty
+    """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python 88%"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+    out_dir = tmp_path / "out"
+
+    empty_profile = {
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    path = exp.export_resume_record_to_docx(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=empty_profile,
+    )
+
+    txt = _doc_text(path)
+    hyperlink_targets = _docx_hyperlink_targets(path)
+
+    assert "john" in txt.lower()
+    assert "SKILLS" in txt
+    assert "PROJECTS" in txt
+    assert "EDUCATION & CERTIFICATES" in txt
+
+    assert "PROFILE" not in txt
+    assert "john@example.com" not in txt
+    assert "1234567890" not in txt
+    assert "LinkedIn" not in txt
+    assert "GitHub" not in txt
+    assert "Kelowna, BC" not in txt
+
+    assert all("linkedin.com" not in target for target in hyperlink_targets)
+    assert all("github.com" not in target for target in hyperlink_targets)
 
 
 def test_resume_export_nonhappy_no_saved_resumes(monkeypatch, capsys):
     """
     Covers: R2 (flow handler: list_resumes empty)
     """
-    import src.menu.resume.flow as flow
-
     monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: [])
     ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
     out = capsys.readouterr().out
@@ -141,8 +261,6 @@ def test_resume_export_nonhappy_cancel_invalid_selection(monkeypatch, capsys):
     """
     Covers: R3 + R4 (cancel, invalid index)
     """
-    import src.menu.resume.flow as flow
-
     resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
     monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
     monkeypatch.setattr(
@@ -171,8 +289,6 @@ def test_resume_export_nonhappy_record_missing(monkeypatch, capsys):
     """
     Covers: R5 (get_resume_snapshot returns None)
     """
-    import src.menu.resume.flow as flow
-
     resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
     monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
     monkeypatch.setattr(flow, "get_resume_snapshot", lambda conn, user_id, rid: None)
@@ -188,8 +304,6 @@ def test_resume_export_fallback_to_rendered_text(monkeypatch, tmp_path):
     """
     Covers: R6 + R7 (malformed JSON -> fallback; missing rendered_text -> message)
     """
-    import src.export.resume_docx as exp
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -222,9 +336,6 @@ def test_resume_export_fallback_to_rendered_text(monkeypatch, tmp_path):
 
 def test_resume_export_uses_key_role(monkeypatch, tmp_path):
     """Test that export uses resolved key_role instead of [Role] placeholder."""
-    import src.export.resume_docx as exp
-    from docx import Document
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -259,9 +370,6 @@ def test_resume_export_uses_key_role(monkeypatch, tmp_path):
 
 def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
     """Test that resume_key_role_override takes priority over base key_role."""
-    import src.export.resume_docx as exp
-    from docx import Document
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -290,7 +398,6 @@ def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
     path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
 
     txt = _doc_text(path)
-    # Should use the resume override (highest priority)
     assert "Lead Developer" in txt
     assert "Senior Developer" not in txt
     assert "[Role]" not in txt
@@ -298,9 +405,6 @@ def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
 
 def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
     """Test that export falls back to [Role] when no key_role is set."""
-    import src.export.resume_docx as exp
-    from docx import Document
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -316,7 +420,6 @@ def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
         "projects": [
             {
                 "project_name": "test_project",
-                # No key_role set
                 "contribution_bullets": ["Did stuff"],
             },
         ],

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -1,12 +1,34 @@
 import json
 from pathlib import Path
-import json
+
 import pytest
 from pypdf import PdfReader
 
-def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
-    import src.export.resume_pdf as exp
+import src.export.resume_pdf as exp
+import src.menu.resume.flow as flow
 
+
+def _pdf_text(path):
+    reader = PdfReader(str(path))
+    return "\n".join((page.extract_text() or "") for page in reader.pages)
+
+
+def _pdf_link_targets(path):
+    reader = PdfReader(str(path))
+    targets = []
+
+    for page in reader.pages:
+        annots = page.get("/Annots") or []
+        for annot_ref in annots:
+            annot = annot_ref.get_object()
+            action = annot.get("/A")
+            if action and action.get("/URI"):
+                targets.append(str(action["/URI"]))
+
+    return targets
+
+
+def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -48,14 +70,9 @@ def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
     assert raw[:4] == b"%PDF"
     assert len(raw) > 1000
 
-def _pdf_text(path):
-    reader = PdfReader(str(path))
-    return "\n".join((page.extract_text() or "") for page in reader.pages)
 
 @pytest.mark.pdf_text
 def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path):
-    import src.export.resume_pdf as exp
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -94,10 +111,25 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
     }
     record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
 
+    user_profile = {
+        "email": "john@example.com",
+        "phone": "1234567890",
+        "linkedin": "https://linkedin.com/in/john",
+        "github": "https://github.com/john",
+        "location": "Kelowna, BC",
+        "profile_text": "Software and data student building practical tools.",
+    }
+
     out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(username="john", record=record, out_dir=str(out_dir))
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
 
     text = _pdf_text(path)
+    link_targets = _pdf_link_targets(path)
 
     # section headings
     assert "PROFILE" in text
@@ -105,8 +137,90 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
     assert "PROJECTS" in text
     assert "EDUCATION" in text
 
+    # profile/contact info
+    assert "1234567890" in text
+    assert "john@example.com" in text
+    assert "LinkedIn" in text
+    assert "GitHub" in text
+    assert "Kelowna, BC" in text
+    assert "Software and data student building practical tools." in text
+
+    # URLs should exist as real PDF links, not as visible text
+    assert "https://linkedin.com/in/john" in link_targets
+    assert "https://github.com/john" in link_targets
+    assert "https://linkedin.com/in/john" not in text
+    assert "https://github.com/john" not in text
+
     # ordering by recency: newer should appear before older
     assert text.find("newer") < text.find("older")
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+
+    empty_profile = {
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=empty_profile,
+    )
+
+    text = _pdf_text(path)
+    link_targets = _pdf_link_targets(path)
+
+    assert "SKILLS" in text
+    assert "PROJECTS" in text
+    assert "EDUCATION" in text
+
+    assert "PROFILE" not in text
+    assert "john@example.com" not in text
+    assert "1234567890" not in text
+    assert "LinkedIn" not in text
+    assert "GitHub" not in text
+    assert "Kelowna, BC" not in text
+
+    assert all("linkedin.com" not in target for target in link_targets)
+    assert all("github.com" not in target for target in link_targets)
+
 
 def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
     """
@@ -115,8 +229,6 @@ def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
     - Invalid index selection
     - Ensures PDF export is not called
     """
-    import src.menu.resume.flow as flow
-
     resumes = [
         {"id": 1, "name": "Resume A", "created_at": "2026-01-01"},
         {"id": 2, "name": "Resume B", "created_at": "2026-01-02"},
@@ -129,13 +241,12 @@ def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
         lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
     )
 
-    # Guard: export must NOT be called
     def fail_export(**kwargs):
         raise AssertionError("PDF export should not be called")
 
     monkeypatch.setattr(flow, "export_resume_record_to_pdf", fail_export)
 
-    # ---- Case 1: Cancel (Enter) ----
+    # cancel
     monkeypatch.setattr("builtins.input", lambda _: "")
     ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
     out = capsys.readouterr().out
@@ -143,7 +254,7 @@ def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
     assert ok is False
     assert "Cancelled" in out
 
-    # ---- Case 2: Invalid index ----
+    # invalid index
     monkeypatch.setattr("builtins.input", lambda _: "999")
     ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
     out = capsys.readouterr().out
@@ -155,8 +266,6 @@ def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
 @pytest.mark.pdf_text
 def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
     """Test that PDF export uses resolved key_role instead of [Role] placeholder."""
-    import src.export.resume_pdf as exp
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -192,8 +301,6 @@ def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
 @pytest.mark.pdf_text
 def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
     """Test that resume_key_role_override takes priority over base key_role in PDF."""
-    import src.export.resume_pdf as exp
-
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -224,8 +331,5 @@ def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
     path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
 
     text = _pdf_text(path)
-    # Should use the resume override (highest priority)
     assert "Lead Developer" in text
-    # The actual role used should be "Lead Developer", others should not appear
-    # (though they might if they overlap in text - just ensure override is present)
     assert "[Role]" not in text

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -5,6 +5,7 @@ import pytest
 from pypdf import PdfReader
 
 import src.export.resume_pdf as exp
+import src.menu.resume.flow as flow
 
 
 def _pdf_text(path):
@@ -27,46 +28,91 @@ def _pdf_link_targets(path):
     return targets
 
 
-class _FakeDatetime:
-    @staticmethod
-    def now():
-        class _DT:
-            def strftime(self, fmt: str) -> str:
-                return "2026-01-10_15-36-58"
-        return _DT()
+def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
 
-
-@pytest.mark.pdf_text
-def test_resume_pdf_profile_happy_path(monkeypatch, tmp_path):
-    """
-    Covers PR 1 happy path:
-    - full_name is used instead of username
-    - profile/contact info render
-    - LinkedIn/GitHub render as labels with hyperlink targets
-    - profile section shows when populated
-    """
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
         "aggregated_skills": {
             "languages": ["Python"],
-            "frameworks": ["FastAPI"],
-            "technical_skills": ["Algorithms"],
+            "frameworks": [],
+            "technical_skills": [],
             "writing_skills": [],
         },
         "projects": [
             {
-                "project_name": "test_project",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Built API endpoints"],
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "role": "[Role]",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="john", record=record, out_dir=str(out_dir))
+
+    assert path.exists()
+    assert path.name == "resume_john_2026-01-10_15-36-58.pdf"
+
+    raw = Path(path).read_bytes()
+    assert raw[:4] == b"%PDF"
+    assert len(raw) > 1000
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "older",
+                "start_date": "2024-01-01",
+                "end_date": "2024-02-01",
+                "role": "[Role]",
+                "contribution_bullets": ["Old bullet"],
+            },
+            {
+                "project_name": "newer",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "role": "[Role]",
+                "contribution_bullets": ["New bullet"],
             },
         ],
     }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
     user_profile = {
-        "full_name": "John Tan",
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -75,39 +121,232 @@ def test_resume_pdf_profile_happy_path(monkeypatch, tmp_path):
         "profile_text": "Software and data student building practical tools.",
     }
 
+    out_dir = tmp_path / "out"
     path = exp.export_resume_record_to_pdf(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=user_profile,
     )
 
     text = _pdf_text(path)
     link_targets = _pdf_link_targets(path)
 
-    assert "JOHN TAN" in text
-    assert "john@example.com" in text
+    # section headings
+    assert "PROFILE" in text
+    assert "SKILLS" in text
+    assert "PROJECTS" in text
+    assert "EDUCATION" in text
+
+    # profile/contact info
     assert "1234567890" in text
+    assert "john@example.com" in text
     assert "LinkedIn" in text
     assert "GitHub" in text
     assert "Kelowna, BC" in text
-    assert "PROFILE" in text
     assert "Software and data student building practical tools." in text
 
+    # URLs should exist as real PDF links, not as visible text
     assert "https://linkedin.com/in/john" in link_targets
     assert "https://github.com/john" in link_targets
     assert "https://linkedin.com/in/john" not in text
     assert "https://github.com/john" not in text
 
+    # ordering by recency: newer should appear before older
+    assert text.find("newer") < text.find("older")
+
 
 @pytest.mark.pdf_text
-def test_resume_pdf_profile_omits_empty_fields(monkeypatch, tmp_path):
+def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+
+    empty_profile = {
+        "full_name": None,
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=empty_profile,
+    )
+
+    text = _pdf_text(path)
+    link_targets = _pdf_link_targets(path)
+
+    assert "SKILLS" in text
+    assert "PROJECTS" in text
+    assert "EDUCATION" in text
+
+    assert "PROFILE" not in text
+    assert "john@example.com" not in text
+    assert "1234567890" not in text
+    assert "LinkedIn" not in text
+    assert "GitHub" not in text
+    assert "Kelowna, BC" not in text
+
+    assert all("linkedin.com" not in target for target in link_targets)
+    assert all("github.com" not in target for target in link_targets)
+
+
+def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
     """
-    Covers PR 1 omission behavior:
-    - falls back to username when full_name missing
-    - contact line is omitted when fields are empty
-    - profile section is omitted when profile_text is empty
+    Covers:
+    - Cancel on Enter
+    - Invalid index selection
+    - Ensures PDF export is not called
     """
+    resumes = [
+        {"id": 1, "name": "Resume A", "created_at": "2026-01-01"},
+        {"id": 2, "name": "Resume B", "created_at": "2026-01-02"},
+    ]
+
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(
+        flow,
+        "get_resume_snapshot",
+        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
+    )
+
+    def fail_export(**kwargs):
+        raise AssertionError("PDF export should not be called")
+
+    monkeypatch.setattr(flow, "export_resume_record_to_pdf", fail_export)
+
+    # cancel
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Cancelled" in out
+
+    # invalid index
+    monkeypatch.setattr("builtins.input", lambda _: "999")
+    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Invalid selection" in out
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
+    """Test that PDF export uses resolved key_role instead of [Role] placeholder."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Backend Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Built API endpoints"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
+
+    text = _pdf_text(path)
+    assert "Backend Developer" in text
+    assert "[Role]" not in text
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
+    """Test that resume_key_role_override takes priority over base key_role in PDF."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Developer",
+                "manual_key_role": "Senior Developer",
+                "resume_key_role_override": "Lead Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Led team"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
+
+    text = _pdf_text(path)
+    assert "Lead Developer" in text
+    assert "[Role]" not in text
+    
+@pytest.mark.pdf_text
+def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that PDF export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
@@ -116,8 +355,10 @@ def test_resume_pdf_profile_omits_empty_fields(monkeypatch, tmp_path):
     }
 
     record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    empty_profile = {
-        "full_name": None,
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
         "email": None,
         "phone": None,
         "linkedin": None,
@@ -129,20 +370,9 @@ def test_resume_pdf_profile_omits_empty_fields(monkeypatch, tmp_path):
     path = exp.export_resume_record_to_pdf(
         username="john123",
         record=record,
-        out_dir=str(tmp_path / "out"),
-        user_profile=empty_profile,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
     )
 
     text = _pdf_text(path)
-    link_targets = _pdf_link_targets(path)
-
-    assert "JOHN123" in text
-    assert "PROFILE" not in text
-    assert "john@example.com" not in text
-    assert "1234567890" not in text
-    assert "LinkedIn" not in text
-    assert "GitHub" not in text
-    assert "Kelowna, BC" not in text
-
-    assert all("linkedin.com" not in target for target in link_targets)
-    assert all("github.com" not in target for target in link_targets)
+    assert "JOHN TAN" in text

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -112,6 +112,7 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
     record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
 
     user_profile = {
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -188,6 +189,7 @@ def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tm
     record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
 
     empty_profile = {
+        "full_name": None,
         "email": None,
         "phone": None,
         "linkedin": None,
@@ -333,3 +335,44 @@ def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
     text = _pdf_text(path)
     assert "Lead Developer" in text
     assert "[Role]" not in text
+    
+@pytest.mark.pdf_text
+def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that PDF export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    path = exp.export_resume_record_to_pdf(
+        username="john123",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
+
+    text = _pdf_text(path)
+    assert "JOHN TAN" in text

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -5,7 +5,6 @@ import pytest
 from pypdf import PdfReader
 
 import src.export.resume_pdf as exp
-import src.menu.resume.flow as flow
 
 
 def _pdf_text(path):
@@ -28,262 +27,36 @@ def _pdf_link_targets(path):
     return targets
 
 
-def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {
-            "languages": ["Python"],
-            "frameworks": [],
-            "technical_skills": [],
-            "writing_skills": [],
-        },
-        "projects": [
-            {
-                "project_name": "projA",
-                "start_date": "2025-08-01",
-                "end_date": "2025-11-01",
-                "role": "[Role]",
-                "contribution_bullets": ["Bullet A"],
-            }
-        ],
-    }
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
-
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(username="john", record=record, out_dir=str(out_dir))
-
-    assert path.exists()
-    assert path.name == "resume_john_2026-01-10_15-36-58.pdf"
-
-    raw = Path(path).read_bytes()
-    assert raw[:4] == b"%PDF"
-    assert len(raw) > 1000
+class _FakeDatetime:
+    @staticmethod
+    def now():
+        class _DT:
+            def strftime(self, fmt: str) -> str:
+                return "2026-01-10_15-36-58"
+        return _DT()
 
 
 @pytest.mark.pdf_text
-def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path):
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {
-            "languages": ["Python"],
-            "frameworks": [],
-            "technical_skills": [],
-            "writing_skills": [],
-        },
-        "projects": [
-            {
-                "project_name": "older",
-                "start_date": "2024-01-01",
-                "end_date": "2024-02-01",
-                "role": "[Role]",
-                "contribution_bullets": ["Old bullet"],
-            },
-            {
-                "project_name": "newer",
-                "start_date": "2025-08-01",
-                "end_date": "2025-11-01",
-                "role": "[Role]",
-                "contribution_bullets": ["New bullet"],
-            },
-        ],
-    }
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
-
-    user_profile = {
-        "full_name": None,
-        "email": "john@example.com",
-        "phone": "1234567890",
-        "linkedin": "https://linkedin.com/in/john",
-        "github": "https://github.com/john",
-        "location": "Kelowna, BC",
-        "profile_text": "Software and data student building practical tools.",
-    }
-
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(
-        username="john",
-        record=record,
-        out_dir=str(out_dir),
-        user_profile=user_profile,
-    )
-
-    text = _pdf_text(path)
-    link_targets = _pdf_link_targets(path)
-
-    # section headings
-    assert "PROFILE" in text
-    assert "SKILLS" in text
-    assert "PROJECTS" in text
-    assert "EDUCATION" in text
-
-    # profile/contact info
-    assert "1234567890" in text
-    assert "john@example.com" in text
-    assert "LinkedIn" in text
-    assert "GitHub" in text
-    assert "Kelowna, BC" in text
-    assert "Software and data student building practical tools." in text
-
-    # URLs should exist as real PDF links, not as visible text
-    assert "https://linkedin.com/in/john" in link_targets
-    assert "https://github.com/john" in link_targets
-    assert "https://linkedin.com/in/john" not in text
-    assert "https://github.com/john" not in text
-
-    # ordering by recency: newer should appear before older
-    assert text.find("newer") < text.find("older")
-
-
-@pytest.mark.pdf_text
-def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tmp_path):
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    if fmt == "%Y-%m-%d_%H-%M-%S":
-                        return "2026-01-10_15-36-58"
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {
-            "languages": ["Python"],
-            "frameworks": [],
-            "technical_skills": [],
-            "writing_skills": [],
-        },
-        "projects": [
-            {
-                "project_name": "projA",
-                "start_date": "2025-08-01",
-                "end_date": "2025-11-01",
-                "contribution_bullets": ["Bullet A"],
-            }
-        ],
-    }
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
-
-    empty_profile = {
-        "full_name": None,
-        "email": None,
-        "phone": None,
-        "linkedin": None,
-        "github": None,
-        "location": None,
-        "profile_text": None,
-    }
-
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(
-        username="john",
-        record=record,
-        out_dir=str(out_dir),
-        user_profile=empty_profile,
-    )
-
-    text = _pdf_text(path)
-    link_targets = _pdf_link_targets(path)
-
-    assert "SKILLS" in text
-    assert "PROJECTS" in text
-    assert "EDUCATION" in text
-
-    assert "PROFILE" not in text
-    assert "john@example.com" not in text
-    assert "1234567890" not in text
-    assert "LinkedIn" not in text
-    assert "GitHub" not in text
-    assert "Kelowna, BC" not in text
-
-    assert all("linkedin.com" not in target for target in link_targets)
-    assert all("github.com" not in target for target in link_targets)
-
-
-def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
+def test_resume_pdf_profile_happy_path(monkeypatch, tmp_path):
     """
-    Covers:
-    - Cancel on Enter
-    - Invalid index selection
-    - Ensures PDF export is not called
+    Covers PR 1 happy path:
+    - full_name is used instead of username
+    - profile/contact info render
+    - LinkedIn/GitHub render as labels with hyperlink targets
+    - profile section shows when populated
     """
-    resumes = [
-        {"id": 1, "name": "Resume A", "created_at": "2026-01-01"},
-        {"id": 2, "name": "Resume B", "created_at": "2026-01-02"},
-    ]
-
-    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
-    monkeypatch.setattr(
-        flow,
-        "get_resume_snapshot",
-        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
-    )
-
-    def fail_export(**kwargs):
-        raise AssertionError("PDF export should not be called")
-
-    monkeypatch.setattr(flow, "export_resume_record_to_pdf", fail_export)
-
-    # cancel
-    monkeypatch.setattr("builtins.input", lambda _: "")
-    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-
-    assert ok is False
-    assert "Cancelled" in out
-
-    # invalid index
-    monkeypatch.setattr("builtins.input", lambda _: "999")
-    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
-    out = capsys.readouterr().out
-
-    assert ok is False
-    assert "Invalid selection" in out
-
-
-@pytest.mark.pdf_text
-def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
-    """Test that PDF export uses resolved key_role instead of [Role] placeholder."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
-        "aggregated_skills": {},
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": ["FastAPI"],
+            "technical_skills": ["Algorithms"],
+            "writing_skills": [],
+        },
         "projects": [
             {
                 "project_name": "test_project",
-                "key_role": "Backend Developer",
                 "start_date": "2025-01-01",
                 "end_date": "2025-06-01",
                 "contribution_bullets": ["Built API endpoints"],
@@ -292,61 +65,49 @@ def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
     }
 
     record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
-
-    text = _pdf_text(path)
-    assert "Backend Developer" in text
-    assert "[Role]" not in text
-
-
-@pytest.mark.pdf_text
-def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
-    """Test that resume_key_role_override takes priority over base key_role in PDF."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
-
-    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
-
-    snapshot = {
-        "aggregated_skills": {},
-        "projects": [
-            {
-                "project_name": "test_project",
-                "key_role": "Developer",
-                "manual_key_role": "Senior Developer",
-                "resume_key_role_override": "Lead Developer",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Led team"],
-            },
-        ],
+    user_profile = {
+        "full_name": "John Tan",
+        "email": "john@example.com",
+        "phone": "1234567890",
+        "linkedin": "https://linkedin.com/in/john",
+        "github": "https://github.com/john",
+        "location": "Kelowna, BC",
+        "profile_text": "Software and data student building practical tools.",
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
+    path = exp.export_resume_record_to_pdf(
+        username="john123",
+        record=record,
+        out_dir=str(tmp_path / "out"),
+        user_profile=user_profile,
+    )
 
     text = _pdf_text(path)
-    assert "Lead Developer" in text
-    assert "[Role]" not in text
-    
-@pytest.mark.pdf_text
-def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
-    """Test that PDF export uses full_name instead of username when present."""
-    class _FakeDatetime:
-        @staticmethod
-        def now():
-            class _DT:
-                def strftime(self, fmt: str) -> str:
-                    return "2026-01-10_15-36-58"
-            return _DT()
+    link_targets = _pdf_link_targets(path)
 
+    assert "JOHN TAN" in text
+    assert "john@example.com" in text
+    assert "1234567890" in text
+    assert "LinkedIn" in text
+    assert "GitHub" in text
+    assert "Kelowna, BC" in text
+    assert "PROFILE" in text
+    assert "Software and data student building practical tools." in text
+
+    assert "https://linkedin.com/in/john" in link_targets
+    assert "https://github.com/john" in link_targets
+    assert "https://linkedin.com/in/john" not in text
+    assert "https://github.com/john" not in text
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_profile_omits_empty_fields(monkeypatch, tmp_path):
+    """
+    Covers PR 1 omission behavior:
+    - falls back to username when full_name missing
+    - contact line is omitted when fields are empty
+    - profile section is omitted when profile_text is empty
+    """
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
@@ -355,10 +116,8 @@ def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
     }
 
     record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    out_dir = tmp_path / "out"
-
-    user_profile = {
-        "full_name": "John Tan",
+    empty_profile = {
+        "full_name": None,
         "email": None,
         "phone": None,
         "linkedin": None,
@@ -370,9 +129,20 @@ def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
     path = exp.export_resume_record_to_pdf(
         username="john123",
         record=record,
-        out_dir=str(out_dir),
-        user_profile=user_profile,
+        out_dir=str(tmp_path / "out"),
+        user_profile=empty_profile,
     )
 
     text = _pdf_text(path)
-    assert "JOHN TAN" in text
+    link_targets = _pdf_link_targets(path)
+
+    assert "JOHN123" in text
+    assert "PROFILE" not in text
+    assert "john@example.com" not in text
+    assert "1234567890" not in text
+    assert "LinkedIn" not in text
+    assert "GitHub" not in text
+    assert "Kelowna, BC" not in text
+
+    assert all("linkedin.com" not in target for target in link_targets)
+    assert all("github.com" not in target for target in link_targets)

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -32,10 +32,14 @@ def test_get_user_profile_defaults_for_new_user():
     assert profile["profile_text"] is None
 
 
-def test_upsert_user_profile_inserts_profile_and_updates_users_email():
+def test_upsert_user_profile_round_trip():
+    """
+    Covers insert + update + clear in one test.
+    """
     conn = make_conn()
     user_id = get_or_create_user(conn, "alice")
 
+    # insert
     upsert_user_profile(
         conn,
         user_id,
@@ -57,29 +61,7 @@ def test_upsert_user_profile_inserts_profile_and_updates_users_email():
     assert profile["location"] == "Kelowna, BC"
     assert profile["profile_text"] == "Software and data student building practical tools."
 
-    row = conn.execute(
-        "SELECT email FROM users WHERE user_id = ?",
-        (user_id,),
-    ).fetchone()
-    assert row[0] == "alice@example.com"
-
-
-def test_upsert_user_profile_updates_existing_values():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    upsert_user_profile(
-        conn,
-        user_id,
-        email="alice@example.com",
-        full_name="Alice Tan",
-        phone="123",
-        linkedin="https://linkedin.com/in/alice",
-        github="https://github.com/alice",
-        location="Kelowna",
-        profile_text="First version.",
-    )
-
+    # update
     upsert_user_profile(
         conn,
         user_id,
@@ -101,49 +83,7 @@ def test_upsert_user_profile_updates_existing_values():
     assert profile["location"] == "Vancouver"
     assert profile["profile_text"] == "Updated paragraph."
 
-
-def test_upsert_user_profile_can_clear_all_fields():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    upsert_user_profile(
-        conn,
-        user_id,
-        email="alice@example.com",
-        full_name="Alice Tan",
-        phone="123",
-        linkedin="https://linkedin.com/in/alice",
-        github="https://github.com/alice",
-        location="Kelowna",
-        profile_text="Hello",
-    )
-
-    upsert_user_profile(
-        conn,
-        user_id,
-        email=None,
-        full_name=None,
-        phone=None,
-        linkedin=None,
-        github=None,
-        location=None,
-        profile_text=None,
-    )
-
-    profile = get_user_profile(conn, user_id)
-    assert profile["email"] is None
-    assert profile["full_name"] is None
-    assert profile["phone"] is None
-    assert profile["linkedin"] is None
-    assert profile["github"] is None
-    assert profile["location"] is None
-    assert profile["profile_text"] is None
-
-
-def test_upsert_user_profile_normalizes_blank_strings_to_none():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
+    # clear
     upsert_user_profile(
         conn,
         user_id,
@@ -166,16 +106,16 @@ def test_upsert_user_profile_normalizes_blank_strings_to_none():
     assert profile["profile_text"] is None
 
 
-def test_get_contact_parts_returns_only_cleaned_values():
-    profile = {
-        "email": " alice@example.com ",
-        "phone": None,
-        "linkedin": " https://linkedin.com/in/alice ",
-        "github": "   ",
-        "location": " Kelowna, BC ",
-    }
-
-    parts = get_contact_parts(profile)
+def test_profile_helpers():
+    parts = get_contact_parts(
+        {
+            "email": " alice@example.com ",
+            "phone": None,
+            "linkedin": " https://linkedin.com/in/alice ",
+            "github": "   ",
+            "location": " Kelowna, BC ",
+        }
+    )
 
     assert parts == {
         "phone": None,
@@ -185,15 +125,11 @@ def test_get_contact_parts_returns_only_cleaned_values():
         "location": "Kelowna, BC",
     }
 
-
-def test_get_visible_profile_text_returns_none_when_empty():
     assert get_visible_profile_text({"profile_text": None}) is None
     assert get_visible_profile_text({"profile_text": ""}) is None
     assert get_visible_profile_text({"profile_text": "   "}) is None
     assert get_visible_profile_text({"profile_text": "Hello"}) == "Hello"
 
-
-def test_get_resume_name_prefers_full_name_and_falls_back_to_username():
     assert get_resume_name({"full_name": "Alice Tan"}, "alice123") == "Alice Tan"
     assert get_resume_name({"full_name": ""}, "alice123") == "alice123"
     assert get_resume_name({"full_name": None}, "alice123") == "alice123"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -6,6 +6,7 @@ from src.db.user_profile import (
     upsert_user_profile,
     get_contact_parts,
     get_visible_profile_text,
+    get_resume_name,
 )
 
 
@@ -23,6 +24,7 @@ def test_get_user_profile_defaults_for_new_user():
 
     assert profile["user_id"] == user_id
     assert profile["email"] is None
+    assert profile["full_name"] is None
     assert profile["phone"] is None
     assert profile["linkedin"] is None
     assert profile["github"] is None
@@ -38,6 +40,7 @@ def test_upsert_user_profile_inserts_profile_and_updates_users_email():
         conn,
         user_id,
         email="alice@example.com",
+        full_name="Alice Tan",
         phone="1234567890",
         linkedin="https://linkedin.com/in/alice",
         github="https://github.com/alice",
@@ -47,6 +50,7 @@ def test_upsert_user_profile_inserts_profile_and_updates_users_email():
 
     profile = get_user_profile(conn, user_id)
     assert profile["email"] == "alice@example.com"
+    assert profile["full_name"] == "Alice Tan"
     assert profile["phone"] == "1234567890"
     assert profile["linkedin"] == "https://linkedin.com/in/alice"
     assert profile["github"] == "https://github.com/alice"
@@ -68,6 +72,7 @@ def test_upsert_user_profile_updates_existing_values():
         conn,
         user_id,
         email="alice@example.com",
+        full_name="Alice Tan",
         phone="123",
         linkedin="https://linkedin.com/in/alice",
         github="https://github.com/alice",
@@ -79,6 +84,7 @@ def test_upsert_user_profile_updates_existing_values():
         conn,
         user_id,
         email="newalice@example.com",
+        full_name="Alice Wong",
         phone="999",
         linkedin="https://linkedin.com/in/newalice",
         github=None,
@@ -88,6 +94,7 @@ def test_upsert_user_profile_updates_existing_values():
 
     profile = get_user_profile(conn, user_id)
     assert profile["email"] == "newalice@example.com"
+    assert profile["full_name"] == "Alice Wong"
     assert profile["phone"] == "999"
     assert profile["linkedin"] == "https://linkedin.com/in/newalice"
     assert profile["github"] is None
@@ -103,6 +110,7 @@ def test_upsert_user_profile_can_clear_all_fields():
         conn,
         user_id,
         email="alice@example.com",
+        full_name="Alice Tan",
         phone="123",
         linkedin="https://linkedin.com/in/alice",
         github="https://github.com/alice",
@@ -114,6 +122,7 @@ def test_upsert_user_profile_can_clear_all_fields():
         conn,
         user_id,
         email=None,
+        full_name=None,
         phone=None,
         linkedin=None,
         github=None,
@@ -123,6 +132,7 @@ def test_upsert_user_profile_can_clear_all_fields():
 
     profile = get_user_profile(conn, user_id)
     assert profile["email"] is None
+    assert profile["full_name"] is None
     assert profile["phone"] is None
     assert profile["linkedin"] is None
     assert profile["github"] is None
@@ -138,6 +148,7 @@ def test_upsert_user_profile_normalizes_blank_strings_to_none():
         conn,
         user_id,
         email="   ",
+        full_name="   ",
         phone="",
         linkedin="   ",
         github="",
@@ -147,6 +158,7 @@ def test_upsert_user_profile_normalizes_blank_strings_to_none():
 
     profile = get_user_profile(conn, user_id)
     assert profile["email"] is None
+    assert profile["full_name"] is None
     assert profile["phone"] is None
     assert profile["linkedin"] is None
     assert profile["github"] is None
@@ -179,3 +191,9 @@ def test_get_visible_profile_text_returns_none_when_empty():
     assert get_visible_profile_text({"profile_text": ""}) is None
     assert get_visible_profile_text({"profile_text": "   "}) is None
     assert get_visible_profile_text({"profile_text": "Hello"}) == "Hello"
+
+
+def test_get_resume_name_prefers_full_name_and_falls_back_to_username():
+    assert get_resume_name({"full_name": "Alice Tan"}, "alice123") == "Alice Tan"
+    assert get_resume_name({"full_name": ""}, "alice123") == "alice123"
+    assert get_resume_name({"full_name": None}, "alice123") == "alice123"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -32,14 +32,10 @@ def test_get_user_profile_defaults_for_new_user():
     assert profile["profile_text"] is None
 
 
-def test_upsert_user_profile_round_trip():
-    """
-    Covers insert + update + clear in one test.
-    """
+def test_upsert_user_profile_inserts_profile_and_updates_users_email():
     conn = make_conn()
     user_id = get_or_create_user(conn, "alice")
 
-    # insert
     upsert_user_profile(
         conn,
         user_id,
@@ -61,7 +57,29 @@ def test_upsert_user_profile_round_trip():
     assert profile["location"] == "Kelowna, BC"
     assert profile["profile_text"] == "Software and data student building practical tools."
 
-    # update
+    row = conn.execute(
+        "SELECT email FROM users WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    assert row[0] == "alice@example.com"
+
+
+def test_upsert_user_profile_updates_existing_values():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="alice@example.com",
+        full_name="Alice Tan",
+        phone="123",
+        linkedin="https://linkedin.com/in/alice",
+        github="https://github.com/alice",
+        location="Kelowna",
+        profile_text="First version.",
+    )
+
     upsert_user_profile(
         conn,
         user_id,
@@ -83,7 +101,49 @@ def test_upsert_user_profile_round_trip():
     assert profile["location"] == "Vancouver"
     assert profile["profile_text"] == "Updated paragraph."
 
-    # clear
+
+def test_upsert_user_profile_can_clear_all_fields():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="alice@example.com",
+        full_name="Alice Tan",
+        phone="123",
+        linkedin="https://linkedin.com/in/alice",
+        github="https://github.com/alice",
+        location="Kelowna",
+        profile_text="Hello",
+    )
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email=None,
+        full_name=None,
+        phone=None,
+        linkedin=None,
+        github=None,
+        location=None,
+        profile_text=None,
+    )
+
+    profile = get_user_profile(conn, user_id)
+    assert profile["email"] is None
+    assert profile["full_name"] is None
+    assert profile["phone"] is None
+    assert profile["linkedin"] is None
+    assert profile["github"] is None
+    assert profile["location"] is None
+    assert profile["profile_text"] is None
+
+
+def test_upsert_user_profile_normalizes_blank_strings_to_none():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
     upsert_user_profile(
         conn,
         user_id,
@@ -106,16 +166,16 @@ def test_upsert_user_profile_round_trip():
     assert profile["profile_text"] is None
 
 
-def test_profile_helpers():
-    parts = get_contact_parts(
-        {
-            "email": " alice@example.com ",
-            "phone": None,
-            "linkedin": " https://linkedin.com/in/alice ",
-            "github": "   ",
-            "location": " Kelowna, BC ",
-        }
-    )
+def test_get_contact_parts_returns_only_cleaned_values():
+    profile = {
+        "email": " alice@example.com ",
+        "phone": None,
+        "linkedin": " https://linkedin.com/in/alice ",
+        "github": "   ",
+        "location": " Kelowna, BC ",
+    }
+
+    parts = get_contact_parts(profile)
 
     assert parts == {
         "phone": None,
@@ -125,11 +185,15 @@ def test_profile_helpers():
         "location": "Kelowna, BC",
     }
 
+
+def test_get_visible_profile_text_returns_none_when_empty():
     assert get_visible_profile_text({"profile_text": None}) is None
     assert get_visible_profile_text({"profile_text": ""}) is None
     assert get_visible_profile_text({"profile_text": "   "}) is None
     assert get_visible_profile_text({"profile_text": "Hello"}) == "Hello"
 
+
+def test_get_resume_name_prefers_full_name_and_falls_back_to_username():
     assert get_resume_name({"full_name": "Alice Tan"}, "alice123") == "Alice Tan"
     assert get_resume_name({"full_name": ""}, "alice123") == "alice123"
     assert get_resume_name({"full_name": None}, "alice123") == "alice123"

--- a/tests/test_user_profile.py
+++ b/tests/test_user_profile.py
@@ -1,0 +1,181 @@
+import sqlite3
+
+from src.db import init_schema, get_or_create_user
+from src.db.user_profile import (
+    get_user_profile,
+    upsert_user_profile,
+    get_contact_parts,
+    get_visible_profile_text,
+)
+
+
+def make_conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    return conn
+
+
+def test_get_user_profile_defaults_for_new_user():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    profile = get_user_profile(conn, user_id)
+
+    assert profile["user_id"] == user_id
+    assert profile["email"] is None
+    assert profile["phone"] is None
+    assert profile["linkedin"] is None
+    assert profile["github"] is None
+    assert profile["location"] is None
+    assert profile["profile_text"] is None
+
+
+def test_upsert_user_profile_inserts_profile_and_updates_users_email():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="alice@example.com",
+        phone="1234567890",
+        linkedin="https://linkedin.com/in/alice",
+        github="https://github.com/alice",
+        location="Kelowna, BC",
+        profile_text="Software and data student building practical tools.",
+    )
+
+    profile = get_user_profile(conn, user_id)
+    assert profile["email"] == "alice@example.com"
+    assert profile["phone"] == "1234567890"
+    assert profile["linkedin"] == "https://linkedin.com/in/alice"
+    assert profile["github"] == "https://github.com/alice"
+    assert profile["location"] == "Kelowna, BC"
+    assert profile["profile_text"] == "Software and data student building practical tools."
+
+    row = conn.execute(
+        "SELECT email FROM users WHERE user_id = ?",
+        (user_id,),
+    ).fetchone()
+    assert row[0] == "alice@example.com"
+
+
+def test_upsert_user_profile_updates_existing_values():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="alice@example.com",
+        phone="123",
+        linkedin="https://linkedin.com/in/alice",
+        github="https://github.com/alice",
+        location="Kelowna",
+        profile_text="First version.",
+    )
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="newalice@example.com",
+        phone="999",
+        linkedin="https://linkedin.com/in/newalice",
+        github=None,
+        location="Vancouver",
+        profile_text="Updated paragraph.",
+    )
+
+    profile = get_user_profile(conn, user_id)
+    assert profile["email"] == "newalice@example.com"
+    assert profile["phone"] == "999"
+    assert profile["linkedin"] == "https://linkedin.com/in/newalice"
+    assert profile["github"] is None
+    assert profile["location"] == "Vancouver"
+    assert profile["profile_text"] == "Updated paragraph."
+
+
+def test_upsert_user_profile_can_clear_all_fields():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="alice@example.com",
+        phone="123",
+        linkedin="https://linkedin.com/in/alice",
+        github="https://github.com/alice",
+        location="Kelowna",
+        profile_text="Hello",
+    )
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email=None,
+        phone=None,
+        linkedin=None,
+        github=None,
+        location=None,
+        profile_text=None,
+    )
+
+    profile = get_user_profile(conn, user_id)
+    assert profile["email"] is None
+    assert profile["phone"] is None
+    assert profile["linkedin"] is None
+    assert profile["github"] is None
+    assert profile["location"] is None
+    assert profile["profile_text"] is None
+
+
+def test_upsert_user_profile_normalizes_blank_strings_to_none():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    upsert_user_profile(
+        conn,
+        user_id,
+        email="   ",
+        phone="",
+        linkedin="   ",
+        github="",
+        location="   ",
+        profile_text="",
+    )
+
+    profile = get_user_profile(conn, user_id)
+    assert profile["email"] is None
+    assert profile["phone"] is None
+    assert profile["linkedin"] is None
+    assert profile["github"] is None
+    assert profile["location"] is None
+    assert profile["profile_text"] is None
+
+
+def test_get_contact_parts_returns_only_cleaned_values():
+    profile = {
+        "email": " alice@example.com ",
+        "phone": None,
+        "linkedin": " https://linkedin.com/in/alice ",
+        "github": "   ",
+        "location": " Kelowna, BC ",
+    }
+
+    parts = get_contact_parts(profile)
+
+    assert parts == {
+        "phone": None,
+        "email": "alice@example.com",
+        "linkedin": "https://linkedin.com/in/alice",
+        "github": None,
+        "location": "Kelowna, BC",
+    }
+
+
+def test_get_visible_profile_text_returns_none_when_empty():
+    assert get_visible_profile_text({"profile_text": None}) is None
+    assert get_visible_profile_text({"profile_text": ""}) is None
+    assert get_visible_profile_text({"profile_text": "   "}) is None
+    assert get_visible_profile_text({"profile_text": "Hello"}) == "Hello"


### PR DESCRIPTION
## 📝 Description

This PR adds a standalone user profile feature that lets users save and edit resume-level personal information outside of the resume menu. The goal was to keep profile editing separate from resume editing, since those will live on different frontend pages later.

The profile now stores and lets users update:
- full name (for display)
- email
- phone
- LinkedIn URL
- GitHub URL
- location
- profile paragraph

Resume export now reads from that profile data instead of hardcoded placeholders. If a field is not populated, it is omitted from the exported resume. If the profile paragraph is empty, the whole `Profile` section is hidden. For LinkedIn and GitHub, the exported resume shows clickable `LinkedIn` / `GitHub` labels instead of printing the raw URLs.

Added/updated tests cover:
* standalone user profile defaults for a new user
* saving, updating, and clearing standalone user profile fields
* helper behavior for cleaned contact fields, visible profile text, and full-name fallback
* DOCX export rendering populated profile/contact fields correctly
* DOCX export using full name when present and falling back to username otherwise
* DOCX export rendering LinkedIn/GitHub as hyperlink labels instead of raw visible URLs
* DOCX export hiding contact/profile content when fields are empty
* PDF export rendering the same profile behavior consistently, including full name and hyperlink labels
* PDF export hiding contact/profile content when fields are empty

**Closes:** #568 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
* [x] ran `python -m pytest`
* [x] Manually tested by:
- selecting the new `Edit profile` option from the main menu
- entering values for email, phone, LinkedIn, GitHub, location, and profile paragraph
- exporting the same resume to both DOCX and PDF and confirming:
  - populated fields show up
  - empty fields are omitted
  - the `Profile` section is hidden if no profile paragraph is saved
  - LinkedIn and GitHub appear as clickable labels instead of raw links
---

## ✓ Checklist

* [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
* [x] 💬 I have commented my code where needed
* [ ] 📖 I have made corresponding changes to the documentation
* [x] ⚠️ My changes generate no new warnings
* [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
* [ ] 🔗 Any dependent changes have been merged and published in downstream modules
* [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
Resume if no profile info:
<img width="360" height="244" alt="Screenshot 2026-03-10 at 2 57 06 PM" src="https://github.com/user-attachments/assets/a8bd8a83-861a-48b3-8560-079ccd77078b" />
<img width="317" height="220" alt="Screenshot 2026-03-10 at 2 57 16 PM" src="https://github.com/user-attachments/assets/1f5f2cb3-6840-495a-abeb-c5eb1944dd4f" />

Resume if added profile info:
<img width="316" height="250" alt="Screenshot 2026-03-10 at 3 34 19 PM" src="https://github.com/user-attachments/assets/8881bbcb-2ab5-4a05-bd86-319c5f663415" />
<img width="406" height="310" alt="Screenshot 2026-03-10 at 3 33 59 PM" src="https://github.com/user-attachments/assets/6bc42b34-2125-4139-8bd0-b3d60f056ae9" />