### PR TITLE
Frontend/public

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,9 @@
-import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
+import { BrowserRouter, Routes, Route, Navigate, useParams } from "react-router-dom";
+
+function PublicHomeRedirect() {
+  const { username } = useParams<{ username: string }>();
+  return <Navigate to={`/public/${username}/projects`} replace />;
+}
 import type { ReactNode } from "react";
 
 import LoginPage from "./pages/Login";
@@ -13,6 +18,8 @@ import ProjectDetailPage from "./pages/ProjectDetail";
 import InsightsPage from "./pages/InsightsPage";
 import OutputsPage from "./pages/Outputs";
 import ProfilePage from "./pages/Profile";
+import PublicProjectsPage from "./pages/public/PublicProjects";
+import PublicProjectDetailPage from "./pages/public/PublicProjectDetail";
 
 function RequireAuth({ children }: { children: ReactNode }) {
   const token = tokenStore.get();
@@ -116,6 +123,11 @@ export default function App() {
             </RequireAuth>
           }
         />
+
+        {/* Public routes — no auth required */}
+        <Route path="/public/:username" element={<PublicHomeRedirect />} />
+        <Route path="/public/:username/projects" element={<PublicProjectsPage />} />
+        <Route path="/public/:username/projects/:id" element={<PublicProjectDetailPage />} />
 
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>

--- a/frontend/src/api/__tests__/public.test.ts
+++ b/frontend/src/api/__tests__/public.test.ts
@@ -13,7 +13,6 @@ import {
   publicGetProject,
   publicFetchThumbnailUrl,
   publicGetRanking,
-  publicGetSkillsTimeline,
   publicListResumes,
   publicGetResume,
 } from '../public'
@@ -79,49 +78,37 @@ describe('public API', () => {
 
   describe('publicGetRanking', () => {
     it('calls the correct endpoint', async () => {
-      const ranking = { projects: [] }
-      vi.mocked(api.get).mockResolvedValue(ranking)
+      const rankings = [{ rank: 1, project_summary_id: 1, project_name: 'Alpha' }]
+      vi.mocked(api.get).mockResolvedValue({ success: true, data: { rankings } })
 
       const result = await publicGetRanking('johndoe')
 
       expect(api.get).toHaveBeenCalledWith('/public/johndoe/ranking')
-      expect(result).toEqual(ranking)
-    })
-  })
-
-  describe('publicGetSkillsTimeline', () => {
-    it('calls the correct endpoint', async () => {
-      const timeline = { events: [] }
-      vi.mocked(api.get).mockResolvedValue(timeline)
-
-      const result = await publicGetSkillsTimeline('johndoe')
-
-      expect(api.get).toHaveBeenCalledWith('/public/johndoe/skills/timeline')
-      expect(result).toEqual(timeline)
+      expect(result).toEqual(rankings)
     })
   })
 
   describe('publicListResumes', () => {
     it('calls the correct endpoint', async () => {
-      const response = { data: { resumes: [] } }
-      vi.mocked(api.get).mockResolvedValue(response)
+      const resumes = [{ id: 1, name: 'My Resume', created_at: null }]
+      vi.mocked(api.get).mockResolvedValue({ success: true, data: { resumes } })
 
       const result = await publicListResumes('johndoe')
 
       expect(api.get).toHaveBeenCalledWith('/public/johndoe/resumes')
-      expect(result).toEqual(response)
+      expect(result).toEqual(resumes)
     })
   })
 
   describe('publicGetResume', () => {
     it('calls the correct endpoint', async () => {
-      const response = { data: { resume_id: 7 } }
-      vi.mocked(api.get).mockResolvedValue(response)
+      const resume = { id: 7, name: 'My Resume', created_at: null, projects: [], aggregated_skills: {}, rendered_text: null }
+      vi.mocked(api.get).mockResolvedValue({ success: true, data: resume })
 
       const result = await publicGetResume('johndoe', 7)
 
       expect(api.get).toHaveBeenCalledWith('/public/johndoe/resumes/7')
-      expect(result).toEqual(response)
+      expect(result).toEqual(resume)
     })
   })
 })

--- a/frontend/src/api/__tests__/public.test.ts
+++ b/frontend/src/api/__tests__/public.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('../client', () => ({
+  api: {
+    get: vi.fn(),
+    getBlob: vi.fn(),
+  },
+}))
+
+import { api } from '../client'
+import {
+  publicListProjects,
+  publicGetProject,
+  publicFetchThumbnailUrl,
+  publicGetRanking,
+  publicGetSkillsTimeline,
+  publicListResumes,
+  publicGetResume,
+} from '../public'
+
+describe('public API', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  describe('publicListProjects', () => {
+    it('calls the correct endpoint and returns projects', async () => {
+      const projects = [{ project_summary_id: 1, project_name: 'Alpha' }]
+      vi.mocked(api.get).mockResolvedValue({ success: true, data: { projects } })
+
+      const result = await publicListProjects('johndoe')
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/projects')
+      expect(result).toEqual(projects)
+    })
+  })
+
+  describe('publicGetProject', () => {
+    it('calls the correct endpoint and returns project detail', async () => {
+      const detail = { project_summary_id: 5, project_name: 'Beta', data: {} }
+      vi.mocked(api.get).mockResolvedValue({ success: true, data: detail })
+
+      const result = await publicGetProject('johndoe', 5)
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/projects/5')
+      expect(result).toEqual(detail)
+    })
+  })
+
+  describe('publicFetchThumbnailUrl', () => {
+    beforeEach(() => {
+      vi.stubGlobal('URL', {
+        createObjectURL: vi.fn(() => 'blob:mock-url'),
+        revokeObjectURL: vi.fn(),
+      })
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('returns an object URL when blob fetch succeeds', async () => {
+      vi.mocked(api.getBlob).mockResolvedValue(new Blob(['img'], { type: 'image/png' }))
+
+      const result = await publicFetchThumbnailUrl('johndoe', 3)
+
+      expect(api.getBlob).toHaveBeenCalledWith('/public/johndoe/projects/3/thumbnail')
+      expect(result).toBe('blob:mock-url')
+    })
+
+    it('returns null when blob fetch throws', async () => {
+      vi.mocked(api.getBlob).mockRejectedValue(new Error('Not found'))
+
+      const result = await publicFetchThumbnailUrl('johndoe', 3)
+
+      expect(result).toBeNull()
+    })
+  })
+
+  describe('publicGetRanking', () => {
+    it('calls the correct endpoint', async () => {
+      const ranking = { projects: [] }
+      vi.mocked(api.get).mockResolvedValue(ranking)
+
+      const result = await publicGetRanking('johndoe')
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/ranking')
+      expect(result).toEqual(ranking)
+    })
+  })
+
+  describe('publicGetSkillsTimeline', () => {
+    it('calls the correct endpoint', async () => {
+      const timeline = { events: [] }
+      vi.mocked(api.get).mockResolvedValue(timeline)
+
+      const result = await publicGetSkillsTimeline('johndoe')
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/skills/timeline')
+      expect(result).toEqual(timeline)
+    })
+  })
+
+  describe('publicListResumes', () => {
+    it('calls the correct endpoint', async () => {
+      const response = { data: { resumes: [] } }
+      vi.mocked(api.get).mockResolvedValue(response)
+
+      const result = await publicListResumes('johndoe')
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/resumes')
+      expect(result).toEqual(response)
+    })
+  })
+
+  describe('publicGetResume', () => {
+    it('calls the correct endpoint', async () => {
+      const response = { data: { resume_id: 7 } }
+      vi.mocked(api.get).mockResolvedValue(response)
+
+      const result = await publicGetResume('johndoe', 7)
+
+      expect(api.get).toHaveBeenCalledWith('/public/johndoe/resumes/7')
+      expect(result).toEqual(response)
+    })
+  })
+})

--- a/frontend/src/api/public.ts
+++ b/frontend/src/api/public.ts
@@ -1,0 +1,47 @@
+import { api } from "./client";
+import type { Project, ProjectDetail } from "./projects";
+import type { ProjectRankingDTO } from "./insights";
+import type { SkillTimelineApiResponse } from "./insights";
+import type { ResumeListItem, ResumeDetail } from "./outputs";
+
+export function publicListProjects(username: string): Promise<Project[]> {
+  return api
+    .get<{ success: boolean; data: { projects: Project[] } }>(`/public/${username}/projects`)
+    .then((r) => r.data.projects);
+}
+
+export function publicGetProject(username: string, projectId: number): Promise<ProjectDetail> {
+  return api
+    .get<{ success: boolean; data: ProjectDetail }>(`/public/${username}/projects/${projectId}`)
+    .then((r) => r.data);
+}
+
+export async function publicFetchThumbnailUrl(
+  username: string,
+  projectId: number,
+): Promise<string | null> {
+  try {
+    const blob = await api.getBlob(`/public/${username}/projects/${projectId}/thumbnail`);
+    return URL.createObjectURL(blob);
+  } catch {
+    return null;
+  }
+}
+
+/** Returns the same shape as getRanking() so it can be used interchangeably. */
+export function publicGetRanking(username: string): Promise<ProjectRankingDTO> {
+  return api.get<ProjectRankingDTO>(`/public/${username}/ranking`);
+}
+
+/** Returns the same shape as getSkillTimeline() so it can be used interchangeably. */
+export function publicGetSkillsTimeline(username: string): Promise<SkillTimelineApiResponse> {
+  return api.get<SkillTimelineApiResponse>(`/public/${username}/skills/timeline`);
+}
+
+export function publicListResumes(username: string): Promise<{ data: { resumes: ResumeListItem[] } }> {
+  return api.get(`/public/${username}/resumes`);
+}
+
+export function publicGetResume(username: string, resumeId: number): Promise<{ data: ResumeDetail }> {
+  return api.get(`/public/${username}/resumes/${resumeId}`);
+}

--- a/frontend/src/api/public.ts
+++ b/frontend/src/api/public.ts
@@ -22,6 +22,8 @@ export interface PublicProjectDetail {
   project_type: string | null;
   project_mode: string | null;
   created_at: string | null;
+  start_date: string | null;
+  end_date: string | null;
   summary_text: string | null;
   languages: string[];
   frameworks: string[];

--- a/frontend/src/components/project-card.tsx
+++ b/frontend/src/components/project-card.tsx
@@ -5,6 +5,10 @@ import { fetchThumbnailUrl } from "../api/projects";
 type Props = {
   projectId: number;
   name: string;
+  /** Base path for the project detail link. Defaults to "/projects". */
+  basePath?: string;
+  /** Custom thumbnail fetcher. Defaults to the private fetchThumbnailUrl. */
+  thumbnailFetcher?: (projectId: number) => Promise<string | null>;
 };
 
 function fallbackColor(): string {
@@ -13,23 +17,28 @@ function fallbackColor(): string {
   return `rgb(${rgb.map((c) => Math.round(c * 255)).join(",")})`;
 }
 
-export default function ProjectCard({ projectId, name }: Props) {
+export default function ProjectCard({
+  projectId,
+  name,
+  basePath = "/projects",
+  thumbnailFetcher = fetchThumbnailUrl,
+}: Props) {
   const nav = useNavigate();
   const [thumbUrl, setThumbUrl] = useState<string | null>(null);
 
   useEffect(() => {
     let objectUrl: string | null = null;
-    fetchThumbnailUrl(projectId).then((url) => {
+    thumbnailFetcher(projectId).then((url) => {
       objectUrl = url;
       setThumbUrl(url);
     });
     return () => {
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
-  }, [projectId]);
+  }, [projectId, thumbnailFetcher]);
 
   return (
-    <div className="projectCard" onClick={() => nav(`/projects/${projectId}`)}>
+    <div className="projectCard" onClick={() => nav(`${basePath}/${projectId}`)}>
       <div
         className="projectCardThumb"
         style={

--- a/frontend/src/pages/ProjectDetail.css
+++ b/frontend/src/pages/ProjectDetail.css
@@ -163,7 +163,6 @@
 .pdNavRow {
   display: flex;
   justify-content: space-between;
-  max-width: 720px;
   margin-top: 8px;
   padding-bottom: 32px;
 }

--- a/frontend/src/pages/__tests__/Profile.test.tsx
+++ b/frontend/src/pages/__tests__/Profile.test.tsx
@@ -29,7 +29,7 @@ describe("ProfilePage", () => {
   it("shows Profile overview section", () => {
     render(<ProfilePage />);
     expect(screen.getByText("Profile overview")).toBeInTheDocument();
-    expect(screen.getByText(/Your account activity,personal information and security controls./)).toBeInTheDocument();
+    expect(screen.getByText(/Your account activity, personal information and security controls./)).toBeInTheDocument();
   });
 
   it("shows stat cards for Uploads, Projects, Resumes", () => {

--- a/frontend/src/pages/public/PublicLayout.tsx
+++ b/frontend/src/pages/public/PublicLayout.tsx
@@ -1,0 +1,58 @@
+import { useParams, NavLink, Link } from "react-router-dom";
+import type { ReactNode } from "react";
+import { tokenStore } from "../../auth/token";
+import { getUsername } from "../../auth/user";
+
+type Props = {
+  children: ReactNode;
+};
+
+export default function PublicLayout({ children }: Props) {
+  const { username } = useParams<{ username: string }>();
+  const isLoggedIn = !!tokenStore.get();
+  const loggedInUsername = getUsername();
+
+  return (
+    <>
+      <div className="topbar">
+        <div className="topbarInner" style={{ position: "relative" }}>
+          <Link to="/" className="brandLink" aria-label="Go to home">
+            <div className="brand">resuME</div>
+          </Link>
+
+          <nav className="nav" style={{ position: "absolute", left: "50%", transform: "translateX(-50%)" }}>
+            <NavLink className="navLink" to={`/public/${username}/projects`}>
+              Projects
+            </NavLink>
+            <span className="navSep">|</span>
+            <NavLink className="navLink" to={`/public/${username}/insights`}>
+              Insights
+            </NavLink>
+            <span className="navSep">|</span>
+            <NavLink className="navLink" to={`/public/${username}/outputs`}>
+              Outputs
+            </NavLink>
+          </nav>
+
+          <div className="userArea">
+            <span className="username" style={{ opacity: 0.6 }}>
+              Viewing {username}&apos;s portfolio
+            </span>
+            {isLoggedIn && (
+              <>
+                <Link to="/profile" className="navLink" aria-label="Open profile">
+                  <div className="avatar" />
+                </Link>
+                <Link to="/profile" className="username" aria-label="Open profile">
+                  {loggedInUsername ?? "username"}
+                </Link>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {children}
+    </>
+  );
+}

--- a/frontend/src/pages/public/PublicProjectDetail.tsx
+++ b/frontend/src/pages/public/PublicProjectDetail.tsx
@@ -7,16 +7,16 @@ import {
   publicFetchThumbnailUrl,
   publicListProjects,
 } from "../../api/public";
-import type { Project, ProjectDetail } from "../../api/projects";
+import type { PublicProjectDetail, PublicProject } from "../../api/public";
 
 export default function PublicProjectDetailPage() {
   const { username, id } = useParams<{ username: string; id: string }>();
   const projectId = Number(id);
   const nav = useNavigate();
 
-  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [project, setProject] = useState<PublicProjectDetail | null>(null);
   const [thumbUrl, setThumbUrl] = useState<string | null>(null);
-  const [allProjects, setAllProjects] = useState<Project[]>([]);
+  const [allProjects, setAllProjects] = useState<PublicProject[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -42,6 +42,11 @@ export default function PublicProjectDetailPage() {
       if (objectUrl) URL.revokeObjectURL(objectUrl);
     };
   }, [username, projectId]);
+
+  function formatDate(d: string | null | undefined) {
+    if (!d) return "—";
+    return d;
+  }
 
   function formatSkillName(s: string) {
     return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
@@ -97,8 +102,20 @@ export default function PublicProjectDetailPage() {
             <h2 className="pdTitle">{project.project_name}</h2>
             {project.project_type && <span className="pdMeta">{project.project_type}</span>}
             {project.project_mode && <span className="pdMeta">{project.project_mode}</span>}
-          </div>
+            </div>
         </div>
+
+        {/* Duration */}
+        {(project.start_date || project.end_date) && (
+          <div className="pdSection">
+            <div className="pdSectionHeader">
+              <h3>Duration</h3>
+            </div>
+            <p className="pdDateDisplay">
+              {formatDate(project.start_date)} → {formatDate(project.end_date)}
+            </p>
+          </div>
+        )}
 
         {/* Summary */}
         <div className="pdSection">
@@ -110,9 +127,7 @@ export default function PublicProjectDetailPage() {
             <>
               <h3 className="pdContribHeading">Contribution Summary</h3>
               <p className="pdSummaryText">
-                {project.contributions?.manual_contribution_summary ?? (
-                  <em>No contribution summary available.</em>
-                )}
+                <em>No contribution summary available.</em>
               </p>
             </>
           )}

--- a/frontend/src/pages/public/PublicProjectDetail.tsx
+++ b/frontend/src/pages/public/PublicProjectDetail.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import "../ProjectDetail.css";
+import PublicLayout from "./PublicLayout";
+import {
+  publicGetProject,
+  publicFetchThumbnailUrl,
+  publicListProjects,
+} from "../../api/public";
+import type { Project, ProjectDetail } from "../../api/projects";
+
+export default function PublicProjectDetailPage() {
+  const { username, id } = useParams<{ username: string; id: string }>();
+  const projectId = Number(id);
+  const nav = useNavigate();
+
+  const [project, setProject] = useState<ProjectDetail | null>(null);
+  const [thumbUrl, setThumbUrl] = useState<string | null>(null);
+  const [allProjects, setAllProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!username) return;
+    let objectUrl: string | null = null;
+
+    Promise.all([
+      publicGetProject(username, projectId),
+      publicFetchThumbnailUrl(username, projectId),
+      publicListProjects(username),
+    ])
+      .then(([proj, thumb, projects]) => {
+        setProject(proj);
+        objectUrl = thumb;
+        setThumbUrl(thumb);
+        setAllProjects(projects);
+      })
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+
+    return () => {
+      if (objectUrl) URL.revokeObjectURL(objectUrl);
+    };
+  }, [username, projectId]);
+
+  function formatSkillName(s: string) {
+    return s.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+  }
+
+  const basePath = `/public/${username}/projects`;
+
+  if (loading) {
+    return (
+      <PublicLayout>
+        <div className="content"><p>Loading…</p></div>
+      </PublicLayout>
+    );
+  }
+
+  if (error || !project) {
+    return (
+      <PublicLayout>
+        <div className="content">
+          <p className="error">{error ?? "Project not found."}</p>
+          <button className="btn" onClick={() => nav(basePath)}>← Back to Projects</button>
+        </div>
+      </PublicLayout>
+    );
+  }
+
+  const currentIndex = allProjects.findIndex((p) => p.project_summary_id === projectId);
+  const prevProject = currentIndex > 0 ? allProjects[currentIndex - 1] : null;
+  const nextProject =
+    currentIndex !== -1 && currentIndex < allProjects.length - 1
+      ? allProjects[currentIndex + 1]
+      : null;
+
+  return (
+    <PublicLayout>
+      <div className="content">
+        <button className="pdBackBtn" onClick={() => nav(basePath)}>← Back to Projects</button>
+
+        {/* Header */}
+        <div className="pdHeader">
+          {/* Thumbnail — read-only */}
+          <div className="pdThumbWrap">
+            <div
+              className="pdThumb"
+              style={thumbUrl ? { backgroundImage: `url(${thumbUrl})` } : undefined}
+            >
+              {!thumbUrl && <span className="pdThumbPlaceholder">No Image</span>}
+            </div>
+          </div>
+
+          {/* Project name + meta */}
+          <div className="pdHeaderInfo">
+            <h2 className="pdTitle">{project.project_name}</h2>
+            {project.project_type && <span className="pdMeta">{project.project_type}</span>}
+            {project.project_mode && <span className="pdMeta">{project.project_mode}</span>}
+          </div>
+        </div>
+
+        {/* Summary */}
+        <div className="pdSection">
+          <h3>Summary</h3>
+          <p className="pdSummaryText">
+            {project.summary_text ?? <em>No summary available.</em>}
+          </p>
+          {project.project_mode === "collaborative" && (
+            <>
+              <h3 className="pdContribHeading">Contribution Summary</h3>
+              <p className="pdSummaryText">
+                {project.contributions?.manual_contribution_summary ?? (
+                  <em>No contribution summary available.</em>
+                )}
+              </p>
+            </>
+          )}
+        </div>
+
+        {/* Skills */}
+        {(project.languages?.length > 0 ||
+          project.frameworks?.length > 0 ||
+          project.skills?.length > 0) && (
+          <div className="pdSection">
+            <h3>Skills &amp; Technologies</h3>
+            {project.languages?.length > 0 && (
+              <p className="pdSummaryText">
+                <strong>Languages:</strong> {project.languages.join(", ")}
+              </p>
+            )}
+            {project.frameworks?.length > 0 && (
+              <p className="pdSummaryText">
+                <strong>Frameworks:</strong> {project.frameworks.join(", ")}
+              </p>
+            )}
+            {project.skills?.length > 0 && (
+              <p className="pdSummaryText">
+                <strong>Skills:</strong>{" "}
+                {project.skills.map(formatSkillName).join(", ")}
+              </p>
+            )}
+          </div>
+        )}
+
+        {/* Prev/Next navigation */}
+        {(prevProject || nextProject) && (
+          <div className="pdNavRow">
+            {prevProject ? (
+              <button
+                className="pdNavBtn"
+                onClick={() => nav(`${basePath}/${prevProject.project_summary_id}`)}
+              >
+                ← {prevProject.project_name}
+              </button>
+            ) : (
+              <span />
+            )}
+            {nextProject && (
+              <button
+                className="pdNavBtn"
+                onClick={() => nav(`${basePath}/${nextProject.project_summary_id}`)}
+              >
+                {nextProject.project_name} →
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/pages/public/PublicProjects.tsx
+++ b/frontend/src/pages/public/PublicProjects.tsx
@@ -1,0 +1,54 @@
+import { useEffect, useState, useCallback } from "react";
+import { useParams } from "react-router-dom";
+import "../Projects.css";
+import PublicLayout from "./PublicLayout";
+import ProjectCard from "../../components/project-card";
+import { publicListProjects, publicFetchThumbnailUrl } from "../../api/public";
+import type { Project } from "../../api/projects";
+
+export default function PublicProjectsPage() {
+  const { username } = useParams<{ username: string }>();
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!username) return;
+    publicListProjects(username)
+      .then(setProjects)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [username]);
+
+  const thumbnailFetcher = useCallback(
+    (projectId: number) => publicFetchThumbnailUrl(username!, projectId),
+    [username],
+  );
+
+  return (
+    <PublicLayout>
+      <div className="content">
+        <h2>Projects</h2>
+
+        {loading && <p>Loading…</p>}
+        {error && <p className="error">{error}</p>}
+
+        {!loading && !error && projects.length === 0 && (
+          <p>No projects yet.</p>
+        )}
+
+        <div className="projectGrid">
+          {projects.map((p) => (
+            <ProjectCard
+              key={p.project_summary_id}
+              projectId={p.project_summary_id}
+              name={p.project_name}
+              basePath={`/public/${username}/projects`}
+              thumbnailFetcher={thumbnailFetcher}
+            />
+          ))}
+        </div>
+      </div>
+    </PublicLayout>
+  );
+}

--- a/frontend/src/pages/public/__tests__/PublicLayout.test.tsx
+++ b/frontend/src/pages/public/__tests__/PublicLayout.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import PublicLayout from '../PublicLayout'
+
+vi.mock('react-router-dom', () => ({
+  useParams: vi.fn(() => ({ username: 'johndoe' })),
+  NavLink: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+vi.mock('../../../auth/token', () => ({
+  tokenStore: { get: vi.fn() },
+}))
+
+vi.mock('../../../auth/user', () => ({
+  getUsername: vi.fn(),
+}))
+
+import { tokenStore } from '../../../auth/token'
+import { getUsername } from '../../../auth/user'
+
+describe('PublicLayout', () => {
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('renders brand name', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.getByText('resuME')).toBeInTheDocument()
+  })
+
+  it('renders nav links for Projects, Insights, and Outputs', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.getByText('Projects')).toBeInTheDocument()
+    expect(screen.getByText('Insights')).toBeInTheDocument()
+    expect(screen.getByText('Outputs')).toBeInTheDocument()
+  })
+
+  it('shows "Viewing {username}\'s portfolio"', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.getByText(/Viewing johndoe's portfolio/)).toBeInTheDocument()
+  })
+
+  it('renders children', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    render(<PublicLayout><div data-testid="child-content" /></PublicLayout>)
+    expect(screen.getByTestId('child-content')).toBeInTheDocument()
+  })
+
+  it('shows logged-in username when user is logged in', () => {
+    vi.mocked(tokenStore.get).mockReturnValue('some-token')
+    vi.mocked(getUsername).mockReturnValue('currentuser')
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.getByText('currentuser')).toBeInTheDocument()
+  })
+
+  it('does not show logged-in user area when not logged in', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    vi.mocked(getUsername).mockReturnValue(null)
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.queryByText('currentuser')).not.toBeInTheDocument()
+  })
+
+  it('nav links point to the correct public URLs', () => {
+    vi.mocked(tokenStore.get).mockReturnValue(null)
+    render(<PublicLayout><div /></PublicLayout>)
+    expect(screen.getByText('Projects').closest('a')).toHaveAttribute(
+      'href',
+      '/public/johndoe/projects',
+    )
+    expect(screen.getByText('Insights').closest('a')).toHaveAttribute(
+      'href',
+      '/public/johndoe/insights',
+    )
+    expect(screen.getByText('Outputs').closest('a')).toHaveAttribute(
+      'href',
+      '/public/johndoe/outputs',
+    )
+  })
+})

--- a/frontend/src/pages/public/__tests__/PublicProjectDetail.test.tsx
+++ b/frontend/src/pages/public/__tests__/PublicProjectDetail.test.tsx
@@ -43,6 +43,8 @@ const baseProject = {
   project_type: 'personal',
   project_mode: 'solo',
   created_at: null,
+  start_date: null,
+  end_date: null,
   summary_text: 'A test summary.',
   languages: ['TypeScript'],
   frameworks: ['React'],
@@ -199,12 +201,11 @@ describe('PublicProjectDetailPage', () => {
       vi.mocked(publicGetProject).mockResolvedValue({
         ...baseProject,
         project_mode: 'collaborative',
-        contributions: { manual_contribution_summary: 'I built the frontend.' },
       })
       render(<PublicProjectDetailPage />)
       await waitFor(() => {
         expect(screen.getByText('Contribution Summary')).toBeInTheDocument()
-        expect(screen.getByText('I built the frontend.')).toBeInTheDocument()
+        expect(screen.getByText('No contribution summary available.')).toBeInTheDocument()
       })
     })
 

--- a/frontend/src/pages/public/__tests__/PublicProjectDetail.test.tsx
+++ b/frontend/src/pages/public/__tests__/PublicProjectDetail.test.tsx
@@ -1,0 +1,271 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import PublicProjectDetailPage from '../PublicProjectDetail'
+
+const mockNavigate = vi.fn()
+
+vi.mock('react-router-dom', () => ({
+  useParams: vi.fn(() => ({ username: 'johndoe', id: '42' })),
+  useNavigate: vi.fn(() => mockNavigate),
+  NavLink: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+vi.mock('../../../api/public', () => ({
+  publicGetProject: vi.fn(),
+  publicFetchThumbnailUrl: vi.fn(),
+  publicListProjects: vi.fn(),
+}))
+
+vi.mock('../../../auth/token', () => ({
+  tokenStore: { get: vi.fn(() => null) },
+}))
+
+vi.mock('../../../auth/user', () => ({
+  getUsername: vi.fn(() => null),
+}))
+
+import {
+  publicGetProject,
+  publicFetchThumbnailUrl,
+  publicListProjects,
+} from '../../../api/public'
+
+const baseProject = {
+  project_summary_id: 42,
+  project_key: null,
+  project_name: 'Test Project',
+  project_type: 'personal',
+  project_mode: 'solo',
+  created_at: null,
+  summary_text: 'A test summary.',
+  languages: ['TypeScript'],
+  frameworks: ['React'],
+  skills: ['frontend_dev'],
+  contributions: {},
+}
+
+function setupDefaultMocks() {
+  vi.mocked(publicGetProject).mockResolvedValue(baseProject)
+  vi.mocked(publicFetchThumbnailUrl).mockResolvedValue(null)
+  vi.mocked(publicListProjects).mockResolvedValue([
+    { project_summary_id: 42, project_name: 'Test Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+  ])
+}
+
+describe('PublicProjectDetailPage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:mock-url'),
+      revokeObjectURL: vi.fn(),
+    })
+    setupDefaultMocks()
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  describe('loading and error states', () => {
+    it('shows loading state initially', () => {
+      vi.mocked(publicGetProject).mockReturnValue(new Promise(() => {}))
+      render(<PublicProjectDetailPage />)
+      expect(screen.getByText('Loading…')).toBeInTheDocument()
+    })
+
+    it('shows error message when API fails', async () => {
+      vi.mocked(publicGetProject).mockRejectedValue(new Error('Not found'))
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Not found')).toBeInTheDocument()
+      })
+    })
+
+    it('shows back button on error state', async () => {
+      vi.mocked(publicGetProject).mockRejectedValue(new Error('Failed'))
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('← Back to Projects')).toBeInTheDocument()
+      })
+    })
+
+    it('navigates back to projects list when back button is clicked in error state', async () => {
+      vi.mocked(publicGetProject).mockRejectedValue(new Error('Failed'))
+      const user = userEvent.setup()
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText('← Back to Projects'))
+      await user.click(screen.getByText('← Back to Projects'))
+      expect(mockNavigate).toHaveBeenCalledWith('/public/johndoe/projects')
+    })
+  })
+
+  describe('project content', () => {
+    it('renders project name after loading', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Test Project')).toBeInTheDocument()
+      })
+    })
+
+    it('renders project summary text', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('A test summary.')).toBeInTheDocument()
+      })
+    })
+
+    it('renders project type and mode metadata', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('personal')).toBeInTheDocument()
+        expect(screen.getByText('solo')).toBeInTheDocument()
+      })
+    })
+
+    it('shows no-image placeholder when thumbnail is null', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('No Image')).toBeInTheDocument()
+      })
+    })
+
+    it('does not show no-image placeholder when thumbnail is present', async () => {
+      vi.mocked(publicFetchThumbnailUrl).mockResolvedValue('blob:mock-url')
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.queryByText('No Image')).not.toBeInTheDocument()
+      })
+    })
+
+    it('renders back button', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('← Back to Projects')).toBeInTheDocument()
+      })
+    })
+
+    it('navigates back when back button is clicked', async () => {
+      const user = userEvent.setup()
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText('← Back to Projects'))
+      await user.click(screen.getByText('← Back to Projects'))
+      expect(mockNavigate).toHaveBeenCalledWith('/public/johndoe/projects')
+    })
+  })
+
+  describe('skills and technologies', () => {
+    it('renders languages', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/TypeScript/)).toBeInTheDocument()
+      })
+    })
+
+    it('renders frameworks', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/React/)).toBeInTheDocument()
+      })
+    })
+
+    it('renders skills with formatted names', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/Frontend Dev/)).toBeInTheDocument()
+      })
+    })
+
+    it('does not render skills section when all arrays are empty', async () => {
+      vi.mocked(publicGetProject).mockResolvedValue({
+        ...baseProject,
+        languages: [],
+        frameworks: [],
+        skills: [],
+      })
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText('Test Project'))
+      expect(screen.queryByText('Skills & Technologies')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('collaborative project', () => {
+    it('shows contribution summary section for collaborative projects', async () => {
+      vi.mocked(publicGetProject).mockResolvedValue({
+        ...baseProject,
+        project_mode: 'collaborative',
+        contributions: { manual_contribution_summary: 'I built the frontend.' },
+      })
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText('Contribution Summary')).toBeInTheDocument()
+        expect(screen.getByText('I built the frontend.')).toBeInTheDocument()
+      })
+    })
+
+    it('does not show contribution summary for solo projects', async () => {
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText('Test Project'))
+      expect(screen.queryByText('Contribution Summary')).not.toBeInTheDocument()
+    })
+  })
+
+  describe('prev/next navigation', () => {
+    it('shows next project button when current is not last', async () => {
+      vi.mocked(publicListProjects).mockResolvedValue([
+        { project_summary_id: 42, project_name: 'Test Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+        { project_summary_id: 43, project_name: 'Next Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+      ])
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/Next Project/)).toBeInTheDocument()
+      })
+    })
+
+    it('shows prev project button when current is not first', async () => {
+      vi.mocked(publicListProjects).mockResolvedValue([
+        { project_summary_id: 41, project_name: 'Prev Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+        { project_summary_id: 42, project_name: 'Test Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+      ])
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => {
+        expect(screen.getByText(/Prev Project/)).toBeInTheDocument()
+      })
+    })
+
+    it('navigates to next project when next button is clicked', async () => {
+      vi.mocked(publicListProjects).mockResolvedValue([
+        { project_summary_id: 42, project_name: 'Test Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+        { project_summary_id: 43, project_name: 'Next Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+      ])
+      const user = userEvent.setup()
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText(/Next Project/))
+      await user.click(screen.getByText(/Next Project/))
+      expect(mockNavigate).toHaveBeenCalledWith('/public/johndoe/projects/43')
+    })
+
+    it('navigates to prev project when prev button is clicked', async () => {
+      vi.mocked(publicListProjects).mockResolvedValue([
+        { project_summary_id: 41, project_name: 'Prev Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+        { project_summary_id: 42, project_name: 'Test Project', project_key: null, project_type: null, project_mode: null, created_at: null },
+      ])
+      const user = userEvent.setup()
+      render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText(/Prev Project/))
+      await user.click(screen.getByText(/Prev Project/))
+      expect(mockNavigate).toHaveBeenCalledWith('/public/johndoe/projects/41')
+    })
+
+    it('hides nav row when project is the only one', async () => {
+      const { container } = render(<PublicProjectDetailPage />)
+      await waitFor(() => screen.getByText('Test Project'))
+      expect(container.querySelector('.pdNavBtn')).toBeNull()
+    })
+  })
+})

--- a/frontend/src/pages/public/__tests__/PublicProjects.test.tsx
+++ b/frontend/src/pages/public/__tests__/PublicProjects.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, waitFor } from '@testing-library/react'
+import PublicProjectsPage from '../PublicProjects'
+
+vi.mock('react-router-dom', () => ({
+  useParams: vi.fn(() => ({ username: 'johndoe' })),
+  NavLink: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+  Link: ({ to, children }: { to: string; children: React.ReactNode }) => (
+    <a href={to}>{children}</a>
+  ),
+}))
+
+vi.mock('../../../api/public', () => ({
+  publicListProjects: vi.fn(),
+  publicFetchThumbnailUrl: vi.fn(),
+}))
+
+vi.mock('../../../auth/token', () => ({
+  tokenStore: { get: vi.fn(() => null) },
+}))
+
+vi.mock('../../../auth/user', () => ({
+  getUsername: vi.fn(() => null),
+}))
+
+vi.mock('../../../components/project-card', () => ({
+  default: ({ name }: { name: string }) => <div data-testid="project-card">{name}</div>,
+}))
+
+import { publicListProjects, publicFetchThumbnailUrl } from '../../../api/public'
+
+describe('PublicProjectsPage', () => {
+  beforeEach(() => {
+    vi.mocked(publicFetchThumbnailUrl).mockResolvedValue(null)
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('shows loading state initially', () => {
+    vi.mocked(publicListProjects).mockReturnValue(new Promise(() => {}))
+    render(<PublicProjectsPage />)
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('renders project cards after successful load', async () => {
+    vi.mocked(publicListProjects).mockResolvedValue([
+      { project_summary_id: 1, project_name: 'Project Alpha', project_key: null, project_type: null, project_mode: null, created_at: null },
+      { project_summary_id: 2, project_name: 'Project Beta', project_key: null, project_type: null, project_mode: null, created_at: null },
+    ])
+    render(<PublicProjectsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Project Alpha')).toBeInTheDocument()
+      expect(screen.getByText('Project Beta')).toBeInTheDocument()
+    })
+  })
+
+  it('shows empty state when no projects exist', async () => {
+    vi.mocked(publicListProjects).mockResolvedValue([])
+    render(<PublicProjectsPage />)
+    await waitFor(() => {
+      expect(screen.getByText(/No projects yet/)).toBeInTheDocument()
+    })
+  })
+
+  it('shows error message when API fails', async () => {
+    vi.mocked(publicListProjects).mockRejectedValue(new Error('Network error'))
+    render(<PublicProjectsPage />)
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument()
+    })
+  })
+
+  it('does not show empty state while loading', () => {
+    vi.mocked(publicListProjects).mockReturnValue(new Promise(() => {}))
+    render(<PublicProjectsPage />)
+    expect(screen.queryByText(/No projects yet/)).not.toBeInTheDocument()
+  })
+
+  it('renders the page heading', () => {
+    vi.mocked(publicListProjects).mockReturnValue(new Promise(() => {}))
+    render(<PublicProjectsPage />)
+    expect(screen.getByRole('heading', { name: 'Projects' })).toBeInTheDocument()
+  })
+
+  it('calls publicListProjects with the username from params', async () => {
+    vi.mocked(publicListProjects).mockResolvedValue([])
+    render(<PublicProjectsPage />)
+    await waitFor(() => {
+      expect(publicListProjects).toHaveBeenCalledWith('johndoe')
+    })
+  })
+})

--- a/src/api/schemas/public_schemas.py
+++ b/src/api/schemas/public_schemas.py
@@ -20,6 +20,8 @@ class PublicProjectDetailDTO(BaseModel):
     project_type: Optional[str] = None
     project_mode: Optional[str] = None
     created_at: Optional[str] = None
+    start_date: Optional[str] = None
+    end_date: Optional[str] = None
     summary_text: Optional[str] = None
     languages: List[str] = []
     frameworks: List[str] = []

--- a/src/services/public_portfolio_service.py
+++ b/src/services/public_portfolio_service.py
@@ -122,7 +122,9 @@ def get_public_project_detail(
             ps.project_type,
             ps.project_mode,
             ps.summary_json,
-            ps.created_at
+            ps.created_at,
+            ps.manual_start_date,
+            ps.manual_end_date
         FROM project_summaries ps
         JOIN projects p ON p.project_key = ps.project_key
         WHERE ps.user_id = ? AND ps.project_summary_id = ? AND ps.is_public = 1
@@ -144,6 +146,8 @@ def get_public_project_detail(
         "project_type": row["project_type"],
         "project_mode": row["project_mode"],
         "created_at": row["created_at"],
+        "start_date": row["manual_start_date"],
+        "end_date": row["manual_end_date"],
         "summary_text": summary_dict.get("summary_text"),
         "languages": summary_dict.get("languages", []),
         "frameworks": summary_dict.get("frameworks", []),


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR adds the frontend page of the project and project details for the public users. It modifies project-card.tsx to use thumbnailfetcher to fetch thumbnail by using GET/public/{username}/projects/{id}/thumbnail so that it can have thumbnail without having authorization header.

This also adds new page: Public Projects, and Public Project Details, which contains all information such as project list and project details such as summary, skill & technology, and without any modification option and Upload navbar.

**Closes:** #582 

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [ ] npm run test:run

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>