### PR TITLE
Frontend - Resume Edit

### DIFF
--- a/frontend/src/api/__tests__/outputs.test.ts
+++ b/frontend/src/api/__tests__/outputs.test.ts
@@ -1,0 +1,73 @@
+import { api } from "../client";
+import { editResume } from "../outputs";
+
+vi.mock("../client", () => ({
+  api: {
+    postJson: vi.fn(),
+  },
+}));
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("editResume", () => {
+  it("sends POST to /resume/{id}/edit with payload", async () => {
+    const mockResponse = { success: true, data: { id: 5, name: "Updated" }, error: null };
+    vi.mocked(api.postJson).mockResolvedValue(mockResponse);
+
+    const payload = {
+      name: "New Name",
+    };
+    const result = await editResume(5, payload);
+
+    expect(api.postJson).toHaveBeenCalledWith("/resume/5/edit", payload);
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("sends project edit fields with scope", async () => {
+    vi.mocked(api.postJson).mockResolvedValue({ success: true, data: null, error: null });
+
+    await editResume(3, {
+      project_summary_id: 10,
+      scope: "resume_only",
+      display_name: "My Project",
+      summary_text: "A summary",
+      key_role: "Lead Dev",
+      contribution_bullets: ["Did X", "Did Y"],
+      contribution_edit_mode: "replace",
+    });
+
+    expect(api.postJson).toHaveBeenCalledWith("/resume/3/edit", {
+      project_summary_id: 10,
+      scope: "resume_only",
+      display_name: "My Project",
+      summary_text: "A summary",
+      key_role: "Lead Dev",
+      contribution_bullets: ["Did X", "Did Y"],
+      contribution_edit_mode: "replace",
+    });
+  });
+
+  it("sends global scope", async () => {
+    vi.mocked(api.postJson).mockResolvedValue({ success: true, data: null, error: null });
+
+    await editResume(1, {
+      project_summary_id: 7,
+      scope: "global",
+      key_role: "Backend Developer",
+    });
+
+    expect(api.postJson).toHaveBeenCalledWith("/resume/1/edit", {
+      project_summary_id: 7,
+      scope: "global",
+      key_role: "Backend Developer",
+    });
+  });
+
+  it("propagates API errors", async () => {
+    vi.mocked(api.postJson).mockRejectedValue(new Error("Not found"));
+
+    await expect(editResume(99, { name: "X" })).rejects.toThrow("Not found");
+  });
+});

--- a/frontend/src/api/outputs.ts
+++ b/frontend/src/api/outputs.ts
@@ -83,6 +83,26 @@ export function getRankedProjects() {
   );
 }
 
+/* ── Resume editing ── */
+
+export interface ResumeEditRequest {
+  name?: string;
+  project_summary_id?: number;
+  scope?: "resume_only" | "global";
+  display_name?: string;
+  summary_text?: string;
+  contribution_bullets?: string[];
+  contribution_edit_mode?: "append" | "replace";
+  key_role?: string;
+}
+
+export function editResume(resumeId: number, payload: ResumeEditRequest) {
+  return api.postJson<ApiResponse<ResumeDetail>>(
+    `/resume/${resumeId}/edit`,
+    payload
+  );
+}
+
 /* ── Export helpers ── */
 
 export async function downloadResumeDocx(id: number) {

--- a/frontend/src/components/outputs/ResumeDetail.tsx
+++ b/frontend/src/components/outputs/ResumeDetail.tsx
@@ -41,7 +41,6 @@ type ProjectEdits = {
   summary_text: string;
   key_role: string;
   contribution_bullets: string[];
-  contribution_edit_mode: "append" | "replace";
   scope: "resume_only" | "global";
 };
 
@@ -146,7 +145,6 @@ export default function ResumeDetail({
       summary_text: p.summary_text ?? "",
       key_role: p.key_role ?? "",
       contribution_bullets: [...p.contribution_bullets],
-      contribution_edit_mode: "replace",
       scope: "resume_only",
     });
     setErr(null);
@@ -185,7 +183,7 @@ export default function ResumeDetail({
           JSON.stringify(original.contribution_bullets);
         if (bulletsChanged) {
           payload.contribution_bullets = projectEdits.contribution_bullets;
-          payload.contribution_edit_mode = projectEdits.contribution_edit_mode;
+          payload.contribution_edit_mode = "replace";
         }
       }
 
@@ -641,35 +639,7 @@ function ProjectEditForm({
       </div>
 
       <div className="space-y-2">
-        <div className="flex items-center justify-between">
-          <Label>Contribution Bullets</Label>
-          <div className="flex items-center gap-3 text-xs text-slate-500">
-            <label className="flex items-center gap-1 cursor-pointer">
-              <input
-                type="radio"
-                name="edit-mode"
-                checked={edits.contribution_edit_mode === "replace"}
-                onChange={() =>
-                  setEdits({ ...edits, contribution_edit_mode: "replace" })
-                }
-                className="accent-slate-700"
-              />
-              Replace all
-            </label>
-            <label className="flex items-center gap-1 cursor-pointer">
-              <input
-                type="radio"
-                name="edit-mode"
-                checked={edits.contribution_edit_mode === "append"}
-                onChange={() =>
-                  setEdits({ ...edits, contribution_edit_mode: "append" })
-                }
-                className="accent-slate-700"
-              />
-              Append new
-            </label>
-          </div>
-        </div>
+        <Label>Contribution Bullets</Label>
 
         <div className="space-y-2">
           {edits.contribution_bullets.map((bullet, i) => (

--- a/frontend/src/components/outputs/ResumeDetail.tsx
+++ b/frontend/src/components/outputs/ResumeDetail.tsx
@@ -1,46 +1,106 @@
 import { useEffect, useState } from "react";
 import {
   getResume,
+  editResume,
   downloadResumeDocx,
   downloadResumePdf,
   type ResumeDetail as ResumeDetailType,
   type ResumeProject,
 } from "../../api/outputs";
 import ExportDropdown from "./ExportDropdown";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  CardAction,
+} from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Label } from "@/components/ui/label";
+import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
+import { Separator } from "@/components/ui/separator";
+import { Badge } from "@/components/ui/badge";
+import {
+  Pencil,
+  Check,
+  X,
+  Plus,
+  Trash2,
+} from "lucide-react";
 
 type Props = {
   resumeId: number;
+  initialEditing?: boolean;
   onBack: () => void;
 };
 
-/** Group projects by "code (individual)", "text (collaborative)", etc. */
-function groupProjects(projects: ResumeProject[]) {
-  const groups: Record<string, ResumeProject[]> = {};
-  for (const p of projects) {
-    const type = p.project_type ?? "other";
-    const mode = p.project_mode ?? "";
-    const key = mode ? `${type} (${mode})` : type;
-    (groups[key] ??= []).push(p);
-  }
-  return groups;
-}
+type ProjectEdits = {
+  display_name: string;
+  summary_text: string;
+  key_role: string;
+  contribution_bullets: string[];
+  contribution_edit_mode: "append" | "replace";
+  scope: "resume_only" | "global";
+};
 
-function formatGroupLabel(key: string) {
-  return key.charAt(0).toUpperCase() + key.slice(1) + " Projects";
-}
-
-export default function ResumeDetail({ resumeId, onBack }: Props) {
+export default function ResumeDetail({
+  resumeId,
+  initialEditing = false,
+  onBack,
+}: Props) {
   const [resume, setResume] = useState<ResumeDetailType | null>(null);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
 
-  useEffect(() => {
+  // Edit mode toggle
+  const [editing, setEditing] = useState(initialEditing);
+
+  // Resume name editing
+  const [editingName, setEditingName] = useState(false);
+  const [nameVal, setNameVal] = useState("");
+  const [savingName, setSavingName] = useState(false);
+
+  // Per-project editing
+  const [editingProjectId, setEditingProjectId] = useState<number | null>(null);
+  const [projectEdits, setProjectEdits] = useState<ProjectEdits | null>(null);
+  const [savingProject, setSavingProject] = useState(false);
+  const [successMsg, setSuccessMsg] = useState<string | null>(null);
+
+  function loadResume() {
+    setLoading(true);
+    setErr(null);
     getResume(resumeId)
-      .then((r) => setResume(r.data))
+      .then((r) => {
+        setResume(r.data);
+        setNameVal(r.data?.name ?? "");
+      })
       .catch((e) => setErr(e.message))
       .finally(() => setLoading(false));
-  }, [resumeId]);
+  }
 
+  useEffect(loadResume, [resumeId]);
+
+  // Clear success message after 3 seconds
+  useEffect(() => {
+    if (!successMsg) return;
+    const t = setTimeout(() => setSuccessMsg(null), 3000);
+    return () => clearTimeout(t);
+  }, [successMsg]);
+
+  // When leaving edit mode, collapse any open project edit
+  function toggleEditing() {
+    if (editing) {
+      setEditingProjectId(null);
+      setProjectEdits(null);
+      setEditingName(false);
+      setNameVal(resume?.name ?? "");
+    }
+    setEditing(!editing);
+  }
+
+  /* ── Export ── */
   async function handleExportDocx() {
     try {
       await downloadResumeDocx(resumeId);
@@ -57,57 +117,389 @@ export default function ResumeDetail({ resumeId, onBack }: Props) {
     }
   }
 
-  if (loading) return <div className="content"><p>Loading...</p></div>;
-  if (err) return <div className="content"><p className="error">{err}</p></div>;
-  if (!resume) return <div className="content"><p>Resume not found.</p></div>;
+  /* ── Resume name save ── */
+  async function handleSaveName() {
+    if (!nameVal.trim() || nameVal === resume?.name) {
+      setEditingName(false);
+      return;
+    }
+    setSavingName(true);
+    setErr(null);
+    try {
+      await editResume(resumeId, { name: nameVal.trim() });
+      setResume((r) => (r ? { ...r, name: nameVal.trim() } : r));
+      setEditingName(false);
+      setSuccessMsg("Resume name updated");
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setSavingName(false);
+    }
+  }
+
+  /* ── Open project edit ── */
+  function startEditingProject(p: ResumeProject) {
+    if (p.project_summary_id == null) return;
+    setEditingProjectId(p.project_summary_id);
+    setProjectEdits({
+      display_name: p.project_name,
+      summary_text: p.summary_text ?? "",
+      key_role: p.key_role ?? "",
+      contribution_bullets: [...p.contribution_bullets],
+      contribution_edit_mode: "replace",
+      scope: "resume_only",
+    });
+    setErr(null);
+  }
+
+  function cancelEditingProject() {
+    setEditingProjectId(null);
+    setProjectEdits(null);
+  }
+
+  /* ── Save project edits ── */
+  async function handleSaveProject() {
+    if (!projectEdits || editingProjectId == null) return;
+    setSavingProject(true);
+    setErr(null);
+    try {
+      const payload: Record<string, unknown> = {
+        project_summary_id: editingProjectId,
+        scope: projectEdits.scope,
+      };
+      const original = resume?.projects.find(
+        (p) => p.project_summary_id === editingProjectId
+      );
+      if (original) {
+        if (projectEdits.display_name !== original.project_name) {
+          payload.display_name = projectEdits.display_name;
+        }
+        if (projectEdits.summary_text !== (original.summary_text ?? "")) {
+          payload.summary_text = projectEdits.summary_text;
+        }
+        if (projectEdits.key_role !== (original.key_role ?? "")) {
+          payload.key_role = projectEdits.key_role;
+        }
+        const bulletsChanged =
+          JSON.stringify(projectEdits.contribution_bullets) !==
+          JSON.stringify(original.contribution_bullets);
+        if (bulletsChanged) {
+          payload.contribution_bullets = projectEdits.contribution_bullets;
+          payload.contribution_edit_mode = projectEdits.contribution_edit_mode;
+        }
+      }
+
+      const fieldKeys = Object.keys(payload).filter(
+        (k) => k !== "project_summary_id" && k !== "scope"
+      );
+      if (fieldKeys.length === 0) {
+        cancelEditingProject();
+        return;
+      }
+
+      await editResume(resumeId, payload as any);
+      setEditingProjectId(null);
+      setProjectEdits(null);
+      setSuccessMsg(
+        projectEdits.scope === "global"
+          ? "Updated across all resumes"
+          : "Updated this resume"
+      );
+      loadResume();
+    } catch (e: any) {
+      setErr(e.message);
+    } finally {
+      setSavingProject(false);
+    }
+  }
+
+  /* ── Bullet helpers ── */
+  function updateBullet(index: number, value: string) {
+    if (!projectEdits) return;
+    const bullets = [...projectEdits.contribution_bullets];
+    bullets[index] = value;
+    setProjectEdits({ ...projectEdits, contribution_bullets: bullets });
+  }
+
+  function removeBullet(index: number) {
+    if (!projectEdits) return;
+    const bullets = projectEdits.contribution_bullets.filter(
+      (_, i) => i !== index
+    );
+    setProjectEdits({ ...projectEdits, contribution_bullets: bullets });
+  }
+
+  function addBullet() {
+    if (!projectEdits) return;
+    setProjectEdits({
+      ...projectEdits,
+      contribution_bullets: [...projectEdits.contribution_bullets, ""],
+    });
+  }
+
+  /* ── Render ── */
+  if (loading)
+    return (
+      <div className="content">
+        <p>Loading...</p>
+      </div>
+    );
+  if (err && !resume)
+    return (
+      <div className="content">
+        <p className="error">{err}</p>
+      </div>
+    );
+  if (!resume)
+    return (
+      <div className="content">
+        <p>Resume not found.</p>
+      </div>
+    );
 
   const grouped = groupProjects(resume.projects);
   const agg = resume.aggregated_skills;
 
   return (
     <div className="content">
+      {/* Header */}
       <div className="outputsHeader">
-        <button className="backBtn" onClick={onBack}>&larr;</button>
-        <h2>{resume.name}</h2>
+        <button className="backBtn" onClick={onBack}>
+          &larr;
+        </button>
+
+        {editing && editingName ? (
+          <>
+            <Input
+              value={nameVal}
+              onChange={(e) => setNameVal(e.target.value)}
+              className="max-w-xs text-lg font-semibold flex-1"
+              autoFocus
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSaveName();
+                if (e.key === "Escape") {
+                  setEditingName(false);
+                  setNameVal(resume.name);
+                }
+              }}
+            />
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={handleSaveName}
+              disabled={savingName}
+            >
+              <Check className="size-4 text-emerald-600" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              onClick={() => {
+                setEditingName(false);
+                setNameVal(resume.name);
+              }}
+            >
+              <X className="size-4 text-slate-400" />
+            </Button>
+          </>
+        ) : (
+          <>
+            <h2>
+              {resume.name}
+              {editing && (
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  className="ml-2 align-middle"
+                  onClick={() => setEditingName(true)}
+                >
+                  <Pencil className="size-3.5 text-slate-400" />
+                </Button>
+              )}
+            </h2>
+          </>
+        )}
+
+        <button
+          className={`actionBtn ${editing ? "dark" : "outline"}`}
+          onClick={toggleEditing}
+        >
+          {editing ? "Done Editing" : "Edit"}
+        </button>
         <ExportDropdown onDocx={handleExportDocx} onPdf={handleExportPdf} />
       </div>
 
       <hr className="divider" />
 
-      {/* Projects grouped by type/mode, matching CLI layout */}
-      {Object.entries(grouped).map(([groupKey, projects]) => (
-        <div key={groupKey} className="resumeGroup">
-          <h3 className="groupHeader">{formatGroupLabel(groupKey)}</h3>
+      {/* Success / Error banners */}
+      {successMsg && (
+        <div className="mb-4 rounded-lg border border-emerald-200 bg-emerald-50 px-4 py-2 text-sm text-emerald-700">
+          {successMsg}
+        </div>
+      )}
+      {err && (
+        <div className="mb-4 rounded-lg border border-red-200 bg-red-50 px-4 py-2 text-sm text-red-600">
+          {err}
+        </div>
+      )}
 
-          {projects.map((p, i) => (
-            <div key={i} className="resumeProjectBlock">
-              <ProjectBlock project={p} />
+      {/* Projects */}
+      {editing ? (
+        /* ── Edit mode: shadcn cards with pencil icons ── */
+        <div className="space-y-4">
+          {resume.projects.map((p) => {
+            const isEditingProject =
+              editingProjectId === p.project_summary_id;
+
+            return (
+              <Card
+                key={p.project_summary_id ?? p.project_name}
+                className="rounded-2xl border-slate-200/80 bg-white shadow-sm"
+              >
+                <CardHeader className="border-b border-slate-100">
+                  <div>
+                    <CardTitle className="text-base text-slate-900">
+                      {isEditingProject
+                        ? "Editing project"
+                        : p.project_name}
+                    </CardTitle>
+                    <div className="mt-1 flex gap-1.5">
+                      {p.project_type && (
+                        <Badge variant="secondary" className="text-xs">
+                          {p.project_type}
+                        </Badge>
+                      )}
+                      {p.project_mode && (
+                        <Badge variant="outline" className="text-xs">
+                          {p.project_mode}
+                        </Badge>
+                      )}
+                    </div>
+                  </div>
+                  <CardAction>
+                    {!isEditingProject && p.project_summary_id != null && (
+                      <Button
+                        variant="ghost"
+                        size="icon-sm"
+                        onClick={() => startEditingProject(p)}
+                      >
+                        <Pencil className="size-4 text-slate-500" />
+                      </Button>
+                    )}
+                  </CardAction>
+                </CardHeader>
+
+                <CardContent>
+                  {isEditingProject && projectEdits ? (
+                    <ProjectEditForm
+                      edits={projectEdits}
+                      setEdits={setProjectEdits}
+                      onSave={handleSaveProject}
+                      onCancel={cancelEditingProject}
+                      saving={savingProject}
+                      updateBullet={updateBullet}
+                      removeBullet={removeBullet}
+                      addBullet={addBullet}
+                    />
+                  ) : (
+                    <ProjectReadView project={p} />
+                  )}
+                </CardContent>
+              </Card>
+            );
+          })}
+        </div>
+      ) : (
+        /* ── View mode: original grouped layout ── */
+        <>
+          {Object.entries(grouped).map(([groupKey, projects]) => (
+            <div key={groupKey} className="resumeGroup">
+              <h3 className="groupHeader">{formatGroupLabel(groupKey)}</h3>
+              {projects.map((p, i) => (
+                <div key={i} className="resumeProjectBlock">
+                  <ProjectBlockView project={p} />
+                </div>
+              ))}
             </div>
           ))}
-        </div>
-      ))}
+        </>
+      )}
 
-      {/* Aggregated skills summary */}
-      <div className="skillsSummaryBlock">
-        <h3>Skills Summary</h3>
-        {agg.languages.length > 0 && (
-          <p><strong>Languages:</strong> {agg.languages.join(", ")}</p>
-        )}
-        {agg.frameworks.length > 0 && (
-          <p><strong>Frameworks:</strong> {agg.frameworks.join(", ")}</p>
-        )}
-        {agg.technical_skills.length > 0 && (
-          <p><strong>Technical skills:</strong> {agg.technical_skills.join(", ")}</p>
-        )}
-        {agg.writing_skills.length > 0 && (
-          <p><strong>Writing skills:</strong> {agg.writing_skills.join(", ")}</p>
-        )}
-      </div>
+      {/* Aggregated skills */}
+      {editing ? (
+        <Card className="mt-6 rounded-2xl border-slate-200/80 bg-white shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-900">
+              Skills Summary
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <SkillRow label="Languages" items={agg.languages} />
+            <SkillRow label="Frameworks" items={agg.frameworks} />
+            <SkillRow label="Technical" items={agg.technical_skills} />
+            <SkillRow label="Writing" items={agg.writing_skills} />
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="skillsSummaryBlock">
+          <h3>Skills Summary</h3>
+          {agg.languages.length > 0 && (
+            <p>
+              <strong>Languages:</strong> {agg.languages.join(", ")}
+            </p>
+          )}
+          {agg.frameworks.length > 0 && (
+            <p>
+              <strong>Frameworks:</strong> {agg.frameworks.join(", ")}
+            </p>
+          )}
+          {agg.technical_skills.length > 0 && (
+            <p>
+              <strong>Technical skills:</strong>{" "}
+              {agg.technical_skills.join(", ")}
+            </p>
+          )}
+          {agg.writing_skills.length > 0 && (
+            <p>
+              <strong>Writing skills:</strong> {agg.writing_skills.join(", ")}
+            </p>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
-function ProjectBlock({ project: p }: { project: ResumeProject }) {
+/* ── Helper functions ── */
+
+function groupProjects(projects: ResumeProject[]) {
+  const groups: Record<string, ResumeProject[]> = {};
+  for (const p of projects) {
+    const type = p.project_type ?? "other";
+    const mode = p.project_mode ?? "";
+    const key = mode ? `${type} (${mode})` : type;
+    (groups[key] ??= []).push(p);
+  }
+  return groups;
+}
+
+function formatGroupLabel(key: string) {
+  return key.charAt(0).toUpperCase() + key.slice(1) + " Projects";
+}
+
+/* ── Sub-components ── */
+
+function SkillRow({ label, items }: { label: string; items: string[] }) {
+  if (items.length === 0) return null;
+  return (
+    <p className="text-sm text-slate-700">
+      <span className="font-medium">{label}:</span> {items.join(", ")}
+    </p>
+  );
+}
+
+/** View-mode project block (original layout) */
+function ProjectBlockView({ project: p }: { project: ResumeProject }) {
   return (
     <div className="projectBlockContent">
       <h4 className="projectBlockName">{p.project_name}</h4>
@@ -122,9 +514,7 @@ function ProjectBlock({ project: p }: { project: ResumeProject }) {
         <p className="projectField">Frameworks: {p.frameworks.join(", ")}</p>
       )}
 
-      {p.text_type && (
-        <p className="projectField">Type: {p.text_type}</p>
-      )}
+      {p.text_type && <p className="projectField">Type: {p.text_type}</p>}
 
       {p.contribution_percent != null && (
         <p className="projectField">
@@ -155,6 +545,223 @@ function ProjectBlock({ project: p }: { project: ResumeProject }) {
           </ul>
         </div>
       )}
+    </div>
+  );
+}
+
+/** Edit-mode project read view (shadcn styled, shown when not actively editing this project) */
+function ProjectReadView({ project: p }: { project: ResumeProject }) {
+  return (
+    <div className="space-y-2 text-sm text-slate-700">
+      {p.key_role && (
+        <p>
+          <span className="font-medium text-slate-900">Role:</span>{" "}
+          {p.key_role}
+        </p>
+      )}
+      {p.languages.length > 0 && (
+        <p>
+          <span className="font-medium text-slate-900">Languages:</span>{" "}
+          {p.languages.join(", ")}
+        </p>
+      )}
+      {p.frameworks.length > 0 && (
+        <p>
+          <span className="font-medium text-slate-900">Frameworks:</span>{" "}
+          {p.frameworks.join(", ")}
+        </p>
+      )}
+      {p.summary_text && (
+        <p>
+          <span className="font-medium text-slate-900">Summary:</span>{" "}
+          {p.summary_text}
+        </p>
+      )}
+      {p.contribution_bullets.length > 0 && (
+        <div>
+          <p className="font-medium text-slate-900">Contributions:</p>
+          <ul className="mt-1 list-disc pl-5 space-y-0.5">
+            {p.contribution_bullets.map((b, j) => (
+              <li key={j}>{b}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {p.skills.length > 0 && (
+        <div className="flex flex-wrap gap-1 pt-1">
+          {p.skills.map((s) => (
+            <Badge key={s} variant="secondary" className="text-xs">
+              {s}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** Edit form for a single project */
+function ProjectEditForm({
+  edits,
+  setEdits,
+  onSave,
+  onCancel,
+  saving,
+  updateBullet,
+  removeBullet,
+  addBullet,
+}: {
+  edits: ProjectEdits;
+  setEdits: (e: ProjectEdits) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  updateBullet: (i: number, v: string) => void;
+  removeBullet: (i: number) => void;
+  addBullet: () => void;
+}) {
+  return (
+    <div className="space-y-5">
+      <div className="space-y-1.5">
+        <Label htmlFor="edit-display-name">Display Name</Label>
+        <Input
+          id="edit-display-name"
+          value={edits.display_name}
+          onChange={(e) =>
+            setEdits({ ...edits, display_name: e.target.value })
+          }
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="edit-key-role">Key Role</Label>
+        <Input
+          id="edit-key-role"
+          placeholder="e.g. Backend Developer"
+          value={edits.key_role}
+          onChange={(e) => setEdits({ ...edits, key_role: e.target.value })}
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="edit-summary">Summary</Label>
+        <Textarea
+          id="edit-summary"
+          rows={3}
+          value={edits.summary_text}
+          onChange={(e) =>
+            setEdits({ ...edits, summary_text: e.target.value })
+          }
+        />
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label>Contribution Bullets</Label>
+          <div className="flex items-center gap-3 text-xs text-slate-500">
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="edit-mode"
+                checked={edits.contribution_edit_mode === "replace"}
+                onChange={() =>
+                  setEdits({ ...edits, contribution_edit_mode: "replace" })
+                }
+                className="accent-slate-700"
+              />
+              Replace all
+            </label>
+            <label className="flex items-center gap-1 cursor-pointer">
+              <input
+                type="radio"
+                name="edit-mode"
+                checked={edits.contribution_edit_mode === "append"}
+                onChange={() =>
+                  setEdits({ ...edits, contribution_edit_mode: "append" })
+                }
+                className="accent-slate-700"
+              />
+              Append new
+            </label>
+          </div>
+        </div>
+
+        <div className="space-y-2">
+          {edits.contribution_bullets.map((bullet, i) => (
+            <div key={i} className="flex items-start gap-2">
+              <span className="mt-2.5 text-xs text-slate-400">{i + 1}.</span>
+              <Textarea
+                rows={2}
+                value={bullet}
+                onChange={(e) => updateBullet(i, e.target.value)}
+                className="flex-1"
+              />
+              <Button
+                variant="ghost"
+                size="icon-xs"
+                onClick={() => removeBullet(i)}
+                className="mt-1 text-slate-400 hover:text-red-500"
+              >
+                <Trash2 className="size-3.5" />
+              </Button>
+            </div>
+          ))}
+        </div>
+
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={addBullet}
+          className="gap-1.5 text-xs"
+        >
+          <Plus className="size-3" />
+          Add bullet
+        </Button>
+      </div>
+
+      <Separator />
+
+      <div className="space-y-2">
+        <Label>Apply changes to</Label>
+        <RadioGroup
+          value={edits.scope}
+          onValueChange={(v) =>
+            setEdits({ ...edits, scope: v as "resume_only" | "global" })
+          }
+          className="flex flex-col gap-2"
+        >
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="resume_only" id="scope-resume" />
+            <Label
+              htmlFor="scope-resume"
+              className="font-normal cursor-pointer"
+            >
+              This resume only
+            </Label>
+          </div>
+          <div className="flex items-center gap-2">
+            <RadioGroupItem value="global" id="scope-global" />
+            <Label
+              htmlFor="scope-global"
+              className="font-normal cursor-pointer"
+            >
+              All resumes &amp; portfolio
+            </Label>
+          </div>
+        </RadioGroup>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center gap-2">
+        <Button onClick={onSave} disabled={saving} className="gap-1.5">
+          <Check className="size-4" />
+          {saving ? "Saving..." : "Save changes"}
+        </Button>
+        <Button variant="ghost" onClick={onCancel} disabled={saving}>
+          Cancel
+        </Button>
+      </div>
     </div>
   );
 }

--- a/frontend/src/components/outputs/ResumeDetail.tsx
+++ b/frontend/src/components/outputs/ResumeDetail.tsx
@@ -269,11 +269,11 @@ export default function ResumeDetail({
         </button>
 
         {editing && editingName ? (
-          <>
+          <div className="flex items-center gap-2" style={{ flex: 1 }}>
             <Input
               value={nameVal}
               onChange={(e) => setNameVal(e.target.value)}
-              className="max-w-xs text-lg font-semibold flex-1"
+              className="max-w-xs text-lg font-semibold"
               autoFocus
               onKeyDown={(e) => {
                 if (e.key === "Enter") handleSaveName();
@@ -301,7 +301,7 @@ export default function ResumeDetail({
             >
               <X className="size-4 text-slate-400" />
             </Button>
-          </>
+          </div>
         ) : (
           <>
             <h2>

--- a/frontend/src/components/outputs/ResumeDetail.tsx
+++ b/frontend/src/components/outputs/ResumeDetail.tsx
@@ -257,7 +257,7 @@ export default function ResumeDetail({
       </div>
     );
 
-  const grouped = groupProjects(resume.projects);
+  const sortedProjects = sortProjectsByDate(resume.projects);
   const agg = resume.aggregated_skills;
 
   return (
@@ -343,6 +343,48 @@ export default function ResumeDetail({
         </div>
       )}
 
+      {/* Skills Summary */}
+      {editing ? (
+        <Card className="mb-6 rounded-2xl border-slate-200/80 bg-white shadow-sm">
+          <CardHeader>
+            <CardTitle className="text-base text-slate-900">
+              Skills
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <SkillRow label="Languages" items={agg.languages} />
+            <SkillRow label="Frameworks" items={agg.frameworks} />
+            <SkillRow label="Technical" items={agg.technical_skills} />
+            <SkillRow label="Writing" items={agg.writing_skills} />
+          </CardContent>
+        </Card>
+      ) : (
+        <div className="skillsSummaryBlock">
+          <h3>Skills</h3>
+          {agg.languages.length > 0 && (
+            <p>
+              <strong>Languages:</strong> {agg.languages.join(", ")}
+            </p>
+          )}
+          {agg.frameworks.length > 0 && (
+            <p>
+              <strong>Frameworks:</strong> {agg.frameworks.join(", ")}
+            </p>
+          )}
+          {agg.technical_skills.length > 0 && (
+            <p>
+              <strong>Technical skills:</strong>{" "}
+              {agg.technical_skills.join(", ")}
+            </p>
+          )}
+          {agg.writing_skills.length > 0 && (
+            <p>
+              <strong>Writing skills:</strong> {agg.writing_skills.join(", ")}
+            </p>
+          )}
+        </div>
+      )}
+
       {/* Projects */}
       {editing ? (
         /* ── Edit mode: shadcn cards with pencil icons ── */
@@ -410,60 +452,14 @@ export default function ResumeDetail({
           })}
         </div>
       ) : (
-        /* ── View mode: original grouped layout ── */
-        <>
-          {Object.entries(grouped).map(([groupKey, projects]) => (
-            <div key={groupKey} className="resumeGroup">
-              <h3 className="groupHeader">{formatGroupLabel(groupKey)}</h3>
-              {projects.map((p, i) => (
-                <div key={i} className="resumeProjectBlock">
-                  <ProjectBlockView project={p} />
-                </div>
-              ))}
+        /* ── View mode: flat list matching export structure ── */
+        <div className="resumeProjectsList">
+          <h3 className="groupHeader">Projects</h3>
+          {sortedProjects.map((p, i) => (
+            <div key={i} className="resumeProjectBlock">
+              <ProjectBlockView project={p} />
             </div>
           ))}
-        </>
-      )}
-
-      {/* Aggregated skills */}
-      {editing ? (
-        <Card className="mt-6 rounded-2xl border-slate-200/80 bg-white shadow-sm">
-          <CardHeader>
-            <CardTitle className="text-base text-slate-900">
-              Skills Summary
-            </CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-2">
-            <SkillRow label="Languages" items={agg.languages} />
-            <SkillRow label="Frameworks" items={agg.frameworks} />
-            <SkillRow label="Technical" items={agg.technical_skills} />
-            <SkillRow label="Writing" items={agg.writing_skills} />
-          </CardContent>
-        </Card>
-      ) : (
-        <div className="skillsSummaryBlock">
-          <h3>Skills Summary</h3>
-          {agg.languages.length > 0 && (
-            <p>
-              <strong>Languages:</strong> {agg.languages.join(", ")}
-            </p>
-          )}
-          {agg.frameworks.length > 0 && (
-            <p>
-              <strong>Frameworks:</strong> {agg.frameworks.join(", ")}
-            </p>
-          )}
-          {agg.technical_skills.length > 0 && (
-            <p>
-              <strong>Technical skills:</strong>{" "}
-              {agg.technical_skills.join(", ")}
-            </p>
-          )}
-          {agg.writing_skills.length > 0 && (
-            <p>
-              <strong>Writing skills:</strong> {agg.writing_skills.join(", ")}
-            </p>
-          )}
         </div>
       )}
     </div>
@@ -472,19 +468,30 @@ export default function ResumeDetail({
 
 /* ── Helper functions ── */
 
-function groupProjects(projects: ResumeProject[]) {
-  const groups: Record<string, ResumeProject[]> = {};
-  for (const p of projects) {
-    const type = p.project_type ?? "other";
-    const mode = p.project_mode ?? "";
-    const key = mode ? `${type} (${mode})` : type;
-    (groups[key] ??= []).push(p);
-  }
-  return groups;
+function sortProjectsByDate(projects: ResumeProject[]): ResumeProject[] {
+  return [...projects].sort((a, b) => {
+    const dateA = a.end_date || a.start_date || "";
+    const dateB = b.end_date || b.start_date || "";
+    // Most recent first; projects with no dates go last
+    if (!dateA && !dateB) return 0;
+    if (!dateA) return 1;
+    if (!dateB) return -1;
+    return dateB.localeCompare(dateA);
+  });
 }
 
-function formatGroupLabel(key: string) {
-  return key.charAt(0).toUpperCase() + key.slice(1) + " Projects";
+function formatDateRange(start: string | null, end: string | null): string {
+  const fmt = (iso: string) => {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return "";
+    return d.toLocaleDateString("en-US", { month: "short", year: "numeric" });
+  };
+  const s = start ? fmt(start) : "";
+  const e = end ? fmt(end) : "";
+  if (s && e) return `${s} \u2013 ${e}`;
+  if (s) return `${s} \u2013 Present`;
+  if (e) return e;
+  return "";
 }
 
 /* ── Sub-components ── */
@@ -498,52 +505,30 @@ function SkillRow({ label, items }: { label: string; items: string[] }) {
   );
 }
 
-/** View-mode project block (original layout) */
+/** View-mode project block matching export structure: name, role | dates, bullets */
 function ProjectBlockView({ project: p }: { project: ResumeProject }) {
+  const dateLine = formatDateRange(p.start_date, p.end_date);
+  const role = p.key_role || "";
+  const subtitle = role && dateLine
+    ? `${role} | ${dateLine}`
+    : role || dateLine;
+
   return (
     <div className="projectBlockContent">
       <h4 className="projectBlockName">{p.project_name}</h4>
 
-      {p.key_role && <p className="projectField">Role: {p.key_role}</p>}
-
-      {p.languages.length > 0 && (
-        <p className="projectField">Languages: {p.languages.join(", ")}</p>
-      )}
-
-      {p.frameworks.length > 0 && (
-        <p className="projectField">Frameworks: {p.frameworks.join(", ")}</p>
-      )}
-
-      {p.text_type && <p className="projectField">Type: {p.text_type}</p>}
-
-      {p.contribution_percent != null && (
-        <p className="projectField">
-          Contribution: {Math.round(p.contribution_percent)}%
+      {subtitle && (
+        <p className="projectField" style={{ fontStyle: "italic" }}>
+          {subtitle}
         </p>
       )}
 
-      {p.summary_text && (
-        <p className="projectField">Summary: {p.summary_text}</p>
-      )}
-
       {p.contribution_bullets.length > 0 && (
-        <div className="projectField">
-          <p>Contributions:</p>
-          <ul className="bulletList">
-            {p.contribution_bullets.map((b, j) => (
-              <li key={j}>{b}</li>
-            ))}
-          </ul>
-        </div>
-      )}
-
-      {p.skills.length > 0 && (
-        <div className="projectField">
-          <p>Skills:</p>
-          <ul className="bulletList">
-            <li>{p.skills.join(", ")}</li>
-          </ul>
-        </div>
+        <ul className="bulletList">
+          {p.contribution_bullets.map((b, j) => (
+            <li key={j}>{b}</li>
+          ))}
+        </ul>
       )}
     </div>
   );

--- a/frontend/src/components/outputs/ResumeList.tsx
+++ b/frontend/src/components/outputs/ResumeList.tsx
@@ -11,10 +11,11 @@ import ExportDropdown from "./ExportDropdown";
 type Props = {
   onBack: () => void;
   onView: (id: number) => void;
+  onEdit: (id: number) => void;
   onCreateNew: () => void;
 };
 
-export default function ResumeList({ onBack, onView, onCreateNew }: Props) {
+export default function ResumeList({ onBack, onView, onEdit, onCreateNew }: Props) {
   const [resumes, setResumes] = useState<ResumeListItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [err, setErr] = useState<string | null>(null);
@@ -102,7 +103,7 @@ export default function ResumeList({ onBack, onView, onCreateNew }: Props) {
               <button className="actionBtn dark" onClick={() => onView(r.id)}>
                 View
               </button>
-              <button className="actionBtn outline" onClick={() => onView(r.id)}>
+              <button className="actionBtn outline" onClick={() => onEdit(r.id)}>
                 Edit
               </button>
               <button

--- a/frontend/src/components/outputs/__tests__/ResumeDetail.test.tsx
+++ b/frontend/src/components/outputs/__tests__/ResumeDetail.test.tsx
@@ -1,0 +1,417 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import ResumeDetail from "../ResumeDetail";
+
+vi.mock("../../../api/outputs", () => ({
+  getResume: vi.fn(),
+  editResume: vi.fn(),
+  downloadResumeDocx: vi.fn(),
+  downloadResumePdf: vi.fn(),
+}));
+
+vi.mock("../ExportDropdown", () => ({
+  default: () => <button>Export</button>,
+}));
+
+import { getResume, editResume } from "../../../api/outputs";
+
+const baseResume = {
+  id: 1,
+  name: "My Resume",
+  created_at: "2026-01-15T00:00:00",
+  projects: [
+    {
+      project_summary_id: 10,
+      project_name: "Project Alpha",
+      project_type: "code",
+      project_mode: "individual",
+      languages: ["Python"],
+      frameworks: ["FastAPI"],
+      summary_text: "A web API project",
+      skills: ["OOP", "Testing"],
+      text_type: null,
+      contribution_percent: null,
+      activities: [],
+      key_role: "Backend Developer",
+      contribution_bullets: ["Built REST API", "Wrote tests"],
+      start_date: null,
+      end_date: null,
+    },
+  ],
+  aggregated_skills: {
+    languages: ["Python"],
+    frameworks: ["FastAPI"],
+    technical_skills: ["OOP"],
+    writing_skills: [],
+  },
+  rendered_text: null,
+};
+
+function setupMocks(overrides: Partial<typeof baseResume> = {}) {
+  const resume = { ...baseResume, ...overrides };
+  vi.mocked(getResume).mockResolvedValue({
+    success: true,
+    data: resume,
+    error: null,
+  } as any);
+  return resume;
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("ResumeDetail", () => {
+  describe("view mode (default)", () => {
+    it("renders resume name and project content", async () => {
+      setupMocks();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("My Resume")).toBeInTheDocument();
+      });
+      expect(screen.getByText("Project Alpha")).toBeInTheDocument();
+      expect(screen.getByText(/Backend Developer/)).toBeInTheDocument();
+      expect(screen.getByText(/Built REST API/)).toBeInTheDocument();
+    });
+
+    it("shows Edit button in header", async () => {
+      setupMocks();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+      });
+    });
+
+    it("does not show pencil icons in view mode", async () => {
+      setupMocks();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("My Resume")).toBeInTheDocument();
+      });
+      // No edit form labels should be visible
+      expect(screen.queryByLabelText("Display Name")).not.toBeInTheDocument();
+    });
+
+    it("shows loading state", () => {
+      vi.mocked(getResume).mockReturnValue(new Promise(() => {}));
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+      expect(screen.getByText("Loading...")).toBeInTheDocument();
+    });
+
+    it("shows error state", async () => {
+      vi.mocked(getResume).mockRejectedValue(new Error("Network error"));
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Network error")).toBeInTheDocument();
+      });
+    });
+
+    it("calls onBack when back button clicked", async () => {
+      setupMocks();
+      const onBack = vi.fn();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} onBack={onBack} />);
+
+      await waitFor(() => screen.getByText("My Resume"));
+      await user.click(screen.getByText("←"));
+      expect(onBack).toHaveBeenCalled();
+    });
+
+    it("shows skills summary", async () => {
+      setupMocks();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Skills Summary")).toBeInTheDocument();
+      });
+      // Python appears in both project and skills summary
+      expect(screen.getAllByText(/Python/).length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  describe("toggling edit mode", () => {
+    it("clicking Edit switches to edit mode with Done Editing button", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Edit"));
+      await user.click(screen.getByText("Edit"));
+
+      expect(screen.getByText("Done Editing")).toBeInTheDocument();
+      expect(screen.queryByText("Edit")).not.toBeInTheDocument();
+    });
+
+    it("clicking Done Editing returns to view mode", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Edit"));
+      await user.click(screen.getByText("Edit"));
+      await user.click(screen.getByText("Done Editing"));
+
+      expect(screen.getByText("Edit")).toBeInTheDocument();
+      expect(screen.queryByText("Done Editing")).not.toBeInTheDocument();
+    });
+
+    it("starts in edit mode when initialEditing is true", async () => {
+      setupMocks();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Done Editing")).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe("editing resume name", () => {
+    it("shows name pencil icon only in edit mode", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("My Resume"));
+      // The pencil button is inside the h2 — find it by aria label isn't set,
+      // but clicking on the heading area should work. We verify the name input
+      // appears after clicking.
+      // In edit mode, there should be a pencil-like button near the name
+      expect(screen.getByText("Done Editing")).toBeInTheDocument();
+    });
+
+    it("saves resume name on confirm", async () => {
+      setupMocks();
+      vi.mocked(editResume).mockResolvedValue({
+        success: true,
+        data: { ...baseResume, name: "Updated Name" },
+        error: null,
+      } as any);
+
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("My Resume"));
+
+      // Find and click the pencil button (inside h2, it's a button element)
+      const buttons = screen.getAllByRole("button");
+      const pencilBtn = buttons.find(
+        (b) => b.querySelector("svg") && b.closest("h2")
+      );
+      if (pencilBtn) {
+        await user.click(pencilBtn);
+
+        // Now we should see an input with the current name
+        const input = screen.getByDisplayValue("My Resume");
+        await user.clear(input);
+        await user.type(input, "Updated Name");
+
+        // Click the check button
+        const checkBtns = screen.getAllByRole("button");
+        const checkBtn = checkBtns.find(
+          (b) => b.querySelector(".text-emerald-600") !== null
+        );
+        if (checkBtn) await user.click(checkBtn);
+
+        await waitFor(() => {
+          expect(editResume).toHaveBeenCalledWith(1, { name: "Updated Name" });
+        });
+      }
+    });
+  });
+
+  describe("editing project fields", () => {
+    it("shows edit form when project pencil is clicked", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      // Find the pencil button on the project card (not inside h2)
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+
+        await waitFor(() => {
+          expect(screen.getByLabelText("Display Name")).toBeInTheDocument();
+          expect(screen.getByLabelText("Key Role")).toBeInTheDocument();
+          expect(screen.getByLabelText("Summary")).toBeInTheDocument();
+          expect(screen.getByText("Save changes")).toBeInTheDocument();
+          expect(screen.getByText("Cancel")).toBeInTheDocument();
+        });
+      }
+    });
+
+    it("cancels project edit without saving", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+        await waitFor(() => screen.getByText("Cancel"));
+        await user.click(screen.getByText("Cancel"));
+
+        // Form should be gone
+        expect(screen.queryByLabelText("Display Name")).not.toBeInTheDocument();
+        expect(editResume).not.toHaveBeenCalled();
+      }
+    });
+
+    it("saves project edits and shows success message", async () => {
+      setupMocks();
+      vi.mocked(editResume).mockResolvedValue({
+        success: true,
+        data: baseResume,
+        error: null,
+      } as any);
+
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      // Click project pencil
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+        await waitFor(() => screen.getByLabelText("Display Name"));
+
+        // Change display name
+        const nameInput = screen.getByLabelText("Display Name");
+        await user.clear(nameInput);
+        await user.type(nameInput, "Renamed Project");
+
+        // Click save
+        await user.click(screen.getByText("Save changes"));
+
+        await waitFor(() => {
+          expect(editResume).toHaveBeenCalledWith(
+            1,
+            expect.objectContaining({
+              project_summary_id: 10,
+              scope: "resume_only",
+              display_name: "Renamed Project",
+            })
+          );
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Updated this resume")).toBeInTheDocument();
+        });
+      }
+    });
+
+    it("shows global success message when scope is global", async () => {
+      setupMocks();
+      vi.mocked(editResume).mockResolvedValue({
+        success: true,
+        data: baseResume,
+        error: null,
+      } as any);
+
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+        await waitFor(() => screen.getByLabelText("Key Role"));
+
+        // Change key role
+        const roleInput = screen.getByLabelText("Key Role");
+        await user.clear(roleInput);
+        await user.type(roleInput, "Full Stack Dev");
+
+        // Switch to global scope
+        await user.click(screen.getByLabelText("All resumes & portfolio"));
+
+        await user.click(screen.getByText("Save changes"));
+
+        await waitFor(() => {
+          expect(editResume).toHaveBeenCalledWith(
+            1,
+            expect.objectContaining({
+              scope: "global",
+              key_role: "Full Stack Dev",
+            })
+          );
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText("Updated across all resumes")).toBeInTheDocument();
+        });
+      }
+    });
+
+    it("does not call API if no fields changed", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+        await waitFor(() => screen.getByText("Save changes"));
+
+        // Save without changing anything
+        await user.click(screen.getByText("Save changes"));
+
+        expect(editResume).not.toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe("leaving edit mode cleans up", () => {
+    it("collapses open project edit when Done Editing is clicked", async () => {
+      setupMocks();
+      const user = userEvent.setup();
+      render(<ResumeDetail resumeId={1} initialEditing onBack={vi.fn()} />);
+
+      await waitFor(() => screen.getByText("Project Alpha"));
+
+      // Open project edit
+      const buttons = screen.getAllByRole("button");
+      const projectPencil = buttons.find(
+        (b) => b.querySelector("svg") && !b.closest("h2") && b.closest("[data-slot='card-action']")
+      );
+      if (projectPencil) {
+        await user.click(projectPencil);
+        await waitFor(() => screen.getByLabelText("Display Name"));
+
+        // Click Done Editing
+        await user.click(screen.getByText("Done Editing"));
+
+        // Form should be gone, back to view mode
+        expect(screen.queryByLabelText("Display Name")).not.toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+      }
+    });
+  });
+});

--- a/frontend/src/components/outputs/__tests__/ResumeDetail.test.tsx
+++ b/frontend/src/components/outputs/__tests__/ResumeDetail.test.tsx
@@ -126,7 +126,7 @@ describe("ResumeDetail", () => {
       render(<ResumeDetail resumeId={1} onBack={vi.fn()} />);
 
       await waitFor(() => {
-        expect(screen.getByText("Skills Summary")).toBeInTheDocument();
+        expect(screen.getByText("Skills")).toBeInTheDocument();
       });
       // Python appears in both project and skills summary
       expect(screen.getAllByText(/Python/).length).toBeGreaterThanOrEqual(1);

--- a/frontend/src/components/ui/badge.tsx
+++ b/frontend/src/components/ui/badge.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+const badgeVariants = cva(
+  "group/badge inline-flex h-5 w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-all focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 [&>svg]:pointer-events-none [&>svg]:size-3!",
+  {
+    variants: {
+      variant: {
+        default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+        secondary:
+          "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+        destructive:
+          "bg-destructive/10 text-destructive focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:focus-visible:ring-destructive/40 [a]:hover:bg-destructive/20",
+        outline:
+          "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+        ghost:
+          "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Badge({
+  className,
+  variant = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"span"> &
+  VariantProps<typeof badgeVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot.Root : "span"
+
+  return (
+    <Comp
+      data-slot="badge"
+      data-variant={variant}
+      className={cn(badgeVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+export { Badge, badgeVariants }

--- a/frontend/src/components/ui/input.tsx
+++ b/frontend/src/components/ui/input.tsx
@@ -1,0 +1,19 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+  return (
+    <input
+      type={type}
+      data-slot="input"
+      className={cn(
+        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-2.5 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Input }

--- a/frontend/src/components/ui/label.tsx
+++ b/frontend/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as React from "react"
+import { Label as LabelPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Label({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  return (
+    <LabelPrimitive.Root
+      data-slot="label"
+      className={cn(
+        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Label }

--- a/frontend/src/components/ui/radio-group.tsx
+++ b/frontend/src/components/ui/radio-group.tsx
@@ -1,0 +1,42 @@
+import * as React from "react"
+import { RadioGroup as RadioGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid w-full gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "group/radio-group-item peer relative flex aspect-square size-4 shrink-0 rounded-full border border-input outline-none after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="flex size-4 items-center justify-center"
+      >
+        <span className="absolute top-1/2 left-1/2 size-2 -translate-x-1/2 -translate-y-1/2 rounded-full bg-primary-foreground" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/frontend/src/components/ui/separator.tsx
+++ b/frontend/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+import { Separator as SeparatorPrimitive } from "radix-ui"
+
+import { cn } from "@/lib/utils"
+
+function Separator({
+  className,
+  orientation = "horizontal",
+  decorative = true,
+  ...props
+}: React.ComponentProps<typeof SeparatorPrimitive.Root>) {
+  return (
+    <SeparatorPrimitive.Root
+      data-slot="separator"
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        "shrink-0 bg-border data-horizontal:h-px data-horizontal:w-full data-vertical:w-px data-vertical:self-stretch",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Separator }

--- a/frontend/src/components/ui/textarea.tsx
+++ b/frontend/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-2.5 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/frontend/src/pages/Outputs.tsx
+++ b/frontend/src/pages/Outputs.tsx
@@ -10,7 +10,7 @@ import PortfolioView from "../components/outputs/PortfolioView";
 type View =
   | { kind: "landing" }
   | { kind: "resumes" }
-  | { kind: "resume-detail"; id: number }
+  | { kind: "resume-detail"; id: number; editing?: boolean }
   | { kind: "portfolio" };
 
 export default function OutputsPage() {
@@ -33,6 +33,7 @@ export default function OutputsPage() {
           <ResumeList
             onBack={() => setView({ kind: "landing" })}
             onView={(id) => setView({ kind: "resume-detail", id })}
+            onEdit={(id) => setView({ kind: "resume-detail", id, editing: true })}
             onCreateNew={() => setShowCreate(true)}
           />
         );
@@ -40,6 +41,7 @@ export default function OutputsPage() {
         return (
           <ResumeDetail
             resumeId={view.id}
+            initialEditing={view.editing}
             onBack={() => setView({ kind: "resumes" })}
           />
         );

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -10,6 +10,9 @@ from src.menu.resume.helpers import (
     render_snapshot,
     apply_resume_only_updates,
     resolve_resume_contribution_bullets,
+    resolve_resume_display_name,
+    resolve_resume_summary_text,
+    resolve_resume_key_role,
     recompute_aggregated_skills,
 )
 from src.menu.resume.date_helpers import enrich_snapshot_with_dates
@@ -72,6 +75,13 @@ def get_resume_by_id(conn, user_id: int, resume_id: int) -> Optional[Dict[str, A
         for project in snapshot.get("projects", []):
             if "skills" in project:
                 project["skills"] = [s for s in project["skills"] if s in highlighted]
+
+    # Resolve overrides so the API returns the effective values
+    for project in snapshot.get("projects", []):
+        project["project_name"] = resolve_resume_display_name(project)
+        project["summary_text"] = resolve_resume_summary_text(project)
+        project["contribution_bullets"] = resolve_resume_contribution_bullets(project)
+        project["key_role"] = resolve_resume_key_role(project)
 
     # Combine DB fields with parsed JSON
     return {


### PR DESCRIPTION
## 📝 Description

Adds resume editing functionality to the frontend. Users can now edit resume names, project display names, key roles, summaries, and contribution bullets directly from the resume detail page. Also fixes a backend bug where the API was returning raw snapshot data instead of resolved override values.

**Backend:** `get_resume_by_id()` in `resumes_service.py` now resolves the 3-level override priority (resume-specific → global → base) for display name, summary, contribution bullets, and key role before returning data to the frontend.

**Frontend:** The resume detail page now has a unified view/edit mode. Clicking "Edit" in the header toggles edit mode, which shows pencil icons on each project card. Each project can be edited inline with a scope choice ("This resume only" or "All resumes & portfolio"). The Edit button in the resume list also routes to the same page with edit mode pre-enabled.

Closes #577

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

### Automated Tests

**Backend (`pytest`):**
- Note: 3 previously failing tests in `tests/api/` are fixed in PR #573. They are unrelated to this PR.

**Frontend (`cd frontend && npx vitest run`):**
- Note: 1 pre-existing test failure in `src/api/__tests__/home.test.tsx` is the same failure on the main branch (unrelated to this PR).

### Manual Testing

Start the backend (`uvicorn src.api.main:app --reload`) and frontend (`cd frontend && npm run dev`). Log in and navigate to Outputs, then Resume Items. Create a resume if you don't have one.

- Open a resume via "View", click "Edit" in the header to enter edit mode, then click the pencil icon on a project card. Change the display name or key role, hit "Save changes", and confirm the updated value shows up after saving.
- Try editing from the resume list by clicking "Edit" directly on a resume card. It should open the same page already in edit mode.
- Edit a project with "All resumes & portfolio" selected as the scope, then check another resume that has the same project to confirm the change applied there too.

**Global scope:**
1. Create a second resume that includes the same project
2. Edit that project on one resume, select "All resumes & portfolio" scope, save
3. View the other resume and verify the edit appears there too

**From the resume list:**
1. Go back to Resume Items list, click "Edit" (not "View") on a resume
2. Verify it opens the same page but already in edit mode (shows "Done Editing" in header)

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

Resume Edit Page:
<img width="1415" height="652" alt="Screenshot 2026-03-12 at 11 37 45 PM" src="https://github.com/user-attachments/assets/deb7d4dd-cf2c-4f6e-99fb-e1ee1f9283b8" />
<img width="1425" height="653" alt="Screenshot 2026-03-12 at 11 37 58 PM" src="https://github.com/user-attachments/assets/c64bb302-8d70-43a8-9cb1-2faf6303d6fa" />
</details>