### PR TITLE
Feature/edu & cert & exp CLI backend

### DIFF
--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -274,6 +274,11 @@ from src.db.user_education import (
     delete_user_education_entry,
 )
 
+from src.db.user_experience import (
+    list_user_experience_entries,
+    add_user_experience_entry,
+    delete_user_experience_entry,
+)
 
 __all__ = [
     "connect",
@@ -414,5 +419,8 @@ __all__ = [
     "add_user_education_entry",
     "delete_user_education_entry",
     "get_resume_name",
+    "list_user_experience_entries",
+    "add_user_experience_entry",
+    "delete_user_experience_entry",
 ]
 

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -266,6 +266,14 @@ from src.db.user_profile import (
     get_visible_profile_text,
     get_user_profile,
 )
+
+from src.db.user_education import (
+    list_user_education_entries,
+    add_user_education_entry,
+    delete_user_education_entry,
+)
+
+
 __all__ = [
     "connect",
     "init_schema",
@@ -401,5 +409,8 @@ __all__ = [
     "get_contact_parts",
     "get_visible_profile_text",
     "get_user_profile",
+    "list_user_education_entries",
+    "add_user_education_entry",
+    "delete_user_education_entry",
 ]
 

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -755,3 +755,20 @@ CREATE TABLE IF NOT EXISTS user_profiles (
     updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
     FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
 );
+
+CREATE TABLE IF NOT EXISTS user_education_entries (
+    entry_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL,
+    entry_type    TEXT NOT NULL CHECK (entry_type IN ('education', 'certificate')),
+    title         TEXT NOT NULL,
+    organization  TEXT,
+    date_text     TEXT,
+    description   TEXT,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_education_entries_user_order
+    ON user_education_entries(user_id, display_order, entry_id);

--- a/src/db/schema/tables.sql
+++ b/src/db/schema/tables.sql
@@ -773,3 +773,19 @@ CREATE TABLE IF NOT EXISTS user_education_entries (
 
 CREATE INDEX IF NOT EXISTS idx_user_education_entries_user_order
     ON user_education_entries(user_id, display_order, entry_id);
+
+CREATE TABLE IF NOT EXISTS user_experience_entries (
+    entry_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+    user_id       INTEGER NOT NULL,
+    role          TEXT NOT NULL,
+    company       TEXT,
+    date_text     TEXT,
+    description   TEXT,
+    display_order INTEGER NOT NULL DEFAULT 0,
+    created_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at    TEXT NOT NULL DEFAULT (datetime('now')),
+    FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_experience_entries_user_order
+    ON user_experience_entries(user_id, display_order, entry_id);

--- a/src/db/user_education.py
+++ b/src/db/user_education.py
@@ -1,0 +1,118 @@
+"""
+src/db/user_education.py
+
+Helpers for storing and retrieving education / certificate entries
+used by resume export.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+def _clean_optional_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def list_user_education_entries(conn: sqlite3.Connection, user_id: int) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT
+            entry_id,
+            entry_type,
+            title,
+            organization,
+            date_text,
+            description,
+            display_order,
+            created_at,
+            updated_at
+        FROM user_education_entries
+        WHERE user_id = ?
+        ORDER BY display_order ASC, entry_id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    return [
+        {
+            "entry_id": row[0],
+            "entry_type": row[1],
+            "title": row[2],
+            "organization": row[3],
+            "date_text": row[4],
+            "description": row[5],
+            "display_order": row[6],
+            "created_at": row[7],
+            "updated_at": row[8],
+        }
+        for row in rows
+    ]
+
+
+def add_user_education_entry(
+    conn: sqlite3.Connection,
+    user_id: int,
+    *,
+    entry_type: str,
+    title: str,
+    organization: Optional[str] = None,
+    date_text: Optional[str] = None,
+    description: Optional[str] = None,
+) -> int:
+    clean_type = _clean_optional_text(entry_type)
+    clean_title = _clean_optional_text(title)
+    clean_organization = _clean_optional_text(organization)
+    clean_date_text = _clean_optional_text(date_text)
+    clean_description = _clean_optional_text(description)
+
+    if clean_type not in {"education", "certificate"}:
+        raise ValueError("entry_type must be 'education' or 'certificate'")
+    if not clean_title:
+        raise ValueError("title is required")
+
+    row = conn.execute(
+        """
+        SELECT COALESCE(MAX(display_order), 0)
+        FROM user_education_entries
+        WHERE user_id = ?
+        """,
+        (user_id,),
+    ).fetchone()
+    next_order = int(row[0] or 0) + 1
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO user_education_entries
+        (user_id, entry_type, title, organization, date_text, description, display_order, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, ?, datetime('now'))
+        """,
+        (
+            user_id,
+            clean_type,
+            clean_title,
+            clean_organization,
+            clean_date_text,
+            clean_description,
+            next_order,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def delete_user_education_entry(conn: sqlite3.Connection, user_id: int, entry_id: int) -> bool:
+    cur = conn.execute(
+        """
+        DELETE FROM user_education_entries
+        WHERE user_id = ? AND entry_id = ?
+        """,
+        (user_id, entry_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0

--- a/src/db/user_experience.py
+++ b/src/db/user_experience.py
@@ -1,0 +1,110 @@
+"""
+src/db/user_experience.py
+
+Helpers for storing and retrieving experience entries used by resume export.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any, Dict, List, Optional
+
+
+def _clean_optional_text(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def list_user_experience_entries(conn: sqlite3.Connection, user_id: int) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT
+            entry_id,
+            role,
+            company,
+            date_text,
+            description,
+            display_order,
+            created_at,
+            updated_at
+        FROM user_experience_entries
+        WHERE user_id = ?
+        ORDER BY display_order ASC, entry_id ASC
+        """,
+        (user_id,),
+    ).fetchall()
+
+    return [
+        {
+            "entry_id": row[0],
+            "role": row[1],
+            "company": row[2],
+            "date_text": row[3],
+            "description": row[4],
+            "display_order": row[5],
+            "created_at": row[6],
+            "updated_at": row[7],
+        }
+        for row in rows
+    ]
+
+
+def add_user_experience_entry(
+    conn: sqlite3.Connection,
+    user_id: int,
+    *,
+    role: str,
+    company: Optional[str] = None,
+    date_text: Optional[str] = None,
+    description: Optional[str] = None,
+) -> int:
+    clean_role = _clean_optional_text(role)
+    clean_company = _clean_optional_text(company)
+    clean_date_text = _clean_optional_text(date_text)
+    clean_description = _clean_optional_text(description)
+
+    if not clean_role:
+        raise ValueError("role is required")
+
+    row = conn.execute(
+        """
+        SELECT COALESCE(MAX(display_order), 0)
+        FROM user_experience_entries
+        WHERE user_id = ?
+        """,
+        (user_id,),
+    ).fetchone()
+    next_order = int(row[0] or 0) + 1
+
+    cur = conn.cursor()
+    cur.execute(
+        """
+        INSERT INTO user_experience_entries
+        (user_id, role, company, date_text, description, display_order, updated_at)
+        VALUES (?, ?, ?, ?, ?, ?, datetime('now'))
+        """,
+        (
+            user_id,
+            clean_role,
+            clean_company,
+            clean_date_text,
+            clean_description,
+            next_order,
+        ),
+    )
+    conn.commit()
+    return cur.lastrowid
+
+
+def delete_user_experience_entry(conn: sqlite3.Connection, user_id: int, entry_id: int) -> bool:
+    cur = conn.execute(
+        """
+        DELETE FROM user_experience_entries
+        WHERE user_id = ? AND entry_id = ?
+        """,
+        (user_id, entry_id),
+    )
+    conn.commit()
+    return cur.rowcount > 0

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -4,12 +4,10 @@ Export a saved resume snapshot (stored JSON) to a Word (.docx) document.
 Output format:
 - Name
 - Contact
-- Profile 
-- Skills 
-- Projects 
-- Education & certificates
-
-Some items are placeholders for now and will be updated later.
+- Profile
+- Skills
+- Projects
+- Education & certificates (only shown if entries exist)
 
 Saves to ./out/ (created if missing).
 """
@@ -29,7 +27,6 @@ from docx.oxml.ns import qn
 from src.export.resume_helpers import (
     format_date_range,
     add_section_heading,
-    add_placeholder,
     add_bullet,
     add_role_date_line,
     _project_sort_key,
@@ -41,6 +38,7 @@ from src.db import (
     get_contact_parts,
     get_visible_profile_text,
 )
+
 
 def _clean_str(value: Any) -> str | None:
     if not isinstance(value, str):
@@ -74,16 +72,6 @@ def _resume_display_name(p: Dict[str, Any]) -> str:
     return p.get("project_name") or "Unnamed project"
 
 
-def _resume_summary_text(p: Dict[str, Any]) -> str | None:
-    summary_override = _clean_str(p.get("resume_summary_override"))
-    if summary_override:
-        return summary_override
-    manual_summary = _clean_str(p.get("manual_summary_text"))
-    if manual_summary:
-        return manual_summary
-    return _clean_str(p.get("summary_text"))
-
-
 def _resume_contribution_bullets(p: Dict[str, Any]) -> List[str]:
     resume_bullets = _clean_bullets(p.get("resume_contributions_override"))
     if resume_bullets:
@@ -95,7 +83,6 @@ def _resume_contribution_bullets(p: Dict[str, Any]) -> List[str]:
 
 
 def _resume_key_role(p: Dict[str, Any]) -> str | None:
-    """Resolve key role with priority: resume override → manual override → base."""
     resume_role = _clean_str(p.get("resume_key_role_override"))
     if resume_role:
         return resume_role
@@ -112,15 +99,7 @@ def _safe_slug(s: str) -> str:
     return s or "user"
 
 
-def _add_bullet(doc: Document, text: str) -> None:
-    p = doc.add_paragraph(text, style="List Bullet")
-    p.paragraph_format.space_after = 0
-    
-
 def _add_hyperlink(paragraph, url: str, text: str) -> None:
-    """
-    Add a clickable hyperlink to a python-docx paragraph.
-    """
     part = paragraph.part
     r_id = part.relate_to(
         url,
@@ -152,6 +131,31 @@ def _add_hyperlink(paragraph, url: str, text: str) -> None:
     paragraph._p.append(hyperlink)
 
 
+def _render_education_entries(doc: Document, education_entries: List[Dict[str, Any]]) -> None:
+    for entry in education_entries:
+        title = entry.get("title") or "Untitled"
+        p = doc.add_paragraph()
+        run = p.add_run(title)
+        run.bold = True
+
+        details = []
+        if entry.get("organization"):
+            details.append(str(entry["organization"]).strip())
+        if entry.get("date_text"):
+            details.append(str(entry["date_text"]).strip())
+
+        if details:
+            meta = doc.add_paragraph(" | ".join(details))
+            if meta.runs:
+                meta.runs[0].italic = True
+
+        description = _clean_str(entry.get("description"))
+        if description:
+            doc.add_paragraph(description)
+
+        doc.add_paragraph("")
+
+
 def export_resume_record_to_docx(
     *,
     username: str,
@@ -160,27 +164,22 @@ def export_resume_record_to_docx(
     highlighted_skills: Optional[List[str]] = None,
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
     user_profile: Optional[Dict[str, Any]] = None,
+    education_entries: Optional[List[Dict[str, Any]]] = None,
 ) -> Path:
-    """
-    record is the dict returned by get_resume_snapshot(...).
-    Must contain resume_json (preferred) or rendered_text (fallback).
-    """
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
 
     now = datetime.now()
-    stamp_filename = now.strftime("%Y-%m-%d_%H-%M-%S")   
-    stamp_display = now.strftime("%Y-%m-%d at %H:%M:%S") 
-    
+    stamp_filename = now.strftime("%Y-%m-%d_%H-%M-%S")
+
     filename = f"resume_{_safe_slug(username)}_{stamp_filename}.docx"
     filepath = out_path / filename
 
     doc = Document()
-    # doc.add_heading(f"Resume — {username}", level=0)
-    # doc.add_paragraph(f"Generated on {stamp_display}")
 
     profile = user_profile or {}
     contact_parts = get_contact_parts(profile)
+    education_entries = education_entries or []
 
     doc.add_heading(username.upper(), level=0)
 
@@ -218,7 +217,6 @@ def export_resume_record_to_docx(
         except Exception:
             snapshot = None
 
-    # If JSON is broken, fall back to dumping rendered_text as plain paragraphs.
     if snapshot is None:
         doc.add_heading("Resume Snapshot", level=1)
         if isinstance(rendered_text, str) and rendered_text.strip():
@@ -232,17 +230,11 @@ def export_resume_record_to_docx(
     projects: List[Dict[str, Any]] = snapshot.get("projects") or []
     agg: Dict[str, Any] = snapshot.get("aggregated_skills") or {}
 
-    # ---------------------------
-    # Skills Summary (FIRST)
-    # ---------------------------
-
-    # PROFILE (placeholder)
     profile_text = get_visible_profile_text(profile)
     if profile_text:
         add_section_heading(doc, "Profile")
         doc.add_paragraph(profile_text)
 
-    # SKILLS (same logic as before)
     add_section_heading(doc, "Skills")
 
     def add_skill_line(label: str, items: List[str]) -> None:
@@ -257,10 +249,8 @@ def export_resume_record_to_docx(
     )
 
     add_skill_line("Languages", languages)
-
     add_skill_line("Frameworks", agg.get("frameworks") or [])
 
-    # Compute effective highlighted skills (union of per-project or flat list)
     effective_highlighted = highlighted_skills
     if highlighted_skills_by_project is not None:
         all_hl: set = set()
@@ -283,23 +273,19 @@ def export_resume_record_to_docx(
     projects_sorted = sorted(
         projects,
         key=_project_sort_key,
-        reverse=True,  # most recent first
+        reverse=True,
     )
 
-    # PROJECTS (no code/text/individual/collaborative labels)
     add_section_heading(doc, "Projects")
 
     for p in projects_sorted:
         project_name = _resume_display_name(p)
         doc.add_heading(project_name, level=2)
 
-        # Resolve key role with priority: resume override → manual override → base
         role = _resume_key_role(p) or "[Role]"
-
         date_line = format_date_range(p.get("start_date"), p.get("end_date"))
         add_role_date_line(doc, role, date_line)
 
-        # bullets - priority: overrides first, then base contribution_bullets
         custom_bullets = _resume_contribution_bullets(p)
         contrib_bullets = _clean_bullets(p.get("contribution_bullets") or [])
 
@@ -326,9 +312,9 @@ def export_resume_record_to_docx(
 
         doc.add_paragraph("")
 
-    # Education & Certificates (placeholder)
-    add_section_heading(doc, "Education & Certificates")
-    add_placeholder(doc, "To be updated later.")
+    if education_entries:
+        add_section_heading(doc, "Education & Certificates")
+        _render_education_entries(doc, education_entries)
 
     doc.save(str(filepath))
     return filepath

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -131,8 +131,8 @@ def _add_hyperlink(paragraph, url: str, text: str) -> None:
     paragraph._p.append(hyperlink)
 
 
-def _render_education_entries(doc: Document, education_entries: List[Dict[str, Any]]) -> None:
-    for entry in education_entries:
+def _render_education_entries(doc: Document, entries: List[Dict[str, Any]]) -> None:
+    for entry in entries:
         title = entry.get("title") or "Untitled"
         p = doc.add_paragraph()
         run = p.add_run(title)
@@ -312,9 +312,16 @@ def export_resume_record_to_docx(
 
         doc.add_paragraph("")
 
-    if education_entries:
-        add_section_heading(doc, "Education & Certificates")
-        _render_education_entries(doc, education_entries)
+    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
+    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
+
+    if education_only:
+        add_section_heading(doc, "Education")
+        _render_education_entries(doc, education_only)
+
+    if certificate_only:
+        add_section_heading(doc, "Certificates")
+        _render_education_entries(doc, certificate_only)
 
     doc.save(str(filepath))
     return filepath

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -5,9 +5,13 @@ Output format:
 - Name
 - Contact
 - Profile
+- Education
 - Skills
+- Experience
 - Projects
-- Education & certificates (only shown if entries exist)
+- Certificates
+
+Sections are only shown when they have content.
 
 Saves to ./out/ (created if missing).
 """
@@ -17,7 +21,6 @@ from __future__ import annotations
 from datetime import datetime
 from pathlib import Path
 import json
-from pydoc import doc
 import re
 from typing import Any, Dict, List, Optional
 
@@ -158,6 +161,31 @@ def _render_education_entries(doc: Document, entries: List[Dict[str, Any]]) -> N
         doc.add_paragraph("")
 
 
+def _render_experience_entries(doc: Document, entries: List[Dict[str, Any]]) -> None:
+    for entry in entries:
+        role = entry.get("role") or "Untitled role"
+        p = doc.add_paragraph()
+        run = p.add_run(role)
+        run.bold = True
+
+        details = []
+        if entry.get("company"):
+            details.append(str(entry["company"]).strip())
+        if entry.get("date_text"):
+            details.append(str(entry["date_text"]).strip())
+
+        if details:
+            meta = doc.add_paragraph(" | ".join(details))
+            if meta.runs:
+                meta.runs[0].italic = True
+
+        description = _clean_str(entry.get("description"))
+        if description:
+            doc.add_paragraph(description)
+
+        doc.add_paragraph("")
+
+
 def export_resume_record_to_docx(
     *,
     username: str,
@@ -167,6 +195,7 @@ def export_resume_record_to_docx(
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
     user_profile: Optional[Dict[str, Any]] = None,
     education_entries: Optional[List[Dict[str, Any]]] = None,
+    experience_entries: Optional[List[Dict[str, Any]]] = None,
 ) -> Path:
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
@@ -182,6 +211,7 @@ def export_resume_record_to_docx(
     profile = user_profile or {}
     contact_parts = get_contact_parts(profile)
     education_entries = education_entries or []
+    experience_entries = experience_entries or []
 
     display_name = get_resume_name(profile, username)
     doc.add_heading(display_name.upper(), level=0)
@@ -238,6 +268,13 @@ def export_resume_record_to_docx(
         add_section_heading(doc, "Profile")
         doc.add_paragraph(profile_text)
 
+    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
+    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
+
+    if education_only:
+        add_section_heading(doc, "Education")
+        _render_education_entries(doc, education_only)
+
     add_section_heading(doc, "Skills")
 
     def add_skill_line(label: str, items: List[str]) -> None:
@@ -272,6 +309,10 @@ def export_resume_record_to_docx(
 
     add_skill_line("Technical skills", tech_skills)
     add_skill_line("Writing skills", writing_skills)
+
+    if experience_entries:
+        add_section_heading(doc, "Experience")
+        _render_experience_entries(doc, experience_entries)
 
     projects_sorted = sorted(
         projects,
@@ -314,13 +355,6 @@ def export_resume_record_to_docx(
             add_bullet(doc, str(b))
 
         doc.add_paragraph("")
-
-    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
-    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
-
-    if education_only:
-        add_section_heading(doc, "Education")
-        _render_education_entries(doc, education_only)
 
     if certificate_only:
         add_section_heading(doc, "Certificates")

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -6,15 +6,10 @@ Layout:
 - Name (largest)
 - line between name and contact
 - Contact line
-- PROFILE (placeholder)
+- PROFILE (only shown if populated)
 - SKILLS
-- PROJECTS (experience-style per project)
-- EDUCATION & CERTIFICATES (placeholder)
-- Add spacing BETWEEN sections (Profile/Skills/Projects/Education)
-
-Notes:
-- Uses snapshot JSON from get_resume_snapshot(...). No external converters needed.
-- Long lines/bullets wrap automatically (Platypus Paragraph + ListFlowable).
+- PROJECTS
+- EDUCATION & CERTIFICATES (only shown if entries exist)
 """
 
 from __future__ import annotations
@@ -51,6 +46,7 @@ from src.db import (
     get_contact_parts,
     get_visible_profile_text,
 )
+
 
 def _safe_slug(s: str) -> str:
     s = (s or "").strip().lower()
@@ -93,7 +89,6 @@ def _clean_str(value: Any) -> str | None:
 
 
 def _resume_key_role(p: Dict[str, Any]) -> str | None:
-    """Resolve key role with priority: resume override → manual override → base."""
     resume_role = _clean_str(p.get("resume_key_role_override"))
     if resume_role:
         return resume_role
@@ -132,6 +127,7 @@ def export_resume_record_to_pdf(
     highlighted_skills: Optional[List[str]] = None,
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
     user_profile: Optional[Dict[str, Any]] = None,
+    education_entries: Optional[List[Dict[str, Any]]] = None,
 ) -> Path:
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
@@ -164,7 +160,6 @@ def export_resume_record_to_pdf(
 
     styles = getSampleStyleSheet()
 
-    # --- Sizing order requested: Name (biggest) > Section > Project title ---
     NameStyle = ParagraphStyle(
         "NameStyle",
         parent=styles["Normal"],
@@ -222,27 +217,16 @@ def export_resume_record_to_pdf(
         spaceAfter=2,
     )
 
-    PlaceholderItalic = ParagraphStyle(
-        "PlaceholderItalic",
-        parent=Body,
-        fontName="Helvetica-Oblique",
-        spaceAfter=0,
-    )
-
     def rule() -> HRFlowable:
-        # Only used for name->contact separator now
         return HRFlowable(width="100%", thickness=0.8, lineCap="round", spaceBefore=6, spaceAfter=10)
 
     def section_gap() -> Spacer:
-        # spacing BETWEEN sections (requested)
         return Spacer(1, 14)
 
     story: List[Any] = []
 
-    # ---------------------------
-    # Header
-    # ---------------------------
     profile = user_profile or {}
+    education_entries = education_entries or []
 
     story.append(Paragraph(username.upper(), NameStyle))
     story.append(rule())
@@ -251,7 +235,6 @@ def export_resume_record_to_pdf(
     if contact_html:
         story.append(Paragraph(contact_html, ContactStyle))
 
-    # If JSON is broken, dump rendered_text as paragraphs
     if snapshot is None:
         story.append(section_gap())
         story.append(Paragraph("RESUME SNAPSHOT", SectionStyle))
@@ -268,18 +251,12 @@ def export_resume_record_to_pdf(
     projects: List[Dict[str, Any]] = snapshot.get("projects") or []
     agg: Dict[str, Any] = snapshot.get("aggregated_skills") or {}
 
-    # ---------------------------
-    # PROFILE
-    # ---------------------------
     profile_text = get_visible_profile_text(profile)
     if profile_text:
         story.append(section_gap())
         story.append(Paragraph("PROFILE", SectionStyle))
         story.append(Paragraph(escape(profile_text), Body))
 
-    # ---------------------------
-    # SKILLS
-    # ---------------------------
     story.append(section_gap())
     story.append(Paragraph("SKILLS", SectionStyle))
 
@@ -295,10 +272,8 @@ def export_resume_record_to_pdf(
     )
 
     add_skill_line("Languages", languages)
-
     add_skill_line("Frameworks", agg.get("frameworks") or [])
 
-    # Compute effective highlighted skills (union of per-project or flat list)
     effective_highlighted = highlighted_skills
     if highlighted_skills_by_project is not None:
         all_hl: set = set()
@@ -318,9 +293,6 @@ def export_resume_record_to_pdf(
     add_skill_line("Technical skills", tech_skills)
     add_skill_line("Writing skills", writing_skills)
 
-    # ---------------------------
-    # PROJECTS
-    # ---------------------------
     story.append(section_gap())
     story.append(Paragraph("PROJECTS", SectionStyle))
 
@@ -336,7 +308,6 @@ def export_resume_record_to_pdf(
             or p.get("project_name")
             or "Unnamed project"
         )
-        # Resolve key role with priority: resume override → manual override → base
         role = _resume_key_role(p) or "[Role]"
         date_line = format_date_range(p.get("start_date"), p.get("end_date"))
         meta = f"{role} | {date_line}" if date_line else role
@@ -344,7 +315,6 @@ def export_resume_record_to_pdf(
         story.append(Paragraph(str(title), ProjectTitleStyle))
         story.append(Paragraph(meta, MetaItalic))
 
-        # Priority: resume-specific override > global override > base field
         bullets = _clean_bullets(
             p.get("resume_contributions_override")
             or p.get("manual_contribution_bullets")
@@ -373,12 +343,28 @@ def export_resume_record_to_pdf(
 
         story.append(Spacer(1, 10))
 
-    # ---------------------------
-    # EDUCATION & CERTIFICATES
-    # ---------------------------
-    story.append(section_gap())
-    story.append(Paragraph("EDUCATION & CERTIFICATES", SectionStyle))
-    story.append(Paragraph("To be updated later.", PlaceholderItalic))
+    if education_entries:
+        story.append(section_gap())
+        story.append(Paragraph("EDUCATION & CERTIFICATES", SectionStyle))
+
+        for entry in education_entries:
+            title = entry.get("title") or "Untitled"
+            story.append(Paragraph(escape(str(title)), ProjectTitleStyle))
+
+            details = []
+            if entry.get("organization"):
+                details.append(str(entry["organization"]).strip())
+            if entry.get("date_text"):
+                details.append(str(entry["date_text"]).strip())
+
+            if details:
+                story.append(Paragraph(escape(" | ".join(details)), MetaItalic))
+
+            description = _clean_str(entry.get("description"))
+            if description:
+                story.append(Paragraph(escape(description), Body))
+
+            story.append(Spacer(1, 10))
 
     doc.build(story)
     return filepath

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -343,11 +343,8 @@ def export_resume_record_to_pdf(
 
         story.append(Spacer(1, 10))
 
-    if education_entries:
-        story.append(section_gap())
-        story.append(Paragraph("EDUCATION & CERTIFICATES", SectionStyle))
-
-        for entry in education_entries:
+    def _render_education_block(entries: List[Dict[str, Any]]) -> None:
+        for entry in entries:
             title = entry.get("title") or "Untitled"
             story.append(Paragraph(escape(str(title)), ProjectTitleStyle))
 
@@ -365,6 +362,19 @@ def export_resume_record_to_pdf(
                 story.append(Paragraph(escape(description), Body))
 
             story.append(Spacer(1, 10))
+
+    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
+    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
+
+    if education_only:
+        story.append(section_gap())
+        story.append(Paragraph("EDUCATION", SectionStyle))
+        _render_education_block(education_only)
+
+    if certificate_only:
+        story.append(section_gap())
+        story.append(Paragraph("CERTIFICATES", SectionStyle))
+        _render_education_block(certificate_only)
 
     doc.build(story)
     return filepath

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -6,10 +6,14 @@ Layout:
 - Name (largest)
 - line between name and contact
 - Contact line
-- PROFILE (only shown if populated)
-- SKILLS
-- PROJECTS
-- EDUCATION & CERTIFICATES (only shown if entries exist)
+- Profile (only shown if populated)
+- Education
+- Skills
+- Experience
+- Projects
+- Certificates
+
+Sections are only shown when they have content.
 """
 
 from __future__ import annotations
@@ -120,6 +124,60 @@ def _pdf_contact_html(profile: Dict[str, Any]) -> str | None:
     return " | ".join(chunks)
 
 
+def _render_education_block(
+    story: List[Any],
+    entries: List[Dict[str, Any]],
+    project_title_style: ParagraphStyle,
+    meta_italic: ParagraphStyle,
+    body: ParagraphStyle,
+) -> None:
+    for entry in entries:
+        title = entry.get("title") or "Untitled"
+        story.append(Paragraph(escape(str(title)), project_title_style))
+
+        details = []
+        if entry.get("organization"):
+            details.append(str(entry["organization"]).strip())
+        if entry.get("date_text"):
+            details.append(str(entry["date_text"]).strip())
+
+        if details:
+            story.append(Paragraph(escape(" | ".join(details)), meta_italic))
+
+        description = _clean_str(entry.get("description"))
+        if description:
+            story.append(Paragraph(escape(description), body))
+
+        story.append(Spacer(1, 10))
+
+
+def _render_experience_block(
+    story: List[Any],
+    entries: List[Dict[str, Any]],
+    project_title_style: ParagraphStyle,
+    meta_italic: ParagraphStyle,
+    body: ParagraphStyle,
+) -> None:
+    for entry in entries:
+        role = entry.get("role") or "Untitled role"
+        story.append(Paragraph(escape(str(role)), project_title_style))
+
+        details = []
+        if entry.get("company"):
+            details.append(str(entry["company"]).strip())
+        if entry.get("date_text"):
+            details.append(str(entry["date_text"]).strip())
+
+        if details:
+            story.append(Paragraph(escape(" | ".join(details)), meta_italic))
+
+        description = _clean_str(entry.get("description"))
+        if description:
+            story.append(Paragraph(escape(description), body))
+
+        story.append(Spacer(1, 10))
+
+
 def export_resume_record_to_pdf(
     *,
     username: str,
@@ -129,6 +187,7 @@ def export_resume_record_to_pdf(
     highlighted_skills_by_project: Optional[Dict[str, List[str]]] = None,
     user_profile: Optional[Dict[str, Any]] = None,
     education_entries: Optional[List[Dict[str, Any]]] = None,
+    experience_entries: Optional[List[Dict[str, Any]]] = None,
 ) -> Path:
     out_path = Path(out_dir)
     out_path.mkdir(parents=True, exist_ok=True)
@@ -148,6 +207,11 @@ def export_resume_record_to_pdf(
         except Exception:
             snapshot = None
 
+    profile = user_profile or {}
+    education_entries = education_entries or []
+    experience_entries = experience_entries or []
+    display_name = get_resume_name(profile, username)
+
     doc = SimpleDocTemplate(
         str(filepath),
         pagesize=LETTER,
@@ -155,8 +219,8 @@ def export_resume_record_to_pdf(
         rightMargin=0.85 * inch,
         topMargin=0.85 * inch,
         bottomMargin=0.85 * inch,
-        title=f"Resume - {username}",
-        author=username,
+        title=f"Resume - {display_name}",
+        author=display_name,
     )
 
     styles = getSampleStyleSheet()
@@ -226,10 +290,6 @@ def export_resume_record_to_pdf(
 
     story: List[Any] = []
 
-    profile = user_profile or {}
-    education_entries = education_entries or []
-
-    display_name = get_resume_name(profile, username)
     story.append(Paragraph(display_name.upper(), NameStyle))
     story.append(rule())
 
@@ -258,6 +318,14 @@ def export_resume_record_to_pdf(
         story.append(section_gap())
         story.append(Paragraph("PROFILE", SectionStyle))
         story.append(Paragraph(escape(profile_text), Body))
+
+    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
+    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
+
+    if education_only:
+        story.append(section_gap())
+        story.append(Paragraph("EDUCATION", SectionStyle))
+        _render_education_block(story, education_only, ProjectTitleStyle, MetaItalic, Body)
 
     story.append(section_gap())
     story.append(Paragraph("SKILLS", SectionStyle))
@@ -294,6 +362,11 @@ def export_resume_record_to_pdf(
 
     add_skill_line("Technical skills", tech_skills)
     add_skill_line("Writing skills", writing_skills)
+
+    if experience_entries:
+        story.append(section_gap())
+        story.append(Paragraph("EXPERIENCE", SectionStyle))
+        _render_experience_block(story, experience_entries, ProjectTitleStyle, MetaItalic, Body)
 
     story.append(section_gap())
     story.append(Paragraph("PROJECTS", SectionStyle))
@@ -345,38 +418,10 @@ def export_resume_record_to_pdf(
 
         story.append(Spacer(1, 10))
 
-    def _render_education_block(entries: List[Dict[str, Any]]) -> None:
-        for entry in entries:
-            title = entry.get("title") or "Untitled"
-            story.append(Paragraph(escape(str(title)), ProjectTitleStyle))
-
-            details = []
-            if entry.get("organization"):
-                details.append(str(entry["organization"]).strip())
-            if entry.get("date_text"):
-                details.append(str(entry["date_text"]).strip())
-
-            if details:
-                story.append(Paragraph(escape(" | ".join(details)), MetaItalic))
-
-            description = _clean_str(entry.get("description"))
-            if description:
-                story.append(Paragraph(escape(description), Body))
-
-            story.append(Spacer(1, 10))
-
-    education_only = [e for e in education_entries if e.get("entry_type") == "education"]
-    certificate_only = [e for e in education_entries if e.get("entry_type") == "certificate"]
-
-    if education_only:
-        story.append(section_gap())
-        story.append(Paragraph("EDUCATION", SectionStyle))
-        _render_education_block(education_only)
-
     if certificate_only:
         story.append(section_gap())
         story.append(Paragraph("CERTIFICATES", SectionStyle))
-        _render_education_block(certificate_only)
+        _render_education_block(story, certificate_only, ProjectTitleStyle, MetaItalic, Body)
 
     doc.build(story)
     return filepath

--- a/src/menu/profile.py
+++ b/src/menu/profile.py
@@ -14,6 +14,11 @@ from src.db.user_education import (
     add_user_education_entry,
     delete_user_education_entry,
 )
+from src.db.user_experience import (
+    list_user_experience_entries,
+    add_user_experience_entry,
+    delete_user_experience_entry,
+)
 
 
 def _display_value(value: str | None) -> str:
@@ -21,11 +26,6 @@ def _display_value(value: str | None) -> str:
 
 
 def _prompt_field(label: str, current: str | None) -> str | None:
-    """
-    Enter -> keep existing value
-    '-'   -> clear/delete value
-    text  -> update value
-    """
     suffix = f" [{current}]" if current else ""
     raw = input(f"{label}{suffix}: ").strip()
 
@@ -38,8 +38,9 @@ def _prompt_field(label: str, current: str | None) -> str | None:
 
 def _edit_basic_profile(conn, user_id: int, username: str) -> None:
     current = get_user_profile(conn, user_id)
+    display_name = current.get("full_name") or username
 
-    print(f"\nProfile settings for {username}:")
+    print(f"\nProfile settings for {display_name}:")
     print(f"Full name: {_display_value(current.get('full_name'))}")
     print(f"Email: {_display_value(current.get('email'))}")
     print(f"Phone: {_display_value(current.get('phone'))}")
@@ -166,19 +167,96 @@ def _delete_education_entry(conn, user_id: int) -> None:
         print("Unable to delete the selected entry.")
 
 
+def _list_experience_entries(conn, user_id: int) -> list[dict]:
+    entries = list_user_experience_entries(conn, user_id)
+
+    if not entries:
+        print("\nNo experience entries saved yet.")
+        return []
+
+    print("\nExperience:")
+    for idx, entry in enumerate(entries, start=1):
+        role = entry["role"]
+        company = entry.get("company") or ""
+        date_text = entry.get("date_text") or ""
+        details = " | ".join(part for part in [company, date_text] if part)
+        if details:
+            print(f"{idx}. {role} — {details}")
+        else:
+            print(f"{idx}. {role}")
+
+        if entry.get("description"):
+            print(f"   {entry['description']}")
+
+    return entries
+
+
+def _add_experience_entry(conn, user_id: int) -> None:
+    role = input("Role (required): ").strip()
+    if not role:
+        print("Role is required.")
+        return
+
+    company = input("Company (optional): ").strip() or None
+    date_text = input("Date text (optional, e.g. 'May 2024 - Aug 2024'): ").strip() or None
+    description = input("Job description (optional): ").strip() or None
+
+    entry_id = add_user_experience_entry(
+        conn,
+        user_id,
+        role=role,
+        company=company,
+        date_text=date_text,
+        description=description,
+    )
+
+    print(f"\nSaved experience entry #{entry_id}.")
+
+
+def _delete_experience_entry(conn, user_id: int) -> None:
+    entries = _list_experience_entries(conn, user_id)
+    if not entries:
+        return
+
+    choice = input("Select an experience entry to delete (number) or press Enter to cancel: ").strip()
+    if not choice:
+        print("Cancelled.")
+        return
+    if not choice.isdigit():
+        print("Invalid selection.")
+        return
+
+    idx = int(choice)
+    if idx < 1 or idx > len(entries):
+        print("Invalid selection.")
+        return
+
+    entry = entries[idx - 1]
+    confirm = input(f"Delete '{entry['role']}'? (y/n): ").strip().lower()
+    if confirm != "y":
+        print("Cancelled.")
+        return
+
+    deleted = delete_user_experience_entry(conn, user_id, entry["entry_id"])
+    if deleted:
+        print("Entry deleted.")
+    else:
+        print("Unable to delete the selected entry.")
+
+
 def edit_user_profile(conn, user_id: int, username: str) -> None:
-    """
-    Standalone profile settings menu.
-    """
     while True:
         print(f"\nProfile options for {username}:")
         print("1. Edit basic profile")
         print("2. View education / certificate entries")
         print("3. Add education / certificate entry")
         print("4. Delete education / certificate entry")
-        print("5. Back to main menu")
+        print("5. View experience entries")
+        print("6. Add experience entry")
+        print("7. Delete experience entry")
+        print("8. Back to main menu")
 
-        choice = input("Select an option (1-5): ").strip()
+        choice = input("Select an option (1-8): ").strip()
 
         if choice == "1":
             _edit_basic_profile(conn, user_id, username)
@@ -189,6 +267,12 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
         elif choice == "4":
             _delete_education_entry(conn, user_id)
         elif choice == "5":
+            _list_experience_entries(conn, user_id)
+        elif choice == "6":
+            _add_experience_entry(conn, user_id)
+        elif choice == "7":
+            _delete_experience_entry(conn, user_id)
+        elif choice == "8":
             return
         else:
             print("Invalid choice.")

--- a/src/menu/profile.py
+++ b/src/menu/profile.py
@@ -2,13 +2,18 @@
 src/menu/profile.py
 
 Standalone profile menu/handler.
-This is intentionally separate from resume editing because the frontend
+Profile editing stays separate from resume editing because the frontend
 will eventually expose profile and resume on different pages.
 """
 
 from __future__ import annotations
 
 from src.db.user_profile import get_user_profile, upsert_user_profile
+from src.db.user_education import (
+    list_user_education_entries,
+    add_user_education_entry,
+    delete_user_education_entry,
+)
 
 
 def _display_value(value: str | None) -> str:
@@ -31,10 +36,7 @@ def _prompt_field(label: str, current: str | None) -> str | None:
     return raw
 
 
-def edit_user_profile(conn, user_id: int, username: str) -> None:
-    """
-    Edit standalone user profile fields used by resume export.
-    """
+def _edit_basic_profile(conn, user_id: int, username: str) -> None:
     current = get_user_profile(conn, user_id)
 
     print(f"\nProfile settings for {username}:")
@@ -67,3 +69,123 @@ def edit_user_profile(conn, user_id: int, username: str) -> None:
     )
 
     print("\nProfile saved.")
+
+
+def _list_education_entries(conn, user_id: int) -> list[dict]:
+    entries = list_user_education_entries(conn, user_id)
+
+    if not entries:
+        print("\nNo education or certificate entries saved yet.")
+        return []
+
+    print("\nEducation & Certificates:")
+    for idx, entry in enumerate(entries, start=1):
+        entry_type = "Education" if entry["entry_type"] == "education" else "Certificate"
+        title = entry["title"]
+        organization = entry.get("organization") or ""
+        date_text = entry.get("date_text") or ""
+        details = " | ".join(part for part in [organization, date_text] if part)
+        if details:
+            print(f"{idx}. [{entry_type}] {title} — {details}")
+        else:
+            print(f"{idx}. [{entry_type}] {title}")
+
+        if entry.get("description"):
+            print(f"   {entry['description']}")
+
+    return entries
+
+
+def _add_education_entry(conn, user_id: int) -> None:
+    print("\nAdd entry type:")
+    print("1. Education")
+    print("2. Certificate")
+    entry_type_choice = input("Select an option (1-2): ").strip()
+
+    if entry_type_choice == "1":
+        entry_type = "education"
+    elif entry_type_choice == "2":
+        entry_type = "certificate"
+    else:
+        print("Invalid selection.")
+        return
+
+    title = input("Title (required): ").strip()
+    if not title:
+        print("Title is required.")
+        return
+
+    organization = input("School / issuer / organization (optional): ").strip() or None
+    date_text = input("Date text (optional, e.g. '2022 - 2026' or 'May 2025'): ").strip() or None
+    description = input("Description (optional): ").strip() or None
+
+    entry_id = add_user_education_entry(
+        conn,
+        user_id,
+        entry_type=entry_type,
+        title=title,
+        organization=organization,
+        date_text=date_text,
+        description=description,
+    )
+
+    print(f"\nSaved entry #{entry_id}.")
+
+
+def _delete_education_entry(conn, user_id: int) -> None:
+    entries = _list_education_entries(conn, user_id)
+    if not entries:
+        return
+
+    choice = input("Select an entry to delete (number) or press Enter to cancel: ").strip()
+    if not choice:
+        print("Cancelled.")
+        return
+    if not choice.isdigit():
+        print("Invalid selection.")
+        return
+
+    idx = int(choice)
+    if idx < 1 or idx > len(entries):
+        print("Invalid selection.")
+        return
+
+    entry = entries[idx - 1]
+    confirm = input(f"Delete '{entry['title']}'? (y/n): ").strip().lower()
+    if confirm != "y":
+        print("Cancelled.")
+        return
+
+    deleted = delete_user_education_entry(conn, user_id, entry["entry_id"])
+    if deleted:
+        print("Entry deleted.")
+    else:
+        print("Unable to delete the selected entry.")
+
+
+def edit_user_profile(conn, user_id: int, username: str) -> None:
+    """
+    Standalone profile settings menu.
+    """
+    while True:
+        print(f"\nProfile options for {username}:")
+        print("1. Edit basic profile")
+        print("2. View education / certificate entries")
+        print("3. Add education / certificate entry")
+        print("4. Delete education / certificate entry")
+        print("5. Back to main menu")
+
+        choice = input("Select an option (1-5): ").strip()
+
+        if choice == "1":
+            _edit_basic_profile(conn, user_id, username)
+        elif choice == "2":
+            _list_education_entries(conn, user_id)
+        elif choice == "3":
+            _add_education_entry(conn, user_id)
+        elif choice == "4":
+            _delete_education_entry(conn, user_id)
+        elif choice == "5":
+            return
+        else:
+            print("Invalid choice.")

--- a/src/menu/resume/flow.py
+++ b/src/menu/resume/flow.py
@@ -16,8 +16,10 @@ from src.db import (
     update_resume_snapshot,
     delete_resume_snapshot,
     get_user_profile,
-    list_user_education_entries
+    list_user_education_entries,
+    list_user_experience_entries,
 )
+
 from src.insights.rank_projects.rank_project_importance import collect_project_data
 from .helpers import (
     load_project_summaries,
@@ -311,6 +313,8 @@ def _handle_export_resume_docx(conn, user_id: int, username: str) -> bool:
     
     user_profile = get_user_profile(conn, user_id)
     education_entries = list_user_education_entries(conn, user_id)
+    experience_entries = list_user_experience_entries(conn, user_id)
+
     out_file = export_resume_record_to_docx(
         username=username,
         record=record,
@@ -318,6 +322,7 @@ def _handle_export_resume_docx(conn, user_id: int, username: str) -> bool:
         highlighted_skills=highlighted_skills,
         user_profile=user_profile,
         education_entries=education_entries,
+        experience_entries=experience_entries,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")
@@ -443,6 +448,8 @@ def _handle_export_resume_pdf(conn, user_id: int, username: str) -> bool:
     
     user_profile = get_user_profile(conn, user_id)
     education_entries = list_user_education_entries(conn, user_id)
+    experience_entries = list_user_experience_entries(conn, user_id)
+
     out_file = export_resume_record_to_pdf(
         username=username,
         record=record,
@@ -450,6 +457,7 @@ def _handle_export_resume_pdf(conn, user_id: int, username: str) -> bool:
         highlighted_skills=highlighted_skills,
         user_profile=user_profile,
         education_entries=education_entries,
+        experience_entries=experience_entries,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")

--- a/src/menu/resume/flow.py
+++ b/src/menu/resume/flow.py
@@ -15,7 +15,8 @@ from src.db import (
     get_resume_snapshot,
     update_resume_snapshot,
     delete_resume_snapshot,
-    get_user_profile
+    get_user_profile,
+    list_user_education_entries
 )
 from src.insights.rank_projects.rank_project_importance import collect_project_data
 from .helpers import (
@@ -309,12 +310,14 @@ def _handle_export_resume_docx(conn, user_id: int, username: str) -> bool:
     )
     
     user_profile = get_user_profile(conn, user_id)
+    education_entries = list_user_education_entries(conn, user_id)
     out_file = export_resume_record_to_docx(
         username=username,
         record=record,
         out_dir="./out",
         highlighted_skills=highlighted_skills,
         user_profile=user_profile,
+        education_entries=education_entries,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")
@@ -439,12 +442,14 @@ def _handle_export_resume_pdf(conn, user_id: int, username: str) -> bool:
     )
     
     user_profile = get_user_profile(conn, user_id)
+    education_entries = list_user_education_entries(conn, user_id)
     out_file = export_resume_record_to_pdf(
         username=username,
         record=record,
         out_dir="./out",
         highlighted_skills=highlighted_skills,
         user_profile=user_profile,
+        education_entries=education_entries,
     )
     print(f"\nSaving resume to {out_file} ...")
     print("✓ Export complete.\n")

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -3,7 +3,9 @@ from pathlib import Path
 import xml.etree.ElementTree as ET
 import zipfile
 
+import pytest
 import src.export.resume_docx as exp
+import src.menu.resume.flow as flow
 
 
 W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
@@ -36,46 +38,60 @@ def _docx_hyperlink_targets(path: Path) -> list[str]:
     return targets
 
 
-class _FakeDatetime:
-    @staticmethod
-    def now():
-        class _DT:
-            def strftime(self, fmt: str) -> str:
-                return "2026-01-10_15-36-58"
-        return _DT()
-
-
-def test_resume_docx_sections_happy_path(monkeypatch, tmp_path):
+def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     """
-    Covers PR 2 happy path:
-    - full_name still used
-    - hyperlinks still work
-    - section order is:
-      Profile -> Education -> Skills -> Experience -> Projects -> Certificates
-    - education / experience / certificate content render
+    Covers:
+    - deterministic filename via frozen datetime
+    - structure/order:
+      Name -> Contact -> PROFILE -> EDUCATION -> SKILLS -> EXPERIENCE -> PROJECTS -> CERTIFICATES
+    - projects sorted by most-recent end_date/start_date first
+    - LinkedIn/GitHub shown as labels, with real hyperlink targets in the docx
+    - education, experience, and certificate entries render in the correct sections
     """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
         "aggregated_skills": {
-            "languages": ["Python 88%"],
+            "languages": ["Python 88%", "SQL 12%"],
             "frameworks": ["FastAPI"],
             "technical_skills": ["Algorithms"],
             "writing_skills": ["Clear communication"],
         },
         "projects": [
             {
-                "project_name": "Capstone Project",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Built API endpoints"],
+                "project_name": "older_project",
+                "role": "[Role]",
+                "start_date": "2024-12-01",
+                "end_date": "2024-12-31",
+                "contribution_bullets": ["Old bullet A"],
+            },
+            {
+                "project_name": "newer_project",
+                "role": "[Role]",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["New bullet A", "New bullet B"],
             },
         ],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+    out_dir = tmp_path / "out"
+
     user_profile = {
-        "full_name": "John Tan",
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -83,6 +99,7 @@ def test_resume_docx_sections_happy_path(monkeypatch, tmp_path):
         "location": "Kelowna, BC",
         "profile_text": "Software and data student building practical tools.",
     }
+
     education_entries = [
         {
             "entry_id": 1,
@@ -101,6 +118,7 @@ def test_resume_docx_sections_happy_path(monkeypatch, tmp_path):
             "description": "Foundational cloud certification.",
         },
     ]
+
     experience_entries = [
         {
             "entry_id": 10,
@@ -112,63 +130,142 @@ def test_resume_docx_sections_happy_path(monkeypatch, tmp_path):
     ]
 
     path = exp.export_resume_record_to_docx(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=user_profile,
         education_entries=education_entries,
         experience_entries=experience_entries,
     )
 
+    assert out_dir.exists()
+    assert path.exists()
+    assert path.name == "resume_john_2026-01-10_15-36-58.docx"
+
     txt = _doc_text(path)
     hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "JOHN TAN" in txt
+    assert "john" in txt.lower()
+
+    # Contact line pieces appear as visible text
+    assert "1234567890" in txt
     assert "john@example.com" in txt
     assert "LinkedIn" in txt
     assert "GitHub" in txt
+    assert "Kelowna, BC" in txt
+
+    # URLs should be hyperlink targets, not visible text
+    assert "https://linkedin.com/in/john" in hyperlink_targets
+    assert "https://github.com/john" in hyperlink_targets
+    assert "https://linkedin.com/in/john" not in txt
+    assert "https://github.com/john" not in txt
+
+    # Required sections exist
     assert "PROFILE" in txt
     assert "EDUCATION" in txt
     assert "SKILLS" in txt
     assert "EXPERIENCE" in txt
     assert "PROJECTS" in txt
     assert "CERTIFICATES" in txt
+    assert "EDUCATION & CERTIFICATES" not in txt
 
+    # Order: PROFILE -> EDUCATION -> SKILLS -> EXPERIENCE -> PROJECTS -> CERTIFICATES
     idx_profile = txt.find("PROFILE")
     idx_education = txt.find("EDUCATION")
     idx_skills = txt.find("SKILLS")
     idx_experience = txt.find("EXPERIENCE")
     idx_projects = txt.find("PROJECTS")
     idx_certificates = txt.find("CERTIFICATES")
+    assert -1 not in (idx_profile, idx_education, idx_skills, idx_experience, idx_projects, idx_certificates)
     assert idx_profile < idx_education < idx_skills < idx_experience < idx_projects < idx_certificates
 
-    assert "https://linkedin.com/in/john" in hyperlink_targets
-    assert "https://github.com/john" in hyperlink_targets
-    assert "https://linkedin.com/in/john" not in txt
-    assert "https://github.com/john" not in txt
+    # Profile paragraph rendered
+    assert "Software and data student building practical tools." in txt
 
-    assert "BSc in Computer Science" in txt
-    assert "UBCO" in txt
+    # Skills lines rendered
+    assert "Languages:" in txt
+    assert ("Python" in txt) and ("SQL" in txt)
+    assert "Frameworks:" in txt
+    assert "FastAPI" in txt
+    assert "Technical skills:" in txt
+    assert "Algorithms" in txt
+    assert "Writing skills:" in txt
+    assert "Clear communication" in txt
+
+    # Experience content
     assert "Data Science Intern" in txt
     assert "PETRONAS" in txt
-    assert "Capstone Project" in txt
+    assert "May 2025 - Aug 2025" in txt
+    assert "Built analytics workflows and dashboards." in txt
+
+    # Projects content
+    assert "newer_project" in txt
+    assert "older_project" in txt
+    assert "[Role]" in txt
+
+    # Contributions bullets appear
+    assert "New bullet A" in txt
+    assert "New bullet B" in txt
+    assert "Old bullet A" in txt
+
+    # Sorting check: newer should appear before older
+    assert txt.find("newer_project") < txt.find("older_project")
+
+    # Education + certificate content
+    assert "BSc in Computer Science" in txt
+    assert "UBCO" in txt
+    assert "2022 - 2026" in txt
+    assert "Major in data science." in txt
+
     assert "AWS Cloud Practitioner" in txt
+    assert "Amazon Web Services" in txt
+    assert "Foundational cloud certification." in txt
+
+    # Optional: verify years appear somewhere
+    assert "2025" in txt and "2024" in txt
 
 
-def test_resume_docx_omits_empty_sections(monkeypatch, tmp_path):
+def test_resume_export_omits_contact_line_profile_education_experience_and_certificate_sections_when_empty(monkeypatch, tmp_path):
     """
-    Covers omission behavior:
-    - falls back to username
-    - hides profile / education / experience / certificates when empty
+    Covers:
+    - empty standalone profile should not render contact info
+    - PROFILE section should be omitted when profile_text is empty
+    - EDUCATION / EXPERIENCE / CERTIFICATES should be omitted when no entries exist
     """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
-        "aggregated_skills": {},
-        "projects": [],
+        "aggregated_skills": {
+            "languages": ["Python 88%"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
     }
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+    out_dir = tmp_path / "out"
+
     empty_profile = {
         "full_name": None,
         "email": None,
@@ -180,18 +277,306 @@ def test_resume_docx_omits_empty_sections(monkeypatch, tmp_path):
     }
 
     path = exp.export_resume_record_to_docx(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=empty_profile,
         education_entries=[],
         experience_entries=[],
     )
 
     txt = _doc_text(path)
+    hyperlink_targets = _docx_hyperlink_targets(path)
 
-    assert "JOHN123" in txt
+    assert "john" in txt.lower()
+    assert "SKILLS" in txt
+    assert "PROJECTS" in txt
+
     assert "PROFILE" not in txt
     assert "EDUCATION" not in txt
     assert "EXPERIENCE" not in txt
     assert "CERTIFICATES" not in txt
+    assert "john@example.com" not in txt
+    assert "1234567890" not in txt
+    assert "LinkedIn" not in txt
+    assert "GitHub" not in txt
+    assert "Kelowna, BC" not in txt
+
+    assert all("linkedin.com" not in target for target in hyperlink_targets)
+    assert all("github.com" not in target for target in hyperlink_targets)
+
+
+def test_resume_export_shows_only_certificate_section_when_only_certificates_exist(monkeypatch, tmp_path):
+    """
+    Covers:
+    - separate section rendering when only certificate entries exist
+    - certificates appear after projects
+    """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    education_entries = [
+        {
+            "entry_id": 2,
+            "entry_type": "certificate",
+            "title": "AWS Cloud Practitioner",
+            "organization": "Amazon Web Services",
+            "date_text": "2025",
+            "description": "Foundational cloud certification.",
+        },
+    ]
+
+    path = exp.export_resume_record_to_docx(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        education_entries=education_entries,
+        experience_entries=[],
+    )
+
+    txt = _doc_text(path)
+
+    assert "CERTIFICATES" in txt
+    assert "AWS Cloud Practitioner" in txt
+    assert "EDUCATION" not in txt
+    assert "PROJECTS" in txt
+    assert txt.find("PROJECTS") < txt.find("CERTIFICATES")
+
+
+def test_resume_export_nonhappy_no_saved_resumes(monkeypatch, capsys):
+    """
+    Covers: R2 (flow handler: list_resumes empty)
+    """
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: [])
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "No saved resumes yet" in out
+
+
+def test_resume_export_nonhappy_cancel_invalid_selection(monkeypatch, capsys):
+    """
+    Covers: R3 + R4 (cancel, invalid index)
+    """
+    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(
+        flow,
+        "get_resume_snapshot",
+        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
+    )
+    monkeypatch.setattr(flow, "export_resume_record_to_docx", lambda **k: Path("./out/fake.docx"))
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Cancelled" in out
+
+    monkeypatch.setattr("builtins.input", lambda _: "999")
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Invalid selection" in out
+
+
+def test_resume_export_nonhappy_record_missing(monkeypatch, capsys):
+    """
+    Covers: R5 (get_resume_snapshot returns None)
+    """
+    resumes = [{"id": 11, "name": "Resume A", "created_at": "2026-01-01"}]
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(flow, "get_resume_snapshot", lambda conn, user_id, rid: None)
+    monkeypatch.setattr("builtins.input", lambda _: "1")
+
+    ok = flow._handle_export_resume_docx(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+    assert ok is False
+    assert "Unable to load the selected resume" in out
+
+
+def test_resume_export_fallback_to_rendered_text(monkeypatch, tmp_path):
+    """
+    Covers: R6 + R7 (malformed JSON -> fallback; missing rendered_text -> message)
+    """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    if fmt == "%Y-%m-%d at %H:%M:%S":
+                        return "2026-01-10 at 15:36:58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    out_dir = tmp_path / "out"
+
+    record = {"resume_json": "{not json", "rendered_text": "LINE1\nLINE2\n"}
+    path = exp.export_resume_record_to_docx(username="john", record=record, out_dir=str(out_dir))
+    txt = _doc_text(path)
+    assert "Resume Snapshot" in txt
+    assert "LINE1" in txt and "LINE2" in txt
+
+    record2 = {"resume_json": "{not json", "rendered_text": ""}
+    path2 = exp.export_resume_record_to_docx(username="john", record=record2, out_dir=str(out_dir))
+    txt2 = _doc_text(path2)
+    assert "Resume data is missing or unreadable" in txt2
+
+
+def test_resume_export_uses_key_role(monkeypatch, tmp_path):
+    """Test that export uses resolved key_role instead of [Role] placeholder."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Backend Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Built API endpoints"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "Backend Developer" in txt
+    assert "[Role]" not in txt
+
+
+def test_resume_export_key_role_override_priority(monkeypatch, tmp_path):
+    """Test that resume_key_role_override takes priority over base key_role."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Developer",
+                "manual_key_role": "Senior Developer",
+                "resume_key_role_override": "Lead Developer",
+                "contribution_bullets": ["Led team"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "Lead Developer" in txt
+    assert "Senior Developer" not in txt
+    assert "[Role]" not in txt
+
+
+def test_resume_export_fallback_to_role_placeholder(monkeypatch, tmp_path):
+    """Test that export falls back to [Role] when no key_role is set."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "contribution_bullets": ["Did stuff"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_docx(username="jane", record=record, out_dir=str(out_dir))
+
+    txt = _doc_text(path)
+    assert "[Role]" in txt
+
+
+def test_resume_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that DOCX export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    path = exp.export_resume_record_to_docx(
+        username="john123",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=user_profile,
+    )
+
+    txt = _doc_text(path)
+    assert "JOHN TAN" in txt

--- a/tests/test_resume_docx.py
+++ b/tests/test_resume_docx.py
@@ -43,9 +43,10 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     Covers:
     - deterministic filename via frozen datetime
     - structure/order:
-      Name -> Contact -> PROFILE -> SKILLS -> PROJECTS -> EDUCATION & CERTIFICATES
+      Name -> Contact -> PROFILE -> SKILLS -> PROJECTS -> EDUCATION -> CERTIFICATES
     - projects sorted by most-recent end_date/start_date first
     - LinkedIn/GitHub shown as labels, with real hyperlink targets in the docx
+    - education + certificate entries render as separate sections
     """
     class _FakeDatetime:
         @staticmethod
@@ -98,11 +99,31 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
         "profile_text": "Software and data student building practical tools.",
     }
 
+    education_entries = [
+        {
+            "entry_id": 1,
+            "entry_type": "education",
+            "title": "BSc in Computer Science",
+            "organization": "UBCO",
+            "date_text": "2022 - 2026",
+            "description": "Major in data science.",
+        },
+        {
+            "entry_id": 2,
+            "entry_type": "certificate",
+            "title": "AWS Cloud Practitioner",
+            "organization": "Amazon Web Services",
+            "date_text": "2025",
+            "description": "Foundational cloud certification.",
+        },
+    ]
+
     path = exp.export_resume_record_to_docx(
         username="john",
         record=record,
         out_dir=str(out_dir),
         user_profile=user_profile,
+        education_entries=education_entries,
     )
 
     assert out_dir.exists()
@@ -131,15 +152,18 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     assert "PROFILE" in txt
     assert "SKILLS" in txt
     assert "PROJECTS" in txt
-    assert "EDUCATION & CERTIFICATES" in txt
+    assert "EDUCATION" in txt
+    assert "CERTIFICATES" in txt
+    assert "EDUCATION & CERTIFICATES" not in txt
 
-    # Order: PROFILE -> SKILLS -> PROJECTS -> EDUCATION
+    # Order: PROFILE -> SKILLS -> PROJECTS -> EDUCATION -> CERTIFICATES
     idx_profile = txt.find("PROFILE")
     idx_skills = txt.find("SKILLS")
     idx_projects = txt.find("PROJECTS")
-    idx_edu = txt.find("EDUCATION & CERTIFICATES")
-    assert -1 not in (idx_profile, idx_skills, idx_projects, idx_edu)
-    assert idx_profile < idx_skills < idx_projects < idx_edu
+    idx_education = txt.find("EDUCATION")
+    idx_certificates = txt.find("CERTIFICATES")
+    assert -1 not in (idx_profile, idx_skills, idx_projects, idx_education, idx_certificates)
+    assert idx_profile < idx_skills < idx_projects < idx_education < idx_certificates
 
     # Profile paragraph rendered
     assert "Software and data student building practical tools." in txt
@@ -167,15 +191,26 @@ def test_resume_export_happy_json_structure_and_order(monkeypatch, tmp_path):
     # Sorting check: newer should appear before older
     assert txt.find("newer_project") < txt.find("older_project")
 
+    # Education + certificate content
+    assert "BSc in Computer Science" in txt
+    assert "UBCO" in txt
+    assert "2022 - 2026" in txt
+    assert "Major in data science." in txt
+
+    assert "AWS Cloud Practitioner" in txt
+    assert "Amazon Web Services" in txt
+    assert "Foundational cloud certification." in txt
+
     # Optional: verify years appear somewhere
     assert "2025" in txt and "2024" in txt
 
 
-def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty(monkeypatch, tmp_path):
+def test_resume_export_omits_contact_line_profile_and_education_sections_when_empty(monkeypatch, tmp_path):
     """
     Covers:
     - empty standalone profile should not render contact info
     - PROFILE section should be omitted when profile_text is empty
+    - EDUCATION / CERTIFICATES should be omitted when no entries exist
     """
     class _FakeDatetime:
         @staticmethod
@@ -225,6 +260,7 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
         record=record,
         out_dir=str(out_dir),
         user_profile=empty_profile,
+        education_entries=[],
     )
 
     txt = _doc_text(path)
@@ -233,9 +269,10 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
     assert "john" in txt.lower()
     assert "SKILLS" in txt
     assert "PROJECTS" in txt
-    assert "EDUCATION & CERTIFICATES" in txt
 
     assert "PROFILE" not in txt
+    assert "EDUCATION" not in txt
+    assert "CERTIFICATES" not in txt
     assert "john@example.com" not in txt
     assert "1234567890" not in txt
     assert "LinkedIn" not in txt
@@ -244,6 +281,54 @@ def test_resume_export_omits_contact_line_and_profile_section_when_profile_empty
 
     assert all("linkedin.com" not in target for target in hyperlink_targets)
     assert all("github.com" not in target for target in hyperlink_targets)
+
+
+def test_resume_export_shows_only_certificate_section_when_only_certificates_exist(monkeypatch, tmp_path):
+    """
+    Covers:
+    - separate section rendering when only certificate entries exist
+    """
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+
+    education_entries = [
+        {
+            "entry_id": 2,
+            "entry_type": "certificate",
+            "title": "AWS Cloud Practitioner",
+            "organization": "Amazon Web Services",
+            "date_text": "2025",
+            "description": "Foundational cloud certification.",
+        },
+    ]
+
+    path = exp.export_resume_record_to_docx(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        education_entries=education_entries,
+    )
+
+    txt = _doc_text(path)
+
+    assert "CERTIFICATES" in txt
+    assert "AWS Cloud Practitioner" in txt
+    assert "EDUCATION" not in txt
 
 
 def test_resume_export_nonhappy_no_saved_resumes(monkeypatch, capsys):

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -5,6 +5,7 @@ import pytest
 from pypdf import PdfReader
 
 import src.export.resume_pdf as exp
+import src.menu.resume.flow as flow
 
 
 def _pdf_text(path):
@@ -27,47 +28,91 @@ def _pdf_link_targets(path):
     return targets
 
 
-class _FakeDatetime:
-    @staticmethod
-    def now():
-        class _DT:
-            def strftime(self, fmt: str) -> str:
-                return "2026-01-10_15-36-58"
-        return _DT()
+def test_resume_pdf_export_creates_valid_pdf(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
 
-
-@pytest.mark.pdf_text
-def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
-    """
-    Covers PR 2 happy path:
-    - full_name still used
-    - hyperlinks still work
-    - section order is:
-      Profile -> Education -> Skills -> Experience -> Projects -> Certificates
-    - education / experience / certificate content render
-    """
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
         "aggregated_skills": {
             "languages": ["Python"],
-            "frameworks": ["FastAPI"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "role": "[Role]",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="john", record=record, out_dir=str(out_dir))
+
+    assert path.exists()
+    assert path.name == "resume_john_2026-01-10_15-36-58.pdf"
+
+    raw = Path(path).read_bytes()
+    assert raw[:4] == b"%PDF"
+    assert len(raw) > 1000
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": [],
             "technical_skills": ["Algorithms"],
             "writing_skills": ["Clear communication"],
         },
         "projects": [
             {
-                "project_name": "Capstone Project",
-                "start_date": "2025-01-01",
-                "end_date": "2025-06-01",
-                "contribution_bullets": ["Built API endpoints"],
+                "project_name": "older",
+                "start_date": "2024-01-01",
+                "end_date": "2024-02-01",
+                "role": "[Role]",
+                "contribution_bullets": ["Old bullet"],
+            },
+            {
+                "project_name": "newer",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "role": "[Role]",
+                "contribution_bullets": ["New bullet"],
             },
         ],
     }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
 
-    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
     user_profile = {
-        "full_name": "John Tan",
+        "full_name": None,
         "email": "john@example.com",
         "phone": "1234567890",
         "linkedin": "https://linkedin.com/in/john",
@@ -75,6 +120,7 @@ def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
         "location": "Kelowna, BC",
         "profile_text": "Software and data student building practical tools.",
     }
+
     education_entries = [
         {
             "entry_id": 1,
@@ -93,6 +139,7 @@ def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
             "description": "Foundational cloud certification.",
         },
     ]
+
     experience_entries = [
         {
             "entry_id": 10,
@@ -103,10 +150,11 @@ def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
         }
     ]
 
+    out_dir = tmp_path / "out"
     path = exp.export_resume_record_to_pdf(
-        username="john123",
+        username="john",
         record=record,
-        out_dir=str(tmp_path / "out"),
+        out_dir=str(out_dir),
         user_profile=user_profile,
         education_entries=education_entries,
         experience_entries=experience_entries,
@@ -115,16 +163,13 @@ def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
     text = _pdf_text(path)
     link_targets = _pdf_link_targets(path)
 
-    assert "JOHN TAN" in text
-    assert "john@example.com" in text
-    assert "LinkedIn" in text
-    assert "GitHub" in text
     assert "PROFILE" in text
     assert "EDUCATION" in text
     assert "SKILLS" in text
     assert "EXPERIENCE" in text
     assert "PROJECTS" in text
     assert "CERTIFICATES" in text
+    assert "EDUCATION & CERTIFICATES" not in text
 
     idx_profile = text.find("PROFILE")
     idx_education = text.find("EDUCATION")
@@ -132,28 +177,279 @@ def test_resume_pdf_sections_happy_path(monkeypatch, tmp_path):
     idx_experience = text.find("EXPERIENCE")
     idx_projects = text.find("PROJECTS")
     idx_certificates = text.find("CERTIFICATES")
+    assert -1 not in (idx_profile, idx_education, idx_skills, idx_experience, idx_projects, idx_certificates)
     assert idx_profile < idx_education < idx_skills < idx_experience < idx_projects < idx_certificates
 
+    # profile/contact info
+    assert "1234567890" in text
+    assert "john@example.com" in text
+    assert "LinkedIn" in text
+    assert "GitHub" in text
+    assert "Kelowna, BC" in text
+    assert "Software and data student building practical tools." in text
+
+    # education / experience / certificate content
+    assert "BSc in Computer Science" in text
+    assert "UBCO" in text
+    assert "AWS Cloud Practitioner" in text
+    assert "Amazon Web Services" in text
+    assert "Data Science Intern" in text
+    assert "PETRONAS" in text
+    assert "Built analytics workflows and dashboards." in text
+
+    # skills
+    assert "Algorithms" in text
+    assert "Clear communication" in text
+
+    # URLs should exist as real PDF links, not as visible text
     assert "https://linkedin.com/in/john" in link_targets
     assert "https://github.com/john" in link_targets
     assert "https://linkedin.com/in/john" not in text
     assert "https://github.com/john" not in text
 
-    assert "BSc in Computer Science" in text
-    assert "UBCO" in text
-    assert "Data Science Intern" in text
-    assert "PETRONAS" in text
-    assert "Capstone Project" in text
-    assert "AWS Cloud Practitioner" in text
+    # ordering by recency: newer should appear before older
+    assert text.find("newer") < text.find("older")
 
 
 @pytest.mark.pdf_text
-def test_resume_pdf_omits_empty_sections(monkeypatch, tmp_path):
+def test_resume_pdf_omits_contact_profile_education_experience_and_certificate_sections_when_empty(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    if fmt == "%Y-%m-%d_%H-%M-%S":
+                        return "2026-01-10_15-36-58"
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {
+            "languages": ["Python"],
+            "frameworks": [],
+            "technical_skills": [],
+            "writing_skills": [],
+        },
+        "projects": [
+            {
+                "project_name": "projA",
+                "start_date": "2025-08-01",
+                "end_date": "2025-11-01",
+                "contribution_bullets": ["Bullet A"],
+            }
+        ],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": "fallback"}
+
+    empty_profile = {
+        "full_name": None,
+        "email": None,
+        "phone": None,
+        "linkedin": None,
+        "github": None,
+        "location": None,
+        "profile_text": None,
+    }
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        user_profile=empty_profile,
+        education_entries=[],
+        experience_entries=[],
+    )
+
+    text = _pdf_text(path)
+    link_targets = _pdf_link_targets(path)
+
+    assert "SKILLS" in text
+    assert "PROJECTS" in text
+
+    assert "PROFILE" not in text
+    assert "EDUCATION" not in text
+    assert "EXPERIENCE" not in text
+    assert "CERTIFICATES" not in text
+    assert "john@example.com" not in text
+    assert "1234567890" not in text
+    assert "LinkedIn" not in text
+    assert "GitHub" not in text
+    assert "Kelowna, BC" not in text
+
+    assert all("linkedin.com" not in target for target in link_targets)
+    assert all("github.com" not in target for target in link_targets)
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_shows_only_education_section_when_only_education_entries_exist(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+
+    education_entries = [
+        {
+            "entry_id": 1,
+            "entry_type": "education",
+            "title": "BSc in Computer Science",
+            "organization": "UBCO",
+            "date_text": "2022 - 2026",
+            "description": "Major in data science.",
+        },
+    ]
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        education_entries=education_entries,
+        experience_entries=[],
+    )
+
+    text = _pdf_text(path)
+
+    assert "EDUCATION" in text
+    assert "BSc in Computer Science" in text
+    assert "CERTIFICATES" not in text
+
+
+def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):
     """
-    Covers omission behavior:
-    - falls back to username
-    - hides profile / education / experience / certificates when empty
+    Covers:
+    - Cancel on Enter
+    - Invalid index selection
+    - Ensures PDF export is not called
     """
+    resumes = [
+        {"id": 1, "name": "Resume A", "created_at": "2026-01-01"},
+        {"id": 2, "name": "Resume B", "created_at": "2026-01-02"},
+    ]
+
+    monkeypatch.setattr(flow, "list_resumes", lambda conn, user_id: resumes)
+    monkeypatch.setattr(
+        flow,
+        "get_resume_snapshot",
+        lambda conn, user_id, rid: {"resume_json": "{}", "rendered_text": ""},
+    )
+
+    def fail_export(**kwargs):
+        raise AssertionError("PDF export should not be called")
+
+    monkeypatch.setattr(flow, "export_resume_record_to_pdf", fail_export)
+
+    monkeypatch.setattr("builtins.input", lambda _: "")
+    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Cancelled" in out
+
+    monkeypatch.setattr("builtins.input", lambda _: "999")
+    ok = flow._handle_export_resume_pdf(conn=None, user_id=1, username="john")
+    out = capsys.readouterr().out
+
+    assert ok is False
+    assert "Invalid selection" in out
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_export_uses_key_role(monkeypatch, tmp_path):
+    """Test that PDF export uses resolved key_role instead of [Role] placeholder."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Backend Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Built API endpoints"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
+
+    text = _pdf_text(path)
+    assert "Backend Developer" in text
+    assert "[Role]" not in text
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_export_key_role_override_priority(monkeypatch, tmp_path):
+    """Test that resume_key_role_override takes priority over base key_role in PDF."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [
+            {
+                "project_name": "test_project",
+                "key_role": "Developer",
+                "manual_key_role": "Senior Developer",
+                "resume_key_role_override": "Lead Developer",
+                "start_date": "2025-01-01",
+                "end_date": "2025-06-01",
+                "contribution_bullets": ["Led team"],
+            },
+        ],
+    }
+
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(username="jane", record=record, out_dir=str(out_dir))
+
+    text = _pdf_text(path)
+    assert "Lead Developer" in text
+    assert "[Role]" not in text
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_export_uses_full_name_when_present(monkeypatch, tmp_path):
+    """Test that PDF export uses full_name instead of username when present."""
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
     monkeypatch.setattr(exp, "datetime", _FakeDatetime)
 
     snapshot = {
@@ -162,8 +458,10 @@ def test_resume_pdf_omits_empty_sections(monkeypatch, tmp_path):
     }
 
     record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
-    empty_profile = {
-        "full_name": None,
+    out_dir = tmp_path / "out"
+
+    user_profile = {
+        "full_name": "John Tan",
         "email": None,
         "phone": None,
         "linkedin": None,
@@ -175,16 +473,9 @@ def test_resume_pdf_omits_empty_sections(monkeypatch, tmp_path):
     path = exp.export_resume_record_to_pdf(
         username="john123",
         record=record,
-        out_dir=str(tmp_path / "out"),
-        user_profile=empty_profile,
-        education_entries=[],
-        experience_entries=[],
+        out_dir=str(out_dir),
+        user_profile=user_profile,
     )
 
     text = _pdf_text(path)
-
-    assert "JOHN123" in text
-    assert "PROFILE" not in text
-    assert "EDUCATION" not in text
-    assert "EXPERIENCE" not in text
-    assert "CERTIFICATES" not in text
+    assert "JOHN TAN" in text

--- a/tests/test_resume_pdf.py
+++ b/tests/test_resume_pdf.py
@@ -120,12 +120,32 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
         "profile_text": "Software and data student building practical tools.",
     }
 
+    education_entries = [
+        {
+            "entry_id": 1,
+            "entry_type": "education",
+            "title": "BSc in Computer Science",
+            "organization": "UBCO",
+            "date_text": "2022 - 2026",
+            "description": "Major in data science.",
+        },
+        {
+            "entry_id": 2,
+            "entry_type": "certificate",
+            "title": "AWS Cloud Practitioner",
+            "organization": "Amazon Web Services",
+            "date_text": "2025",
+            "description": "Foundational cloud certification.",
+        },
+    ]
+
     out_dir = tmp_path / "out"
     path = exp.export_resume_record_to_pdf(
         username="john",
         record=record,
         out_dir=str(out_dir),
         user_profile=user_profile,
+        education_entries=education_entries,
     )
 
     text = _pdf_text(path)
@@ -136,6 +156,8 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
     assert "SKILLS" in text
     assert "PROJECTS" in text
     assert "EDUCATION" in text
+    assert "CERTIFICATES" in text
+    assert "EDUCATION & CERTIFICATES" not in text
 
     # profile/contact info
     assert "1234567890" in text
@@ -144,6 +166,12 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
     assert "GitHub" in text
     assert "Kelowna, BC" in text
     assert "Software and data student building practical tools." in text
+
+    # education content
+    assert "BSc in Computer Science" in text
+    assert "UBCO" in text
+    assert "AWS Cloud Practitioner" in text
+    assert "Amazon Web Services" in text
 
     # URLs should exist as real PDF links, not as visible text
     assert "https://linkedin.com/in/john" in link_targets
@@ -156,7 +184,7 @@ def test_resume_pdf_contains_sections_and_orders_projects(monkeypatch, tmp_path)
 
 
 @pytest.mark.pdf_text
-def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tmp_path):
+def test_resume_pdf_omits_contact_profile_and_education_sections_when_empty(monkeypatch, tmp_path):
     class _FakeDatetime:
         @staticmethod
         def now():
@@ -202,6 +230,7 @@ def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tm
         record=record,
         out_dir=str(out_dir),
         user_profile=empty_profile,
+        education_entries=[],
     )
 
     text = _pdf_text(path)
@@ -209,9 +238,10 @@ def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tm
 
     assert "SKILLS" in text
     assert "PROJECTS" in text
-    assert "EDUCATION" in text
 
     assert "PROFILE" not in text
+    assert "EDUCATION" not in text
+    assert "CERTIFICATES" not in text
     assert "john@example.com" not in text
     assert "1234567890" not in text
     assert "LinkedIn" not in text
@@ -220,6 +250,50 @@ def test_resume_pdf_omits_contact_and_profile_when_profile_empty(monkeypatch, tm
 
     assert all("linkedin.com" not in target for target in link_targets)
     assert all("github.com" not in target for target in link_targets)
+
+
+@pytest.mark.pdf_text
+def test_resume_pdf_shows_only_education_section_when_only_education_entries_exist(monkeypatch, tmp_path):
+    class _FakeDatetime:
+        @staticmethod
+        def now():
+            class _DT:
+                def strftime(self, fmt: str) -> str:
+                    return "2026-01-10_15-36-58"
+            return _DT()
+
+    monkeypatch.setattr(exp, "datetime", _FakeDatetime)
+
+    snapshot = {
+        "aggregated_skills": {},
+        "projects": [],
+    }
+    record = {"resume_json": json.dumps(snapshot), "rendered_text": ""}
+
+    education_entries = [
+        {
+            "entry_id": 1,
+            "entry_type": "education",
+            "title": "BSc in Computer Science",
+            "organization": "UBCO",
+            "date_text": "2022 - 2026",
+            "description": "Major in data science.",
+        },
+    ]
+
+    out_dir = tmp_path / "out"
+    path = exp.export_resume_record_to_pdf(
+        username="john",
+        record=record,
+        out_dir=str(out_dir),
+        education_entries=education_entries,
+    )
+
+    text = _pdf_text(path)
+
+    assert "EDUCATION" in text
+    assert "BSc in Computer Science" in text
+    assert "CERTIFICATES" not in text
 
 
 def test_resume_export_pdf_cancel_invalid_selection(monkeypatch, capsys):

--- a/tests/test_user_education.py
+++ b/tests/test_user_education.py
@@ -1,0 +1,147 @@
+import sqlite3
+
+from src.db import init_schema, get_or_create_user
+from src.db.user_education import (
+    list_user_education_entries,
+    add_user_education_entry,
+    delete_user_education_entry,
+)
+
+
+def make_conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    return conn
+
+
+def test_list_user_education_entries_empty_for_new_user():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    entries = list_user_education_entries(conn, user_id)
+
+    assert entries == []
+
+
+def test_add_user_education_entry_saves_education_entry():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    entry_id = add_user_education_entry(
+        conn,
+        user_id,
+        entry_type="education",
+        title="BSc in Computer Science",
+        organization="UBCO",
+        date_text="2022 - 2026",
+        description="Major in data science.",
+    )
+
+    entries = list_user_education_entries(conn, user_id)
+
+    assert len(entries) == 1
+    assert entries[0]["entry_id"] == entry_id
+    assert entries[0]["entry_type"] == "education"
+    assert entries[0]["title"] == "BSc in Computer Science"
+    assert entries[0]["organization"] == "UBCO"
+    assert entries[0]["date_text"] == "2022 - 2026"
+    assert entries[0]["description"] == "Major in data science."
+    assert entries[0]["display_order"] == 1
+
+
+def test_add_user_education_entry_saves_certificate_and_increments_order():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    add_user_education_entry(
+        conn,
+        user_id,
+        entry_type="education",
+        title="BSc in Computer Science",
+        organization="UBCO",
+        date_text="2022 - 2026",
+        description="Major in data science.",
+    )
+
+    cert_id = add_user_education_entry(
+        conn,
+        user_id,
+        entry_type="certificate",
+        title="AWS Cloud Practitioner",
+        organization="Amazon Web Services",
+        date_text="2025",
+        description="Foundational cloud certification.",
+    )
+
+    entries = list_user_education_entries(conn, user_id)
+
+    assert len(entries) == 2
+    assert entries[1]["entry_id"] == cert_id
+    assert entries[1]["entry_type"] == "certificate"
+    assert entries[1]["title"] == "AWS Cloud Practitioner"
+    assert entries[1]["organization"] == "Amazon Web Services"
+    assert entries[1]["date_text"] == "2025"
+    assert entries[1]["description"] == "Foundational cloud certification."
+    assert entries[1]["display_order"] == 2
+
+
+def test_add_user_education_entry_rejects_invalid_type():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    try:
+        add_user_education_entry(
+            conn,
+            user_id,
+            entry_type="award",
+            title="Some Award",
+        )
+        assert False, "Expected ValueError for invalid entry type"
+    except ValueError as exc:
+        assert "entry_type" in str(exc)
+
+
+def test_add_user_education_entry_requires_title():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    try:
+        add_user_education_entry(
+            conn,
+            user_id,
+            entry_type="education",
+            title="",
+        )
+        assert False, "Expected ValueError for missing title"
+    except ValueError as exc:
+        assert "title" in str(exc).lower()
+
+
+def test_delete_user_education_entry_removes_entry():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    entry_id = add_user_education_entry(
+        conn,
+        user_id,
+        entry_type="certificate",
+        title="AWS Cloud Practitioner",
+        organization="Amazon Web Services",
+        date_text="2025",
+        description="Foundational cloud certification.",
+    )
+
+    deleted = delete_user_education_entry(conn, user_id, entry_id)
+    entries = list_user_education_entries(conn, user_id)
+
+    assert deleted is True
+    assert entries == []
+
+
+def test_delete_user_education_entry_returns_false_for_missing_entry():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    deleted = delete_user_education_entry(conn, user_id, 9999)
+
+    assert deleted is False

--- a/tests/test_user_education.py
+++ b/tests/test_user_education.py
@@ -23,37 +23,14 @@ def test_list_user_education_entries_empty_for_new_user():
     assert entries == []
 
 
-def test_add_user_education_entry_saves_education_entry():
+def test_user_education_round_trip():
+    """
+    Covers add/list/delete for both education and certificate entries.
+    """
     conn = make_conn()
     user_id = get_or_create_user(conn, "alice")
 
-    entry_id = add_user_education_entry(
-        conn,
-        user_id,
-        entry_type="education",
-        title="BSc in Computer Science",
-        organization="UBCO",
-        date_text="2022 - 2026",
-        description="Major in data science.",
-    )
-
-    entries = list_user_education_entries(conn, user_id)
-
-    assert len(entries) == 1
-    assert entries[0]["entry_id"] == entry_id
-    assert entries[0]["entry_type"] == "education"
-    assert entries[0]["title"] == "BSc in Computer Science"
-    assert entries[0]["organization"] == "UBCO"
-    assert entries[0]["date_text"] == "2022 - 2026"
-    assert entries[0]["description"] == "Major in data science."
-    assert entries[0]["display_order"] == 1
-
-
-def test_add_user_education_entry_saves_certificate_and_increments_order():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    add_user_education_entry(
+    edu_id = add_user_education_entry(
         conn,
         user_id,
         entry_type="education",
@@ -76,72 +53,11 @@ def test_add_user_education_entry_saves_certificate_and_increments_order():
     entries = list_user_education_entries(conn, user_id)
 
     assert len(entries) == 2
+    assert entries[0]["entry_id"] == edu_id
+    assert entries[0]["entry_type"] == "education"
     assert entries[1]["entry_id"] == cert_id
     assert entries[1]["entry_type"] == "certificate"
-    assert entries[1]["title"] == "AWS Cloud Practitioner"
-    assert entries[1]["organization"] == "Amazon Web Services"
-    assert entries[1]["date_text"] == "2025"
-    assert entries[1]["description"] == "Foundational cloud certification."
-    assert entries[1]["display_order"] == 2
 
-
-def test_add_user_education_entry_rejects_invalid_type():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    try:
-        add_user_education_entry(
-            conn,
-            user_id,
-            entry_type="award",
-            title="Some Award",
-        )
-        assert False, "Expected ValueError for invalid entry type"
-    except ValueError as exc:
-        assert "entry_type" in str(exc)
-
-
-def test_add_user_education_entry_requires_title():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    try:
-        add_user_education_entry(
-            conn,
-            user_id,
-            entry_type="education",
-            title="",
-        )
-        assert False, "Expected ValueError for missing title"
-    except ValueError as exc:
-        assert "title" in str(exc).lower()
-
-
-def test_delete_user_education_entry_removes_entry():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    entry_id = add_user_education_entry(
-        conn,
-        user_id,
-        entry_type="certificate",
-        title="AWS Cloud Practitioner",
-        organization="Amazon Web Services",
-        date_text="2025",
-        description="Foundational cloud certification.",
-    )
-
-    deleted = delete_user_education_entry(conn, user_id, entry_id)
-    entries = list_user_education_entries(conn, user_id)
-
-    assert deleted is True
-    assert entries == []
-
-
-def test_delete_user_education_entry_returns_false_for_missing_entry():
-    conn = make_conn()
-    user_id = get_or_create_user(conn, "alice")
-
-    deleted = delete_user_education_entry(conn, user_id, 9999)
-
-    assert deleted is False
+    assert delete_user_education_entry(conn, user_id, edu_id) is True
+    assert delete_user_education_entry(conn, user_id, cert_id) is True
+    assert list_user_education_entries(conn, user_id) == []

--- a/tests/test_user_experience.py
+++ b/tests/test_user_experience.py
@@ -1,0 +1,47 @@
+import sqlite3
+
+from src.db import init_schema, get_or_create_user
+from src.db.user_experience import (
+    list_user_experience_entries,
+    add_user_experience_entry,
+    delete_user_experience_entry,
+)
+
+
+def make_conn():
+    conn = sqlite3.connect(":memory:")
+    init_schema(conn)
+    return conn
+
+
+def test_list_user_experience_entries_empty_for_new_user():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    entries = list_user_experience_entries(conn, user_id)
+
+    assert entries == []
+
+
+def test_user_experience_round_trip():
+    conn = make_conn()
+    user_id = get_or_create_user(conn, "alice")
+
+    entry_id = add_user_experience_entry(
+        conn,
+        user_id,
+        role="Data Science Intern",
+        company="PETRONAS",
+        date_text="May 2025 - Aug 2025",
+        description="Built analytics workflows and dashboards.",
+    )
+
+    entries = list_user_experience_entries(conn, user_id)
+
+    assert len(entries) == 1
+    assert entries[0]["entry_id"] == entry_id
+    assert entries[0]["role"] == "Data Science Intern"
+    assert entries[0]["company"] == "PETRONAS"
+
+    assert delete_user_experience_entry(conn, user_id, entry_id) is True
+    assert list_user_experience_entries(conn, user_id) == []


### PR DESCRIPTION
## 📝 Description

This PR extends the standalone profile feature by letting users add and delete structured education, certificate, and experience entries, which are then rendered in resume exports.

The profile page now supports:
- viewing saved education / certificate / experience entries
- adding a new education entry
- adding a new certificate entry
- adding a new experience entry
- deleting an existing entry

Resume export was updated to read those entries and render them as three separate sections:
- `Education`
- `Certificates`
- `Experience`

Each section is only shown if the user has entries of that type. This replaces the old placeholder behavior for `Education & Certificates`, so resumes now only show real content instead of a static placeholder.

This PR builds directly on the standalone profile work from the previous PR, so profile editing and education/certificate/experience management both stay outside the resume menu. That keeps the structure aligned with the planned frontend, where profile and resume editing will live on different pages.

Added/updated tests cover:
* DOCX export rendering the new resume section order correctly: `Profile -> Education -> Skills -> Experience -> Projects -> Certificates`
* DOCX export rendering education, experience, and certificate content in their respective sections
* DOCX export omitting optional sections when no profile, education, experience, or certificate entries exist
* PDF export rendering the same section order and content correctly
* PDF export omitting optional sections when no profile, education, experience, or certificate entries exist
* database helpers for listing, adding, and deleting education / certificate entries
* database helpers for listing, adding, and deleting experience entries

NOTE: this PR will be rebased to main once PR #573 is merged

**Closes:** #569

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing
* [x] ran `python -m pytest`
* [x] Manually tested by:
- selecting the standalone `Edit profile` option from the main menu
- adding education, certificate, and experience entries
- deleting existing entries
- exporting the same resume to both DOCX and PDF and confirming:
  - `Education` and `Certificates` show as separate sections
  - `Experience` section shows up when added
  - each section only appears when entries of that type exist
  - the sections are omitted entirely when no entries are saved
  - added entries render with title, organization, date text, and description when provided

---

## ✓ Checklist

* [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
* [x] 💬 I have commented my code where needed
* [ ] 📖 I have made corresponding changes to the documentation
* [x] ⚠️ My changes generate no new warnings
* [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
* [ ] 🔗 Any dependent changes have been merged and published in downstream modules
* [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots
Resume before Education/ Certificates/ Experience inputs:
<img width="362" height="456" alt="Screenshot 2026-03-10 at 5 05 14 PM" src="https://github.com/user-attachments/assets/69c9b504-aaef-479c-b5c0-077491b29af5" />

Resume after Education/ Certificates/ Experience inputs:
<img width="591" height="377" alt="Screenshot 2026-03-11 at 2 39 59 PM" src="https://github.com/user-attachments/assets/b003461f-71f4-420e-97f7-e3ff9c0c0150" />