### PR TITLE
Make Resume only 1 page long

### DIFF
--- a/src/api/routes/export.py
+++ b/src/api/routes/export.py
@@ -54,6 +54,24 @@ def export_resume_docx(
     temp_dir = tempfile.mkdtemp()
     background_tasks.add_task(_cleanup_temp_dir, temp_dir)
 
+    # First, validate that this resume fits on a single PDF page using the
+    # same export pipeline and layout. If the PDF export raises a ValueError
+    # about exceeding one page, we propagate that as a 400 and avoid
+    # generating the DOCX as well.
+    pdf_check_dir = tempfile.mkdtemp()
+    try:
+        try:
+            export_resume_record_to_pdf(
+                username=username,
+                record=record,
+                out_dir=pdf_check_dir,
+            )
+        except ValueError as e:
+            _cleanup_temp_dir(pdf_check_dir)
+            raise HTTPException(status_code=400, detail=str(e))
+    finally:
+        _cleanup_temp_dir(pdf_check_dir)
+
     filepath = export_resume_record_to_docx(
         username=username,
         record=record,

--- a/src/db/user_profile.py
+++ b/src/db/user_profile.py
@@ -91,6 +91,15 @@ def upsert_user_profile(
     clean_location = _clean_optional_text(location)
     clean_profile_text = _clean_optional_text(profile_text)
 
+    # Enforce a maximum length for the profile paragraph so it fits well on a resume.
+    # This is a backend guard; callers should provide shorter text rather than expecting truncation.
+    if clean_profile_text is not None:
+        MAX_PROFILE_CHARS = 900
+        if len(clean_profile_text) > MAX_PROFILE_CHARS:
+            raise ValueError(
+                f"profile_text must be at most {MAX_PROFILE_CHARS} characters."
+            )
+
     conn.execute(
         """
         UPDATE users

--- a/src/export/resume_docx.py
+++ b/src/export/resume_docx.py
@@ -320,9 +320,14 @@ def export_resume_record_to_docx(
         reverse=True,
     )
 
+    # Limit the number of projects shown on the resume to keep layout tight.
+    # We keep the newest projects by taking from the already date-sorted list.
+    MAX_PROJECTS = 4
+    visible_projects = projects_sorted[:MAX_PROJECTS]
+
     add_section_heading(doc, "Projects")
 
-    for p in projects_sorted:
+    for p in visible_projects:
         project_name = _resume_display_name(p)
         doc.add_heading(project_name, level=2)
 
@@ -350,6 +355,10 @@ def export_resume_record_to_docx(
                 pct = p.get("contribution_percent")
                 if isinstance(pct, (int, float)):
                     bullets_to_use.append(f"Contributed to {pct:.1f}% of document")
+
+        # Cap the number of bullets per project for readability and space.
+        MAX_BULLETS_PER_PROJECT = 4
+        bullets_to_use = bullets_to_use[:MAX_BULLETS_PER_PROJECT]
 
         for b in bullets_to_use:
             add_bullet(doc, str(b))

--- a/src/export/resume_pdf.py
+++ b/src/export/resume_pdf.py
@@ -39,6 +39,8 @@ from reportlab.platypus import (
 )
 from reportlab.platypus.flowables import HRFlowable
 
+from pypdf import PdfReader
+
 from src.export.resume_helpers import (
     format_date_range,
     parse_date,
@@ -308,6 +310,14 @@ def export_resume_record_to_pdf(
         else:
             story.append(Paragraph("Resume data is missing or unreadable.", Body))
         doc.build(story)
+
+        # For snapshot-only exports, a single page is expected by design. If
+        # this grows, fail fast so callers can adjust content.
+        reader = PdfReader(str(filepath))
+        if len(reader.pages) > 1:
+            filepath.unlink(missing_ok=True)
+            raise ValueError("Resume PDF exceeds one page; please shorten content.")
+
         return filepath
 
     projects: List[Dict[str, Any]] = snapshot.get("projects") or []
@@ -376,7 +386,12 @@ def export_resume_record_to_pdf(
 
     projects_sorted = sorted(projects, key=sort_key, reverse=True)
 
-    for p in projects_sorted:
+    # Limit the number of projects shown on the PDF resume to keep layout tight.
+    # We keep the newest projects by taking from the already date-sorted list.
+    MAX_PROJECTS = 4
+    visible_projects = projects_sorted[:MAX_PROJECTS]
+
+    for p in visible_projects:
         title = (
             p.get("resume_display_name_override")
             or p.get("manual_display_name")
@@ -396,6 +411,10 @@ def export_resume_record_to_pdf(
             or p.get("contribution_bullets")
             or []
         )
+
+        # Cap the number of bullets per project for readability and space.
+        MAX_BULLETS_PER_PROJECT = 4
+        bullets = bullets[:MAX_BULLETS_PER_PROJECT]
 
         if bullets:
             story.append(
@@ -424,4 +443,14 @@ def export_resume_record_to_pdf(
         _render_education_block(story, certificate_only, ProjectTitleStyle, MetaItalic, Body)
 
     doc.build(story)
+
+    # Enforce a strict single-page resume for PDF exports. If the rendered
+    # document exceeds one page, delete the file and raise an error so the
+    # caller can prompt the user to reduce content (fewer projects, shorter
+    # experience, etc.).
+    reader = PdfReader(str(filepath))
+    if len(reader.pages) > 1:
+        filepath.unlink(missing_ok=True)
+        raise ValueError("Resume PDF exceeds one page; please shorten content.")
+
     return filepath

--- a/src/menu/resume/flow.py
+++ b/src/menu/resume/flow.py
@@ -8,6 +8,8 @@ Separated from menu.py to keep menu wiring light.
 import json
 from typing import Any
 from datetime import datetime
+import tempfile
+import shutil
 
 from src.db import (
     get_all_user_project_summaries,
@@ -310,10 +312,31 @@ def _handle_export_resume_docx(conn, user_id: int, username: str) -> bool:
     highlighted_skills = get_highlighted_skills_for_display(
         conn, user_id, context="resume", context_id=resume_id
     )
-    
+
     user_profile = get_user_profile(conn, user_id)
     education_entries = list_user_education_entries(conn, user_id)
     experience_entries = list_user_experience_entries(conn, user_id)
+
+    # Before exporting to DOCX, validate that the same content fits on a
+    # single PDF page. This ensures the 1-page rule is consistently applied
+    # regardless of the chosen format.
+    tmp_dir = tempfile.mkdtemp()
+    try:
+        try:
+            export_resume_record_to_pdf(
+                username=username,
+                record=record,
+                out_dir=tmp_dir,
+                highlighted_skills=highlighted_skills,
+                user_profile=user_profile,
+                education_entries=education_entries,
+                experience_entries=experience_entries,
+            )
+        except ValueError as e:
+            print(f"\n[Resume] Unable to export: {e}")
+            return False
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
 
     out_file = export_resume_record_to_docx(
         username=username,

--- a/src/services/resumes_service.py
+++ b/src/services/resumes_service.py
@@ -41,6 +41,43 @@ from src.db.skill_preferences import (
 import json
 
 
+def _clean_bullet_text(value: Any) -> str:
+    # Keep behavior consistent with other parts of the app: trim and strip leading bullet markers.
+    text = str(value).strip()
+    if text.startswith(("-", "•")):
+        text = text.lstrip("-•").strip()
+    return text
+
+
+def _validate_contribution_bullets(bullets: List[Any]) -> List[str]:
+    """
+    Enforce resume-safe constraints on contribution bullets.
+
+    - Must be between 2 and 4 bullets (inclusive)
+    - Each bullet must be non-empty after cleaning
+    - Each bullet must be short enough to fit cleanly in exports
+    """
+    MIN_BULLETS = 2
+    MAX_BULLETS = 4
+    MAX_BULLET_CHARS = 240
+
+    cleaned: List[str] = [_clean_bullet_text(b) for b in bullets]
+    cleaned = [b for b in cleaned if b]
+
+    if len(cleaned) < MIN_BULLETS or len(cleaned) > MAX_BULLETS:
+        raise ValueError(
+            f"contribution_bullets must contain between {MIN_BULLETS} and {MAX_BULLETS} bullet points."
+        )
+
+    too_long = [i + 1 for i, b in enumerate(cleaned) if len(b) > MAX_BULLET_CHARS]
+    if too_long:
+        raise ValueError(
+            f"Contribution bullet(s) {', '.join(map(str, too_long))} exceed {MAX_BULLET_CHARS} characters."
+        )
+
+    return cleaned
+
+
 def list_user_resumes(conn, user_id: int) -> List[Dict[str, Any]]:
     """
     Service method for listing resumes.
@@ -210,13 +247,20 @@ def edit_resume(
     if summary_text is not None:
         updates["summary_text"] = summary_text or None
     if contribution_bullets is not None:
+        # Validate user-provided bullets so exports don't need to truncate text.
+        # Note: we validate the final bullet list after applying append/replace logic.
         if contribution_edit_mode == "append" and contribution_bullets:
             # Append new bullets to existing ones
             current_bullets = resolve_resume_contribution_bullets(project_entry)
-            updates["contribution_bullets"] = current_bullets + contribution_bullets
+            combined = current_bullets + contribution_bullets
+            updates["contribution_bullets"] = _validate_contribution_bullets(combined)
         else:
             # Replace mode: use provided bullets directly
-            updates["contribution_bullets"] = contribution_bullets or None
+            updates["contribution_bullets"] = (
+                _validate_contribution_bullets(contribution_bullets)
+                if contribution_bullets
+                else None
+            )
     if key_role is not None:
         updates["key_role"] = key_role or None
 


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

As of right now we have no guards on how many pages a resume someone generates can be, and as per milestone 1 requirements description we should be making a 1-page resume. Hence this PR works on adding limitations and guards to ensure resume are only 1 page long and that the fields in the resume also have limits.

**Closes:** #595

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [ ] Test A
- [ ] Test B

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
