### PR TITLE
GitHub bug + redirect flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,7 @@ GROQ_API_KEY=<your-api-key>
 GITHUB_CLIENT_ID = ""
 GITHUB_CLIENT_SECRET=<your-new-client-secret>
 GITHUB_REDIRECT_URI=http://localhost:8000/auth/github/callback
+FRONTEND_BASE_URL=http://localhost:5173
 
 DEVICE_CODE_URL = "https://github.com/login/device/code"
 TOKEN_URL = "https://github.com/login/oauth/access_token"

--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ A template file (`.env.example`) is provided and should be copied directly.
     - `GITHUB_CLIENT_ID` / `GITHUB_CLIENT_SECRET` — GitHub OAuth (leave empty to skip GitHub analysis)
     - `GOOGLE_CLIENT_ID` / `GOOGLE_CLIENT_SECRET` — Google Drive (leave empty to skip Drive analysis)
     - `DEVICE_CODE_URL`, `TOKEN_URL`, `GITHUB_REDIRECT_URI`, `GOOGLE_REDIRECT_URI` — URL constants, do not modify
+    - `FRONTEND_BASE_URL` — Base URL of the frontend (e.g. `http://localhost:5173`). Used by the GitHub OAuth callback to redirect users back to the setup page after authorization.
 
 > **Security Note**
 > The `.env` file may contain sensitive information and is ignored by Git via `.gitignore`.
@@ -292,7 +293,10 @@ To enable GitHub analysis:
 4. Add the following to your `.env` file (as shown in `.env.example`):
     ```env
     GITHUB_CLIENT_ID=<your-client-id>
+    GITHUB_CLIENT_SECRET=<your-client-secret>
+    FRONTEND_BASE_URL=http://localhost:5173
     ```
+   The OAuth callback redirects to `FRONTEND_BASE_URL/upload/setup?uploadId=...&github=success` so the setup page can refresh and load repositories. Ensure your frontend dev server matches this URL when testing.
 
 ### LLM Services (optional)
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1215,7 +1215,7 @@ Handles GitHub OAuth authentication and repository linking for projects during t
 
 - **Start GitHub Connection**
   - **Endpoint**: `POST /start`
-  - **Description**: Initiates GitHub OAuth connection flow for a project. If `connect_now` is `true` and user is not already connected, returns an authorization URL. If `connect_now` is `false`, records that GitHub connection was skipped.
+  - **Description**: Initiates GitHub OAuth connection flow for a project. If `connect_now` is `true` and user is not already connected, returns an authorization URL. If a stored token exists, it is validated first; if validation fails (expired or revoked), the token is cleared and an auth URL is returned so the user can re-authorize. If `connect_now` is `false`, records that GitHub connection was skipped.
   - **Path Parameters**:
     - `{upload_id}` (integer, required): The upload session ID
     - `{project}` (string, required): The project name

--- a/docs/github_integration.md
+++ b/docs/github_integration.md
@@ -75,6 +75,10 @@ OAuth scope required:
 
 The token is stored locally in the application's database and reused until revoked.
 
+### Token Validation (Web Flow)
+
+When the web API receives a request to start the GitHub connection (`POST /projects/upload/{id}/projects/{name}/github/start`), it validates any existing stored token before trusting it. A quick `GET https://api.github.com/user` request verifies the token is still valid. If the token is invalid (expired, revoked, or "Bad credentials"), it is revoked locally and the user is given a new authorization URL so they can re-authenticate. This prevents the "No repositories found" error when a stored token has gone stale.
+
 ---
 
 ## Data Retrieved

--- a/frontend/src/pages/upload/setup/SetupPage.tsx
+++ b/frontend/src/pages/upload/setup/SetupPage.tsx
@@ -6,6 +6,7 @@ import UploadWizardShell from "../../../components/UploadWizardShell";
 import "../UploadShared.css";
 import SetupAnalyzeConfirmDialog from "./components/SetupAnalyzeConfirmDialog";
 import SetupProjectGroup from "./components/SetupProjectGroup";
+import { useGitHubOAuthCallback } from "./hooks/useGitHubOAuthCallback";
 import { useSetupFlow } from "./hooks/useSetupFlow";
 import type { SummaryMode } from "./types";
 
@@ -60,58 +61,13 @@ export default function UploadSetupPage() {
     nav("/upload/upload", { replace: true });
   }, [flow.hasValidUploadId, nav]);
 
-  useEffect(() => {
-    const githubStatus = searchParams.get("github");
-    if (githubStatus === "success") {
-      if (window.opener) {
-        window.opener.postMessage({ type: "github-auth-success" }, window.location.origin);
-        window.close();
-        return;
-      }
-      if (flow.hasValidUploadId) {
-        void flow.refreshUpload();
-      }
-      setSearchParams(
-        (prev) => {
-          const p = new URLSearchParams(prev);
-          p.delete("github");
-          return Object.fromEntries(p.entries());
-        },
-        { replace: true },
-      );
-    } else if (githubStatus === "error") {
-      if (window.opener) {
-        const errorMsg = searchParams.get("message") ?? "GitHub authorization failed.";
-        window.opener.postMessage({ type: "github-auth-error", message: errorMsg }, window.location.origin);
-        window.close();
-        return;
-      }
-      const errorMsg = searchParams.get("message") ?? "GitHub authorization failed.";
-      flow.setActionError(errorMsg);
-      setSearchParams(
-        (prev) => {
-          const p = new URLSearchParams(prev);
-          p.delete("github");
-          p.delete("message");
-          return Object.fromEntries(p.entries());
-        },
-        { replace: true },
-      );
-    }
-  }, [searchParams, flow.hasValidUploadId, flow.refreshUpload, flow.setActionError, setSearchParams]);
-
-  useEffect(() => {
-    function onMessage(event: MessageEvent) {
-      if (event.origin !== window.location.origin) return;
-      if (event.data?.type === "github-auth-success") {
-        void flow.refreshUpload();
-      } else if (event.data?.type === "github-auth-error") {
-        flow.setActionError(event.data.message ?? "GitHub authorization failed.");
-      }
-    }
-    window.addEventListener("message", onMessage);
-    return () => window.removeEventListener("message", onMessage);
-  }, [flow.refreshUpload, flow.setActionError]);
+  useGitHubOAuthCallback({
+    searchParams,
+    setSearchParams,
+    hasValidUploadId: flow.hasValidUploadId,
+    refreshUpload: flow.refreshUpload,
+    setActionError: flow.setActionError,
+  });
 
   useEffect(() => {
     if (!flow.uploadNotFound) return;

--- a/frontend/src/pages/upload/setup/SetupPage.tsx
+++ b/frontend/src/pages/upload/setup/SetupPage.tsx
@@ -45,7 +45,7 @@ function deriveInitialSummaryModes(manualOnlySummaries: boolean): ProjectSummary
 export default function UploadSetupPage() {
   const username = getUsername();
   const nav = useNavigate();
-  const [searchParams] = useSearchParams();
+  const [searchParams, setSearchParams] = useSearchParams();
   const [readiness, setReadiness] = useState<RunPreflightRecord | null>(null);
   const [checkingReadiness, setCheckingReadiness] = useState(false);
   const [confirmOpen, setConfirmOpen] = useState(false);
@@ -59,6 +59,59 @@ export default function UploadSetupPage() {
     if (flow.hasValidUploadId) return;
     nav("/upload/upload", { replace: true });
   }, [flow.hasValidUploadId, nav]);
+
+  useEffect(() => {
+    const githubStatus = searchParams.get("github");
+    if (githubStatus === "success") {
+      if (window.opener) {
+        window.opener.postMessage({ type: "github-auth-success" }, window.location.origin);
+        window.close();
+        return;
+      }
+      if (flow.hasValidUploadId) {
+        void flow.refreshUpload();
+      }
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          p.delete("github");
+          return Object.fromEntries(p.entries());
+        },
+        { replace: true },
+      );
+    } else if (githubStatus === "error") {
+      if (window.opener) {
+        const errorMsg = searchParams.get("message") ?? "GitHub authorization failed.";
+        window.opener.postMessage({ type: "github-auth-error", message: errorMsg }, window.location.origin);
+        window.close();
+        return;
+      }
+      const errorMsg = searchParams.get("message") ?? "GitHub authorization failed.";
+      flow.setActionError(errorMsg);
+      setSearchParams(
+        (prev) => {
+          const p = new URLSearchParams(prev);
+          p.delete("github");
+          p.delete("message");
+          return Object.fromEntries(p.entries());
+        },
+        { replace: true },
+      );
+    }
+  }, [searchParams, flow.hasValidUploadId, flow.refreshUpload, flow.setActionError, setSearchParams]);
+
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type === "github-auth-success") {
+        void flow.refreshUpload();
+      } else if (event.data?.type === "github-auth-error") {
+        flow.setActionError(event.data.message ?? "GitHub authorization failed.");
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [flow.refreshUpload, flow.setActionError]);
 
   useEffect(() => {
     if (!flow.uploadNotFound) return;

--- a/frontend/src/pages/upload/setup/components/RepoSearchDropdown.tsx
+++ b/frontend/src/pages/upload/setup/components/RepoSearchDropdown.tsx
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import type { GitHubRepo } from "../../../../api/uploads";
+
+type Props = {
+  repos: GitHubRepo[];
+  selectedRepo: string;
+  onSelect: (fullName: string) => void;
+  disabled?: boolean;
+};
+
+function ChevronIcon({ direction }: { direction: "up" | "down" }) {
+  const d = direction === "up" ? "M3 10 L8 5 L13 10 Z" : "M3 6 L8 11 L13 6 Z";
+  return (
+    <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+      <path d={d} />
+    </svg>
+  );
+}
+
+/**
+ * Searchable dropdown for selecting a GitHub repository.
+ * Renders the option list in a portal above the input to avoid
+ * parent overflow clipping.
+ */
+export default function RepoSearchDropdown({ repos, selectedRepo, onSelect, disabled }: Props) {
+  const [query, setQuery] = useState(selectedRepo);
+  const [open, setOpen] = useState(false);
+
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [style, setStyle] = useState<{ bottom: number; left: number; width: number } | null>(null);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter((r) => r.full_name.toLowerCase().includes(q));
+  }, [repos, query]);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  // Keep the display text in sync with external selection changes
+  useEffect(() => {
+    setQuery(selectedRepo);
+  }, [selectedRepo]);
+
+  // Position the dropdown above the input
+  useLayoutEffect(() => {
+    if (open && inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setStyle({
+        bottom: window.innerHeight - rect.top + 4,
+        left: rect.left,
+        width: rect.width,
+      });
+    } else {
+      setStyle(null);
+    }
+  }, [open]);
+
+  // Close on outside click or external scroll
+  useEffect(() => {
+    if (!open) return;
+
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      if (inputRef.current?.contains(target) || dropdownRef.current?.contains(target)) return;
+      close();
+    }
+
+    function handleScroll(e: Event) {
+      if (dropdownRef.current?.contains(e.target as Node)) return;
+      close();
+    }
+
+    document.addEventListener("mousedown", handleClickOutside);
+    window.addEventListener("scroll", handleScroll, true);
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      window.removeEventListener("scroll", handleScroll, true);
+    };
+  }, [open, close]);
+
+  return (
+    <div className="relative">
+      <input
+        ref={inputRef}
+        type="text"
+        value={open ? query : selectedRepo || ""}
+        onChange={(e) => {
+          setQuery(e.target.value);
+          setOpen(true);
+        }}
+        onFocus={() => setOpen(true)}
+        placeholder="Select a repository..."
+        className="h-12 w-full rounded border border-zinc-300 bg-zinc-50 px-4 py-3 pr-10 text-sm text-zinc-700 placeholder:text-zinc-400"
+        disabled={disabled}
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        aria-label="Search repositories"
+      />
+
+      <span
+        className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-zinc-500"
+        onClick={() => inputRef.current?.focus()}
+        role="button"
+        aria-label={open ? "Close repository list" : "Open repository list"}
+      >
+        <ChevronIcon direction={open ? "down" : "up"} />
+      </span>
+
+      {open &&
+        style &&
+        createPortal(
+          <div
+            ref={dropdownRef}
+            className="fixed z-[9999] max-h-48 overflow-y-auto rounded border border-zinc-300 bg-white shadow-lg"
+            role="listbox"
+            style={{ bottom: style.bottom, left: style.left, width: style.width }}
+          >
+            {filtered.length === 0 ? (
+              <div className="px-4 py-3 text-sm text-zinc-500">No matching repositories</div>
+            ) : (
+              filtered.map((repo) => (
+                <button
+                  key={repo.full_name}
+                  type="button"
+                  role="option"
+                  aria-selected={selectedRepo === repo.full_name}
+                  className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 ${
+                    selectedRepo === repo.full_name ? "bg-zinc-100 font-medium" : "text-zinc-700"
+                  }`}
+                  onClick={() => {
+                    onSelect(repo.full_name);
+                    setQuery(repo.full_name);
+                    setOpen(false);
+                  }}
+                >
+                  {repo.full_name}
+                </button>
+              ))
+            )}
+          </div>,
+          document.body,
+        )}
+    </div>
+  );
+}

--- a/frontend/src/pages/upload/setup/components/__tests__/RepoSearchDropdown.test.tsx
+++ b/frontend/src/pages/upload/setup/components/__tests__/RepoSearchDropdown.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import RepoSearchDropdown from "../RepoSearchDropdown";
+
+const mockRepos = [
+  { full_name: "owner/repo-a" },
+  { full_name: "owner/repo-b" },
+  { full_name: "other/mylib" },
+];
+
+describe("RepoSearchDropdown", () => {
+  it("renders input with placeholder", () => {
+    render(
+      <RepoSearchDropdown repos={mockRepos} selectedRepo="" onSelect={vi.fn()} />,
+    );
+    expect(screen.getByPlaceholderText("Select a repository...")).toBeInTheDocument();
+  });
+
+  it("displays selected repo when one is selected", () => {
+    render(
+      <RepoSearchDropdown
+        repos={mockRepos}
+        selectedRepo="owner/repo-a"
+        onSelect={vi.fn()}
+      />,
+    );
+    expect(screen.getByDisplayValue("owner/repo-a")).toBeInTheDocument();
+  });
+
+  it("filters repos by search query", async () => {
+    const user = userEvent.setup();
+    render(
+      <RepoSearchDropdown repos={mockRepos} selectedRepo="" onSelect={vi.fn()} />,
+    );
+    const input = screen.getByPlaceholderText("Select a repository...");
+    await user.click(input);
+    await user.type(input, "owner");
+    expect(screen.getByRole("option", { name: "owner/repo-a" })).toBeInTheDocument();
+    expect(screen.getByRole("option", { name: "owner/repo-b" })).toBeInTheDocument();
+    expect(screen.queryByRole("option", { name: "other/mylib" })).not.toBeInTheDocument();
+  });
+
+  it("calls onSelect when a repo option is clicked", async () => {
+    const user = userEvent.setup();
+    const onSelect = vi.fn();
+    render(
+      <RepoSearchDropdown repos={mockRepos} selectedRepo="" onSelect={onSelect} />,
+    );
+    await user.click(screen.getByPlaceholderText("Select a repository..."));
+    await user.click(screen.getByRole("option", { name: "owner/repo-b" }));
+    expect(onSelect).toHaveBeenCalledWith("owner/repo-b");
+  });
+
+  it("disables input when disabled prop is true", () => {
+    render(
+      <RepoSearchDropdown repos={mockRepos} selectedRepo="" onSelect={vi.fn()} disabled />,
+    );
+    expect(screen.getByPlaceholderText("Select a repository...")).toBeDisabled();
+  });
+
+  it("shows no matching message when filter has no results", async () => {
+    const user = userEvent.setup();
+    render(
+      <RepoSearchDropdown repos={mockRepos} selectedRepo="" onSelect={vi.fn()} />,
+    );
+    const input = screen.getByPlaceholderText("Select a repository...");
+    await user.click(input);
+    await user.type(input, "nonexistent");
+    expect(screen.getByText("No matching repositories")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/upload/setup/components/sections/CodeSetupSection.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/CodeSetupSection.tsx
@@ -1,4 +1,5 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { GitHubRepo, GitIdentityOption } from "../../../../../api/uploads";
 import type { SetupFlowResult, SetupProjectCard } from "../../types";
 
@@ -32,6 +33,23 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
   const [repos, setRepos] = useState<GitHubRepo[]>([]);
   const [selectedRepo, setSelectedRepo] = useState(project.githubRepoFullName ?? "");
   const [reposLoading, setReposLoading] = useState(false);
+  const [repoSearchQuery, setRepoSearchQuery] = useState("");
+  const [repoListOpen, setRepoListOpen] = useState(false);
+  const repoListRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const [dropdownStyle, setDropdownStyle] = useState<{ bottom: number; left: number; width: number } | null>(null);
+
+  const filteredRepos = useMemo(() => {
+    const q = repoSearchQuery.trim().toLowerCase();
+    if (!q) return repos;
+    return repos.filter((r) => r.full_name.toLowerCase().includes(q));
+  }, [repos, repoSearchQuery]);
+
+  const hideRepoList = useCallback(() => {
+    setRepoListOpen(false);
+  }, []);
+
   const [authUrl, setAuthUrl] = useState<string | null>(null);
   const [githubMessage, setGithubMessage] = useState<string | null>(null);
 
@@ -50,8 +68,74 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
   }, [project.gitSelectedIdentityIndices]);
 
   useEffect(() => {
-    setSelectedRepo(project.githubRepoFullName ?? "");
+    const fullName = project.githubRepoFullName ?? "";
+    setSelectedRepo(fullName);
+    if (fullName) setRepoSearchQuery(fullName);
   }, [project.githubRepoFullName]);
+
+  useLayoutEffect(() => {
+    if (repoListOpen && inputRef.current) {
+      const rect = inputRef.current.getBoundingClientRect();
+      setDropdownStyle({
+        bottom: window.innerHeight - rect.top + 4,
+        left: rect.left,
+        width: rect.width,
+      });
+    } else {
+      setDropdownStyle(null);
+    }
+  }, [repoListOpen]);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      const target = e.target as Node;
+      const inInput = inputRef.current?.contains(target);
+      const inDropdown = dropdownRef.current?.contains(target);
+      if (!inInput && !inDropdown) {
+        hideRepoList();
+      }
+    }
+    function handleScroll(e: Event) {
+      const target = e.target as Node;
+      if (dropdownRef.current?.contains(target)) return;
+      hideRepoList();
+    }
+    if (repoListOpen) {
+      document.addEventListener("mousedown", handleClickOutside);
+      window.addEventListener("scroll", handleScroll, true);
+      return () => {
+        document.removeEventListener("mousedown", handleClickOutside);
+        window.removeEventListener("scroll", handleScroll, true);
+      };
+    }
+  }, [repoListOpen, hideRepoList]);
+
+  useEffect(() => {
+    if (
+      project.githubState !== "connected" ||
+      repos.length > 0 ||
+      reposLoading ||
+      project.githubRepoLinked
+    ) {
+      return;
+    }
+    let active = true;
+    setReposLoading(true);
+    setGithubMessage(null);
+    actions
+      .githubRepos(project.projectName)
+      .then((data) => {
+        if (!active || !data) return;
+        setRepos(data.repos);
+        setGithubMessage(data.repos.length > 0 ? "Repositories loaded. Search and select one, then click Link." : "No repositories found.");
+      })
+      .finally(() => {
+        if (active) setReposLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  }, [project.githubState, project.githubRepoLinked, project.projectName, actions]);
 
   useEffect(() => {
     if (project.projectKey === null) {
@@ -126,7 +210,13 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
     }
 
     if (data.auth_url) {
-      setGithubMessage("Continue with GitHub OAuth using the link below.");
+      const opened = window.open(data.auth_url, "_blank");
+      if (opened) {
+        setGithubMessage("Authorize in the new tab. It will close automatically when done.");
+      } else {
+        setGithubMessage("Popup was blocked. Click the link below to authorize.");
+      }
+      setGithubMessage("Click “Open GitHub Authorization” to authorize in your browser.");
       return;
     }
 
@@ -141,10 +231,7 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
     if (!data) return;
 
     setRepos(data.repos);
-    if (!selectedRepo && data.repos.length > 0) {
-      setSelectedRepo(data.repos[0].full_name);
-    }
-    setGithubMessage(data.repos.length > 0 ? "Repositories loaded." : "No repositories found.");
+    setGithubMessage(data.repos.length > 0 ? "Repositories loaded. Search and select one, then click Link." : "No repositories found.");
   }
 
   async function onLinkRepo() {
@@ -213,75 +300,158 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
 
       <div className="space-y-3">
         <h4 className="text-lg leading-tight font-semibold text-zinc-900">GitHub Integration</h4>
-        <p className="text-sm text-zinc-700">
-          State: <span className="font-medium">{project.githubState}</span>
-          {project.githubRepoLinked && project.githubRepoFullName ? ` | Linked repo: ${project.githubRepoFullName}` : ""}
-        </p>
-        {!localGitDetected && project.classification === "collaborative" && (
+        {project.githubRepoLinked && project.githubRepoFullName ? (
           <p className="text-sm text-zinc-700">
+            Linked repo: <span className="font-medium">{project.githubRepoFullName}</span>
+          </p>
+        ) : (
+          <>
+            {project.githubState !== "connected" ? (
+              <div className="space-y-2">
+                <p className="text-sm text-zinc-700">
+                  <strong>Step 1:</strong> Connect your GitHub account to fetch your repositories.
+                </p>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    type="button"
+                    onClick={() => onGithubStart(true)}
+                    disabled={isMutating}
+                    className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+                  >
+                    Connect GitHub
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => onGithubStart(false)}
+                    disabled={isMutating}
+                    className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-600 hover:bg-zinc-50 disabled:opacity-50"
+                  >
+                    Skip GitHub
+                  </button>
+                </div>
+              </div>
+            ) : reposLoading ? (
+              <p className="text-sm text-zinc-700">Loading your repositories...</p>
+            ) : repos.length === 0 ? (
+              <div className="space-y-2">
+                <p className="text-sm text-zinc-700">
+                  <strong>Step 2:</strong> Load your repositories from GitHub.
+                </p>
+                <button
+                  type="button"
+                  onClick={onLoadRepos}
+                  disabled={isMutating || reposLoading}
+                  className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
+                >
+                  Load repositories
+                </button>
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <p className="text-sm text-zinc-700">
+                  <strong>Step 3:</strong> Select the repo that matches this project and link it.
+                </p>
+              </div>
+            )}
+            {authUrl && (
+              <a
+                href={authUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="text-sm text-[#0969da] hover:underline"
+              >
+                Open GitHub Authorization (if the tab didn&apos;t open)
+              </a>
+            )}
+          </>
+        )}
+        {!localGitDetected && project.classification === "collaborative" && (
+          <p className="text-sm text-zinc-600">
             With no local .git history, collaborative identity is inferred from the connected GitHub account during analysis.
           </p>
         )}
 
-        <div className="flex flex-wrap gap-2">
-          <button
-            type="button"
-            onClick={() => onGithubStart(true)}
-            disabled={isMutating}
-            className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 disabled:opacity-50"
-          >
-            Connect GitHub
-          </button>
-          <button
-            type="button"
-            onClick={() => onGithubStart(false)}
-            disabled={isMutating}
-            className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 disabled:opacity-50"
-          >
-            Skip for now
-          </button>
-          <button
-            type="button"
-            onClick={onLoadRepos}
-            disabled={isMutating || reposLoading}
-            className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 disabled:opacity-50"
-          >
-            {reposLoading ? "Loading..." : "Load repositories"}
-          </button>
-        </div>
-
-        {authUrl && (
-          <a
-            href={authUrl}
-            target="_blank"
-            rel="noreferrer"
-            className="inline-flex items-center rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-[#001166]"
-          >
-            Open GitHub Authorization
-          </a>
-        )}
-
         {repos.length > 0 && (
-          <div className="space-y-2">
-            <select
-              value={selectedRepo}
-              onChange={(event) => setSelectedRepo(event.target.value)}
-              className="h-12 w-full rounded border border-zinc-300 bg-zinc-50 px-4 py-3 text-sm text-zinc-700"
-              disabled={isMutating}
-            >
-              {repos.map((repo) => (
-                <option key={repo.full_name} value={repo.full_name}>
-                  {repo.full_name}
-                </option>
-              ))}
-            </select>
+          <div className="space-y-2" ref={repoListRef}>
+            <div className="relative">
+              <input
+                ref={inputRef}
+                type="text"
+                value={repoListOpen ? repoSearchQuery : selectedRepo || ""}
+                onChange={(e) => {
+                  setRepoSearchQuery(e.target.value);
+                  setRepoListOpen(true);
+                }}
+                onFocus={() => setRepoListOpen(true)}
+                placeholder="Select a repository..."
+                className="h-12 w-full rounded border border-zinc-300 bg-zinc-50 px-4 py-3 pr-10 text-sm text-zinc-700 placeholder:text-zinc-400"
+                disabled={isMutating}
+                aria-expanded={repoListOpen}
+                aria-haspopup="listbox"
+                aria-label="Search repositories"
+              />
+              <span
+                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-zinc-500"
+                onClick={() => inputRef.current?.focus()}
+                role="button"
+                aria-label={repoListOpen ? "Close repository list" : "Open repository list"}
+              >
+                {repoListOpen ? (
+                  <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M3 6 L8 11 L13 6 Z" />
+                  </svg>
+                ) : (
+                  <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
+                    <path d="M3 10 L8 5 L13 10 Z" />
+                  </svg>
+                )}
+              </span>
+              {repoListOpen &&
+                dropdownStyle &&
+                createPortal(
+                  <div
+                    ref={dropdownRef}
+                    className="fixed z-[9999] max-h-48 overflow-y-auto rounded border border-zinc-300 bg-white shadow-lg"
+                    role="listbox"
+                    style={{
+                      bottom: dropdownStyle.bottom,
+                      left: dropdownStyle.left,
+                      width: dropdownStyle.width,
+                    }}
+                  >
+                    {filteredRepos.length === 0 ? (
+                      <div className="px-4 py-3 text-sm text-zinc-500">No matching repositories</div>
+                    ) : (
+                      filteredRepos.map((repo) => (
+                        <button
+                          key={repo.full_name}
+                          type="button"
+                          role="option"
+                          aria-selected={selectedRepo === repo.full_name}
+                          className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 ${
+                            selectedRepo === repo.full_name ? "bg-zinc-100 font-medium" : "text-zinc-700"
+                          }`}
+                          onClick={() => {
+                            setSelectedRepo(repo.full_name);
+                            setRepoSearchQuery(repo.full_name);
+                            setRepoListOpen(false);
+                          }}
+                        >
+                          {repo.full_name}
+                        </button>
+                      ))
+                    )}
+                  </div>,
+                  document.body,
+                )}
+            </div>
             <button
               type="button"
               onClick={onLinkRepo}
               disabled={isMutating || !selectedRepo}
-              className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 disabled:opacity-50"
+              className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
             >
-              Link selected repository
+              Link repository
             </button>
           </div>
         )}

--- a/frontend/src/pages/upload/setup/components/sections/CodeSetupSection.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/CodeSetupSection.tsx
@@ -1,7 +1,7 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
-import type { GitHubRepo, GitIdentityOption } from "../../../../../api/uploads";
+import { useEffect, useMemo, useState } from "react";
+import type { GitIdentityOption } from "../../../../../api/uploads";
 import type { SetupFlowResult, SetupProjectCard } from "../../types";
+import GitHubIntegrationSection from "./GitHubIntegrationSection";
 
 type Props = {
   project: SetupProjectCard;
@@ -30,29 +30,6 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
   const [identityMessage, setIdentityMessage] = useState<string | null>(null);
   const [localGitDetected, setLocalGitDetected] = useState<boolean | null>(null);
 
-  const [repos, setRepos] = useState<GitHubRepo[]>([]);
-  const [selectedRepo, setSelectedRepo] = useState(project.githubRepoFullName ?? "");
-  const [reposLoading, setReposLoading] = useState(false);
-  const [repoSearchQuery, setRepoSearchQuery] = useState("");
-  const [repoListOpen, setRepoListOpen] = useState(false);
-  const repoListRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const [dropdownStyle, setDropdownStyle] = useState<{ bottom: number; left: number; width: number } | null>(null);
-
-  const filteredRepos = useMemo(() => {
-    const q = repoSearchQuery.trim().toLowerCase();
-    if (!q) return repos;
-    return repos.filter((r) => r.full_name.toLowerCase().includes(q));
-  }, [repos, repoSearchQuery]);
-
-  const hideRepoList = useCallback(() => {
-    setRepoListOpen(false);
-  }, []);
-
-  const [authUrl, setAuthUrl] = useState<string | null>(null);
-  const [githubMessage, setGithubMessage] = useState<string | null>(null);
-
   const canPickIdentities =
     project.classification === "collaborative" &&
     localGitDetected === true &&
@@ -67,76 +44,7 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
     setSelectedIndices(project.gitSelectedIdentityIndices);
   }, [project.gitSelectedIdentityIndices]);
 
-  useEffect(() => {
-    const fullName = project.githubRepoFullName ?? "";
-    setSelectedRepo(fullName);
-    if (fullName) setRepoSearchQuery(fullName);
-  }, [project.githubRepoFullName]);
-
-  useLayoutEffect(() => {
-    if (repoListOpen && inputRef.current) {
-      const rect = inputRef.current.getBoundingClientRect();
-      setDropdownStyle({
-        bottom: window.innerHeight - rect.top + 4,
-        left: rect.left,
-        width: rect.width,
-      });
-    } else {
-      setDropdownStyle(null);
-    }
-  }, [repoListOpen]);
-
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      const target = e.target as Node;
-      const inInput = inputRef.current?.contains(target);
-      const inDropdown = dropdownRef.current?.contains(target);
-      if (!inInput && !inDropdown) {
-        hideRepoList();
-      }
-    }
-    function handleScroll(e: Event) {
-      const target = e.target as Node;
-      if (dropdownRef.current?.contains(target)) return;
-      hideRepoList();
-    }
-    if (repoListOpen) {
-      document.addEventListener("mousedown", handleClickOutside);
-      window.addEventListener("scroll", handleScroll, true);
-      return () => {
-        document.removeEventListener("mousedown", handleClickOutside);
-        window.removeEventListener("scroll", handleScroll, true);
-      };
-    }
-  }, [repoListOpen, hideRepoList]);
-
-  useEffect(() => {
-    if (
-      project.githubState !== "connected" ||
-      repos.length > 0 ||
-      reposLoading ||
-      project.githubRepoLinked
-    ) {
-      return;
-    }
-    let active = true;
-    setReposLoading(true);
-    setGithubMessage(null);
-    actions
-      .githubRepos(project.projectName)
-      .then((data) => {
-        if (!active || !data) return;
-        setRepos(data.repos);
-        setGithubMessage(data.repos.length > 0 ? "Repositories loaded. Search and select one, then click Link." : "No repositories found.");
-      })
-      .finally(() => {
-        if (active) setReposLoading(false);
-      });
-    return () => {
-      active = false;
-    };
-  }, [project.githubState, project.githubRepoLinked, project.projectName, actions]);
-
+  // Detect local .git and load contributor identities
   useEffect(() => {
     if (project.projectKey === null) {
       setLocalGitDetected(null);
@@ -157,13 +65,11 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
         setLocalGitDetected(true);
         setIdentities(gitData.options);
         setSelectedIndices(gitData.selected_indices);
-        setIdentitiesLoading(false);
-        return;
+      } else {
+        setLocalGitDetected(false);
+        setIdentities([]);
+        setSelectedIndices([]);
       }
-
-      setLocalGitDetected(false);
-      setIdentities([]);
-      setSelectedIndices([]);
       setIdentitiesLoading(false);
     }
 
@@ -198,51 +104,9 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
     setIdentityMessage("Identity selection saved.");
   }
 
-  async function onGithubStart(connectNow: boolean) {
-    setGithubMessage(null);
-    const data = await actions.githubStart(project.projectName, connectNow);
-    if (!data) return;
-
-    setAuthUrl(data.auth_url ?? null);
-    if (!connectNow) {
-      setGithubMessage("GitHub integration skipped for now.");
-      return;
-    }
-
-    if (data.auth_url) {
-      const opened = window.open(data.auth_url, "_blank");
-      if (opened) {
-        setGithubMessage("Authorize in the new tab. It will close automatically when done.");
-      } else {
-        setGithubMessage("Popup was blocked. Click the link below to authorize.");
-      }
-      setGithubMessage("Click “Open GitHub Authorization” to authorize in your browser.");
-      return;
-    }
-
-    setGithubMessage("GitHub is connected.");
-  }
-
-  async function onLoadRepos() {
-    setReposLoading(true);
-    setGithubMessage(null);
-    const data = await actions.githubRepos(project.projectName);
-    setReposLoading(false);
-    if (!data) return;
-
-    setRepos(data.repos);
-    setGithubMessage(data.repos.length > 0 ? "Repositories loaded. Search and select one, then click Link." : "No repositories found.");
-  }
-
-  async function onLinkRepo() {
-    if (!selectedRepo) return;
-    const data = await actions.githubLink(project.projectName, selectedRepo);
-    if (!data) return;
-    setGithubMessage("Repository linked.");
-  }
-
   return (
     <div className="space-y-4">
+      {/* --- Git Detection --- */}
       <div className="space-y-2">
         <h4 className="text-lg leading-tight font-semibold text-zinc-900">Git Detection</h4>
         <p className="text-sm leading-relaxed text-zinc-700">{identitySummary}</p>
@@ -254,6 +118,7 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
         </p>
       )}
 
+      {/* --- Identity picker (collaborative projects with a .git repo) --- */}
       {canPickIdentities && (
         <div className="space-y-3">
           <div className="text-sm font-semibold text-zinc-900">Select your identity (collaborative code)</div>
@@ -298,166 +163,13 @@ export default function CodeSetupSection({ project, actions, isMutating }: Props
         </div>
       )}
 
-      <div className="space-y-3">
-        <h4 className="text-lg leading-tight font-semibold text-zinc-900">GitHub Integration</h4>
-        {project.githubRepoLinked && project.githubRepoFullName ? (
-          <p className="text-sm text-zinc-700">
-            Linked repo: <span className="font-medium">{project.githubRepoFullName}</span>
-          </p>
-        ) : (
-          <>
-            {project.githubState !== "connected" ? (
-              <div className="space-y-2">
-                <p className="text-sm text-zinc-700">
-                  <strong>Step 1:</strong> Connect your GitHub account to fetch your repositories.
-                </p>
-                <div className="flex flex-wrap gap-2">
-                  <button
-                    type="button"
-                    onClick={() => onGithubStart(true)}
-                    disabled={isMutating}
-                    className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
-                  >
-                    Connect GitHub
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onGithubStart(false)}
-                    disabled={isMutating}
-                    className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-600 hover:bg-zinc-50 disabled:opacity-50"
-                  >
-                    Skip GitHub
-                  </button>
-                </div>
-              </div>
-            ) : reposLoading ? (
-              <p className="text-sm text-zinc-700">Loading your repositories...</p>
-            ) : repos.length === 0 ? (
-              <div className="space-y-2">
-                <p className="text-sm text-zinc-700">
-                  <strong>Step 2:</strong> Load your repositories from GitHub.
-                </p>
-                <button
-                  type="button"
-                  onClick={onLoadRepos}
-                  disabled={isMutating || reposLoading}
-                  className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
-                >
-                  Load repositories
-                </button>
-              </div>
-            ) : (
-              <div className="space-y-2">
-                <p className="text-sm text-zinc-700">
-                  <strong>Step 3:</strong> Select the repo that matches this project and link it.
-                </p>
-              </div>
-            )}
-            {authUrl && (
-              <a
-                href={authUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="text-sm text-[#0969da] hover:underline"
-              >
-                Open GitHub Authorization (if the tab didn&apos;t open)
-              </a>
-            )}
-          </>
-        )}
-        {!localGitDetected && project.classification === "collaborative" && (
-          <p className="text-sm text-zinc-600">
-            With no local .git history, collaborative identity is inferred from the connected GitHub account during analysis.
-          </p>
-        )}
-
-        {repos.length > 0 && (
-          <div className="space-y-2" ref={repoListRef}>
-            <div className="relative">
-              <input
-                ref={inputRef}
-                type="text"
-                value={repoListOpen ? repoSearchQuery : selectedRepo || ""}
-                onChange={(e) => {
-                  setRepoSearchQuery(e.target.value);
-                  setRepoListOpen(true);
-                }}
-                onFocus={() => setRepoListOpen(true)}
-                placeholder="Select a repository..."
-                className="h-12 w-full rounded border border-zinc-300 bg-zinc-50 px-4 py-3 pr-10 text-sm text-zinc-700 placeholder:text-zinc-400"
-                disabled={isMutating}
-                aria-expanded={repoListOpen}
-                aria-haspopup="listbox"
-                aria-label="Search repositories"
-              />
-              <span
-                className="absolute right-3 top-1/2 -translate-y-1/2 cursor-pointer text-zinc-500"
-                onClick={() => inputRef.current?.focus()}
-                role="button"
-                aria-label={repoListOpen ? "Close repository list" : "Open repository list"}
-              >
-                {repoListOpen ? (
-                  <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M3 6 L8 11 L13 6 Z" />
-                  </svg>
-                ) : (
-                  <svg className="h-4 w-4" viewBox="0 0 16 16" fill="currentColor">
-                    <path d="M3 10 L8 5 L13 10 Z" />
-                  </svg>
-                )}
-              </span>
-              {repoListOpen &&
-                dropdownStyle &&
-                createPortal(
-                  <div
-                    ref={dropdownRef}
-                    className="fixed z-[9999] max-h-48 overflow-y-auto rounded border border-zinc-300 bg-white shadow-lg"
-                    role="listbox"
-                    style={{
-                      bottom: dropdownStyle.bottom,
-                      left: dropdownStyle.left,
-                      width: dropdownStyle.width,
-                    }}
-                  >
-                    {filteredRepos.length === 0 ? (
-                      <div className="px-4 py-3 text-sm text-zinc-500">No matching repositories</div>
-                    ) : (
-                      filteredRepos.map((repo) => (
-                        <button
-                          key={repo.full_name}
-                          type="button"
-                          role="option"
-                          aria-selected={selectedRepo === repo.full_name}
-                          className={`block w-full px-4 py-2.5 text-left text-sm hover:bg-zinc-100 ${
-                            selectedRepo === repo.full_name ? "bg-zinc-100 font-medium" : "text-zinc-700"
-                          }`}
-                          onClick={() => {
-                            setSelectedRepo(repo.full_name);
-                            setRepoSearchQuery(repo.full_name);
-                            setRepoListOpen(false);
-                          }}
-                        >
-                          {repo.full_name}
-                        </button>
-                      ))
-                    )}
-                  </div>,
-                  document.body,
-                )}
-            </div>
-            <button
-              type="button"
-              onClick={onLinkRepo}
-              disabled={isMutating || !selectedRepo}
-              className="rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50"
-            >
-              Link repository
-            </button>
-          </div>
-        )}
-
-        {githubMessage && <p className="text-sm text-zinc-700">{githubMessage}</p>}
-      </div>
+      {/* --- GitHub Integration (connect, load repos, link) --- */}
+      <GitHubIntegrationSection
+        project={project}
+        actions={actions}
+        isMutating={isMutating}
+        localGitDetected={localGitDetected}
+      />
     </div>
   );
 }

--- a/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
@@ -73,7 +73,7 @@ export default function GitHubIntegrationSection({ project, actions, isMutating,
       setMessage(
         opened
           ? "Authorize in the new tab. It will close automatically when done."
-          : "Popup was blocked. Click the link below to authorize.",
+          : "Popup was blocked. Try Connect GitHub again or allow popups for this site.",
       );
       return;
     }

--- a/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
@@ -140,7 +140,12 @@ export default function GitHubIntegrationSection({ project, actions, isMutating,
             onSelect={setSelectedRepo}
             disabled={isMutating}
           />
-          <button type="button" onClick={onLinkRepo} disabled={isMutating || !selectedRepo} className={BTN_PRIMARY}>
+          <button
+            type="button"
+            onClick={onLinkRepo}
+            disabled={isMutating || !selectedRepo}
+            className="rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-900 hover:bg-zinc-50 disabled:opacity-50"
+          >
             Link repository
           </button>
         </div>
@@ -189,7 +194,15 @@ function StepContent({
   }
 
   if (reposLoading) {
-    return <p className="text-sm text-zinc-700">Loading your repositories...</p>;
+    return (
+      <div className="flex items-center gap-2">
+        <span
+          className="h-4 w-4 animate-spin rounded-full border-2 border-zinc-300 border-t-zinc-600"
+          aria-hidden
+        />
+        <p className="text-sm text-zinc-700">Loading your repositories...</p>
+      </div>
+    );
   }
 
   if (reposCount === 0) {

--- a/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/GitHubIntegrationSection.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from "react";
+import type { GitHubRepo } from "../../../../../api/uploads";
+import type { SetupFlowResult, SetupProjectCard } from "../../types";
+import RepoSearchDropdown from "../RepoSearchDropdown";
+
+type Props = {
+  project: SetupProjectCard;
+  actions: SetupFlowResult["actions"];
+  isMutating: boolean;
+  localGitDetected: boolean | null;
+};
+
+const BTN_PRIMARY = "rounded bg-zinc-900 px-4 py-2 text-sm font-medium text-white hover:bg-zinc-800 disabled:opacity-50";
+const BTN_SECONDARY = "rounded border border-zinc-300 bg-white px-3 py-1.5 text-sm font-medium text-zinc-600 hover:bg-zinc-50 disabled:opacity-50";
+
+export default function GitHubIntegrationSection({ project, actions, isMutating, localGitDetected }: Props) {
+  const [repos, setRepos] = useState<GitHubRepo[]>([]);
+  const [selectedRepo, setSelectedRepo] = useState(project.githubRepoFullName ?? "");
+  const [reposLoading, setReposLoading] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  // Sync external repo name into local state (e.g. after a refresh)
+  useEffect(() => {
+    const fullName = project.githubRepoFullName ?? "";
+    setSelectedRepo(fullName);
+  }, [project.githubRepoFullName]);
+
+  // Auto-load repos after returning from OAuth (githubState flips to "connected")
+  useEffect(() => {
+    if (
+      project.githubState !== "connected" ||
+      repos.length > 0 ||
+      reposLoading ||
+      project.githubRepoLinked
+    ) {
+      return;
+    }
+    let active = true;
+    setReposLoading(true);
+    setMessage(null);
+    actions
+      .githubRepos(project.projectName)
+      .then((data) => {
+        if (!active || !data) return;
+        setRepos(data.repos);
+        setMessage(
+          data.repos.length > 0
+            ? "Repositories loaded. Search and select one, then click Link."
+            : "No repositories found.",
+        );
+      })
+      .finally(() => {
+        if (active) setReposLoading(false);
+      });
+    return () => {
+      active = false;
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps -- repos.length and reposLoading are guards, not triggers
+  }, [project.githubState, project.githubRepoLinked, project.projectName, actions]);
+
+  async function onConnect(connectNow: boolean) {
+    setMessage(null);
+    const data = await actions.githubStart(project.projectName, connectNow);
+    if (!data) return;
+
+    if (!connectNow) {
+      setMessage("GitHub integration skipped for now.");
+      return;
+    }
+
+    if (data.auth_url) {
+      const opened = window.open(data.auth_url, "_blank");
+      setMessage(
+        opened
+          ? "Authorize in the new tab. It will close automatically when done."
+          : "Popup was blocked. Click the link below to authorize.",
+      );
+      return;
+    }
+
+    setMessage("GitHub is connected.");
+  }
+
+  async function onLoadRepos() {
+    setReposLoading(true);
+    setMessage(null);
+    const data = await actions.githubRepos(project.projectName);
+    setReposLoading(false);
+    if (!data) return;
+    setRepos(data.repos);
+    setMessage(
+      data.repos.length > 0
+        ? "Repositories loaded. Search and select one, then click Link."
+        : "No repositories found.",
+    );
+  }
+
+  async function onLinkRepo() {
+    if (!selectedRepo) return;
+    const data = await actions.githubLink(project.projectName, selectedRepo);
+    if (!data) return;
+    setMessage("Repository linked.");
+  }
+
+  // --- Render helpers ---
+
+  const linked = project.githubRepoLinked && project.githubRepoFullName;
+
+  return (
+    <div className="space-y-3">
+      <h4 className="text-lg leading-tight font-semibold text-zinc-900">GitHub Integration</h4>
+
+      {linked ? (
+        <p className="text-sm text-zinc-700">
+          Linked repo: <span className="font-medium">{project.githubRepoFullName}</span>
+        </p>
+      ) : (
+        <StepContent
+          githubState={project.githubState}
+          reposLoading={reposLoading}
+          reposCount={repos.length}
+          isMutating={isMutating}
+          onConnect={onConnect}
+          onLoadRepos={onLoadRepos}
+        />
+      )}
+
+      {!localGitDetected && project.classification === "collaborative" && (
+        <p className="text-sm text-zinc-600">
+          With no local .git history, collaborative identity is inferred from the connected GitHub
+          account during analysis.
+        </p>
+      )}
+
+      {repos.length > 0 && (
+        <div className="space-y-2">
+          <RepoSearchDropdown
+            repos={repos}
+            selectedRepo={selectedRepo}
+            onSelect={setSelectedRepo}
+            disabled={isMutating}
+          />
+          <button type="button" onClick={onLinkRepo} disabled={isMutating || !selectedRepo} className={BTN_PRIMARY}>
+            Link repository
+          </button>
+        </div>
+      )}
+
+      {message && <p className="text-sm text-zinc-700">{message}</p>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sub-component: renders only the step-appropriate prompt + buttons
+// ---------------------------------------------------------------------------
+
+function StepContent({
+  githubState,
+  reposLoading,
+  reposCount,
+  isMutating,
+  onConnect,
+  onLoadRepos,
+}: {
+  githubState: string;
+  reposLoading: boolean;
+  reposCount: number;
+  isMutating: boolean;
+  onConnect: (connectNow: boolean) => void;
+  onLoadRepos: () => void;
+}) {
+  if (githubState !== "connected") {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-zinc-700">
+          <strong>Step 1:</strong> Connect your GitHub account to fetch your repositories.
+        </p>
+        <div className="flex flex-wrap gap-2">
+          <button type="button" onClick={() => onConnect(true)} disabled={isMutating} className={BTN_PRIMARY}>
+            Connect GitHub
+          </button>
+          <button type="button" onClick={() => onConnect(false)} disabled={isMutating} className={BTN_SECONDARY}>
+            Skip GitHub
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (reposLoading) {
+    return <p className="text-sm text-zinc-700">Loading your repositories...</p>;
+  }
+
+  if (reposCount === 0) {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-zinc-700">
+          <strong>Step 2:</strong> Load your repositories from GitHub.
+        </p>
+        <button type="button" onClick={onLoadRepos} disabled={isMutating} className={BTN_PRIMARY}>
+          Load repositories
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-sm text-zinc-700">
+        <strong>Step 3:</strong> Select the repo that matches this project and link it.
+      </p>
+    </div>
+  );
+}

--- a/frontend/src/pages/upload/setup/components/sections/__tests__/GitHubIntegrationSection.test.tsx
+++ b/frontend/src/pages/upload/setup/components/sections/__tests__/GitHubIntegrationSection.test.tsx
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import GitHubIntegrationSection from "../GitHubIntegrationSection";
+import type { SetupProjectCard } from "../../../types";
+
+const baseProject: SetupProjectCard = {
+  projectName: "TestProject",
+  projectKey: 1,
+  classification: "collaborative",
+  projectType: "code",
+  gitRepoDetected: true,
+  gitCommitCountHint: 10,
+  gitAuthorCountHint: 2,
+  gitMultiAuthorHint: false,
+  gitSelectedIdentityIndices: [],
+  githubState: "unset",
+  githubRepoLinked: false,
+  githubRepoFullName: null,
+  mainFileRelpath: null,
+  mainSectionIds: [],
+  supportingTextRelpaths: [],
+  supportingCsvRelpaths: [],
+  driveState: "unset",
+  driveLinkedFilesCount: 0,
+  manualProjectSummary: "",
+  manualContributionSummary: "",
+  keyRole: "",
+  statusLabel: "",
+  statusTone: "neutral",
+};
+
+function makeActions() {
+  return {
+    githubStart: vi.fn(),
+    githubRepos: vi.fn(),
+    githubLink: vi.fn(),
+  } as unknown as ReturnType<typeof import("../../../hooks/useSetupFlow")>["actions"];
+}
+
+describe("GitHubIntegrationSection", () => {
+  beforeEach(() => {
+    vi.stubGlobal("window.open", vi.fn(() => ({})));
+  });
+
+  it("shows Step 1 when not connected", () => {
+    const actions = makeActions();
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "unset" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    expect(screen.getByText(/Step 1:/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Connect GitHub/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Skip GitHub/i })).toBeInTheDocument();
+  });
+
+  it("shows linked repo when already linked", () => {
+    render(
+      <GitHubIntegrationSection
+        project={{
+          ...baseProject,
+          githubState: "connected",
+          githubRepoLinked: true,
+          githubRepoFullName: "owner/myrepo",
+        }}
+        actions={makeActions()}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    expect(screen.getByText(/Linked repo:/)).toBeInTheDocument();
+    expect(screen.getByText("owner/myrepo")).toBeInTheDocument();
+  });
+
+  it("shows loading spinner when repos are loading", async () => {
+    const actions = makeActions();
+    actions.githubRepos.mockImplementation(
+      () => new Promise(() => {}),
+    );
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "connected" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Loading your repositories/i)).toBeInTheDocument();
+    });
+    expect(document.querySelector(".animate-spin")).toBeInTheDocument();
+  });
+
+  it("shows Step 2 with Load repositories when connected and no repos", async () => {
+    const actions = makeActions();
+    actions.githubRepos.mockResolvedValue({ repos: [] });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "connected" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Step 2:/)).toBeInTheDocument();
+    });
+    expect(screen.getByRole("button", { name: /Load repositories/i })).toBeInTheDocument();
+  });
+
+  it("shows Step 3, dropdown and Link button when repos are loaded", async () => {
+    const actions = makeActions();
+    actions.githubRepos.mockResolvedValue({
+      repos: [{ full_name: "owner/repo-a" }, { full_name: "owner/repo-b" }],
+    });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "connected" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/Step 3:/)).toBeInTheDocument();
+    });
+    expect(screen.getByPlaceholderText("Select a repository...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Link repository/i })).toBeInTheDocument();
+  });
+
+  it("calls githubStart with connectNow true when Connect GitHub is clicked", async () => {
+    const user = userEvent.setup();
+    const actions = makeActions();
+    actions.githubStart.mockResolvedValue({ auth_url: "https://github.com/auth" });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "unset" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Connect GitHub/i }));
+    expect(actions.githubStart).toHaveBeenCalledWith("TestProject", true);
+  });
+
+  it("calls githubStart with connectNow false when Skip GitHub is clicked", async () => {
+    const user = userEvent.setup();
+    const actions = makeActions();
+    actions.githubStart.mockResolvedValue({ auth_url: null });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "unset" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /Skip GitHub/i }));
+    expect(actions.githubStart).toHaveBeenCalledWith("TestProject", false);
+  });
+
+  it("calls onLoadRepos when Load repositories is clicked", async () => {
+    const user = userEvent.setup();
+    const actions = makeActions();
+    actions.githubRepos.mockResolvedValue({ repos: [] });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "connected" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /Load repositories/i })).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole("button", { name: /Load repositories/i }));
+    expect(actions.githubRepos).toHaveBeenCalledWith("TestProject");
+  });
+
+  it("shows message when no repositories found", async () => {
+    const actions = makeActions();
+    actions.githubRepos.mockResolvedValue({ repos: [] });
+    render(
+      <GitHubIntegrationSection
+        project={{ ...baseProject, githubState: "connected" }}
+        actions={actions}
+        isMutating={false}
+        localGitDetected={true}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/No repositories found/i)).toBeInTheDocument();
+    });
+  });
+});

--- a/frontend/src/pages/upload/setup/hooks/useGitHubOAuthCallback.ts
+++ b/frontend/src/pages/upload/setup/hooks/useGitHubOAuthCallback.ts
@@ -16,10 +16,10 @@ type Deps = {
  *
  * Two paths:
  * 1. **Popup** – The page was opened by `window.open` during the Connect
- *    flow.  Post a message back to the opener tab and close this tab.
- * 2. **Direct** – The user navigated here directly (e.g. popup was blocked
- *    and they clicked the fallback link).  Refresh upload data in-place and
- *    strip the query params.
+ *    flow. Post a message back to the opener tab and close this tab.
+ * 2. **Direct** – The user navigated here in the same window (e.g. opened
+ *    the auth URL in the same tab, or popup was blocked). Refresh upload
+ *    data in-place and strip the query params.
  *
  * Also listens for cross-tab messages from the popup path so the opener
  * tab can react without a full page reload.

--- a/frontend/src/pages/upload/setup/hooks/useGitHubOAuthCallback.ts
+++ b/frontend/src/pages/upload/setup/hooks/useGitHubOAuthCallback.ts
@@ -1,0 +1,80 @@
+import { useEffect } from "react";
+
+type Deps = {
+  searchParams: URLSearchParams;
+  setSearchParams: (
+    updater: (prev: URLSearchParams) => Record<string, string>,
+    opts?: { replace?: boolean },
+  ) => void;
+  hasValidUploadId: boolean;
+  refreshUpload: () => Promise<boolean>;
+  setActionError: (message: string | null) => void;
+};
+
+/**
+ * Handles the GitHub OAuth redirect that lands on the setup page.
+ *
+ * Two paths:
+ * 1. **Popup** – The page was opened by `window.open` during the Connect
+ *    flow.  Post a message back to the opener tab and close this tab.
+ * 2. **Direct** – The user navigated here directly (e.g. popup was blocked
+ *    and they clicked the fallback link).  Refresh upload data in-place and
+ *    strip the query params.
+ *
+ * Also listens for cross-tab messages from the popup path so the opener
+ * tab can react without a full page reload.
+ */
+export function useGitHubOAuthCallback({
+  searchParams,
+  setSearchParams,
+  hasValidUploadId,
+  refreshUpload,
+  setActionError,
+}: Deps) {
+  // Handle ?github=success|error from the redirect
+  useEffect(() => {
+    const status = searchParams.get("github");
+    if (!status) return;
+
+    if (status === "success") {
+      if (window.opener) {
+        window.opener.postMessage({ type: "github-auth-success" }, window.location.origin);
+        window.close();
+        return;
+      }
+      if (hasValidUploadId) void refreshUpload();
+    } else if (status === "error") {
+      if (window.opener) {
+        const msg = searchParams.get("message") ?? "GitHub authorization failed.";
+        window.opener.postMessage({ type: "github-auth-error", message: msg }, window.location.origin);
+        window.close();
+        return;
+      }
+      setActionError(searchParams.get("message") ?? "GitHub authorization failed.");
+    }
+
+    setSearchParams(
+      (prev) => {
+        const p = new URLSearchParams(prev);
+        p.delete("github");
+        p.delete("message");
+        return Object.fromEntries(p.entries());
+      },
+      { replace: true },
+    );
+  }, [searchParams, hasValidUploadId, refreshUpload, setActionError, setSearchParams]);
+
+  // Listen for postMessage from a popup tab
+  useEffect(() => {
+    function onMessage(event: MessageEvent) {
+      if (event.origin !== window.location.origin) return;
+      if (event.data?.type === "github-auth-success") {
+        void refreshUpload();
+      } else if (event.data?.type === "github-auth-error") {
+        setActionError(event.data.message ?? "GitHub authorization failed.");
+      }
+    }
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [refreshUpload, setActionError]);
+}

--- a/frontend/src/pages/upload/setup/hooks/useSetupFlow.ts
+++ b/frontend/src/pages/upload/setup/hooks/useSetupFlow.ts
@@ -389,6 +389,7 @@ export function useSetupFlow(uploadIdParam: string): SetupFlowResult {
     expandedProjectNames,
     onToggleProject,
     clearActionError,
+    setActionError,
     refreshUpload,
     actions,
   };

--- a/frontend/src/pages/upload/setup/types.ts
+++ b/frontend/src/pages/upload/setup/types.ts
@@ -65,6 +65,7 @@ export type SetupFlowResult = {
   expandedProjectNames: string[];
   onToggleProject: (projectName: string) => void;
   clearActionError: () => void;
+  setActionError: (message: string | null) => void;
   refreshUpload: () => Promise<boolean>;
   actions: {
     getProjectFiles: (projectKey: number) => Promise<UploadProjectFilesRecord | null>;

--- a/src/api/routes/github.py
+++ b/src/api/routes/github.py
@@ -1,4 +1,8 @@
+import os
+from urllib.parse import urlencode
+
 from fastapi import APIRouter, Depends, Query, HTTPException
+from fastapi.responses import RedirectResponse
 from sqlite3 import Connection
 
 from src.api.dependencies import get_current_user_id, get_db
@@ -14,27 +18,32 @@ from src.services.uploads_service import get_upload_status
 router = APIRouter(tags=["github"])
 
 
+_FRONTEND_BASE_URL = os.getenv("FRONTEND_BASE_URL", "http://localhost:5173")
+
+
 @router.get("/auth/github/callback")
 def get_github_callback(
     code: str = Query(...),
     state: str = Query(None),
     conn: Connection = Depends(get_db),
 ):
-    """OAuth callback endpoint for GitHub."""
+    """OAuth callback endpoint for GitHub. Redirects to frontend setup page on success."""
     try:
         result = github_handle_callback(conn, code, state)
-        return {
-            "success": True,
-            "message": "GitHub connected successfully",
-            "data": result
-        }
-    except HTTPException:
-        raise
+        upload_id = result.get("upload_id")
+        params = {"github": "success"}
+        if upload_id is not None:
+            params["uploadId"] = str(upload_id)
+        redirect_url = f"{_FRONTEND_BASE_URL}/upload/setup?{urlencode(params)}"
+        return RedirectResponse(url=redirect_url, status_code=302)
+    except HTTPException as exc:
+        params = {"github": "error", "message": str(exc.detail)}
+        redirect_url = f"{_FRONTEND_BASE_URL}/upload/setup?{urlencode(params)}"
+        return RedirectResponse(url=redirect_url, status_code=302)
     except Exception as e:
-        raise HTTPException(
-            status_code=500,
-            detail=f"Failed to complete GitHub authorization: {str(e)}"
-        )
+        params = {"github": "error", "message": str(e)}
+        redirect_url = f"{_FRONTEND_BASE_URL}/upload/setup?{urlencode(params)}"
+        return RedirectResponse(url=redirect_url, status_code=302)
 
 
 @router.post("/projects/upload/{upload_id}/projects/{project}/github/start", response_model=ApiResponse[GitHubStartResponse])

--- a/src/services/github_service.py
+++ b/src/services/github_service.py
@@ -4,8 +4,8 @@ from typing import Optional, Dict, Any
 from fastapi import HTTPException
 
 from src.integrations.github.github_web_oauth import generate_github_auth_url, exchange_code_for_token
-from src.integrations.github.token_store import get_github_token, save_github_token
-from src.integrations.github.github_api import list_user_repos
+from src.integrations.github.token_store import get_github_token, save_github_token, revoke_github_token
+from src.integrations.github.github_api import list_user_repos, gh_get
 from src.integrations.github.link_repo import get_github_repo_metadata
 from src.db.github_repositories import save_project_repo
 from src.db.uploads import get_upload_by_id, patch_upload_state
@@ -32,17 +32,23 @@ def github_start_connection(
         )
         return {"auth_url": None, "connected": False}
     
-    if get_github_token(conn, user_id):
-        patch_upload_state(conn, upload_id, {
-            f"github_{project_name}": {"connected": True}
-        })
-        merge_project_run_inputs(
-            conn,
-            upload_id,
-            project_name,
-            {"integrations": {"github": {"state": "connected"}}},
-        )
-        return {"auth_url": None, "connected": True}
+    token = get_github_token(conn, user_id)
+    if token:
+        # Verify the token is still valid before trusting it
+        check = gh_get(token, "https://api.github.com/user", retries=1, delay=0)
+        if isinstance(check, dict) and check.get("login"):
+            patch_upload_state(conn, upload_id, {
+                f"github_{project_name}": {"connected": True}
+            })
+            merge_project_run_inputs(
+                conn,
+                upload_id,
+                project_name,
+                {"integrations": {"github": {"state": "connected"}}},
+            )
+            return {"auth_url": None, "connected": True}
+        # Token is stale — clear it and fall through to new auth
+        revoke_github_token(conn, user_id)
     
     oauth_state = secrets.token_urlsafe(32)
     

--- a/tests/api/test_github_api_endpoints.py
+++ b/tests/api/test_github_api_endpoints.py
@@ -46,14 +46,37 @@ def test_github_start_connect_now_true_generates_url(mock_auth_url, mock_get_tok
     assert res.json()["data"]["auth_url"] == "https://github.com/login/oauth/authorize?state=abc123"
     mock_auth_url.assert_called_once()
 
+@patch("src.services.github_service.gh_get")
 @patch("src.services.github_service.get_github_token")
-def test_github_start_already_connected(mock_get_token, client, auth_headers, seed_conn):
+def test_github_start_already_connected(mock_get_token, mock_gh_get, client, auth_headers, seed_conn):
     upload_id = _create_test_upload(seed_conn, 1)
     mock_get_token.return_value = "existing_token"
+    mock_gh_get.return_value = {"login": "testuser"}
     res = client.post(f"/projects/upload/{upload_id}/projects/TestProject/github/start", headers=auth_headers, json={"connect_now": True})
     assert res.status_code == 200
     assert res.json()["success"] is True
     assert res.json()["data"]["auth_url"] is None
+    mock_gh_get.assert_called_once()
+
+
+@patch("src.services.github_service.revoke_github_token")
+@patch("src.services.github_service.generate_github_auth_url")
+@patch("src.services.github_service.gh_get")
+@patch("src.services.github_service.get_github_token")
+def test_github_start_stale_token_revokes_and_returns_auth_url(
+    mock_get_token, mock_gh_get, mock_auth_url, mock_revoke, client, auth_headers, seed_conn
+):
+    """When the stored token fails validation (bad/expired), revoke it and return auth_url."""
+    upload_id = _create_test_upload(seed_conn, 1)
+    mock_get_token.return_value = "stale_token"
+    mock_gh_get.return_value = {}  # Invalid response (e.g. Bad credentials)
+    mock_auth_url.return_value = "https://github.com/login/oauth/authorize?state=xyz"
+    res = client.post(f"/projects/upload/{upload_id}/projects/TestProject/github/start", headers=auth_headers, json={"connect_now": True})
+    assert res.status_code == 200
+    assert res.json()["success"] is True
+    assert res.json()["data"]["auth_url"] == "https://github.com/login/oauth/authorize?state=xyz"
+    mock_revoke.assert_called_once()
+    mock_auth_url.assert_called_once()
 
 def test_github_start_upload_not_found(client, auth_headers):
     res = client.post("/projects/upload/999/projects/TestProject/github/start", headers=auth_headers, json={"connect_now": True})
@@ -65,9 +88,10 @@ def test_github_callback_success(mock_save_token, mock_exchange, client, seed_co
     upload_id = _create_test_upload(seed_conn, 1)
     _setup_oauth_state(seed_conn, upload_id, "test_state_123")
     mock_exchange.return_value = {"access_token": "token123"}
-    res = client.get("/auth/github/callback?code=abc123&state=test_state_123")
-    assert res.status_code == 200
-    assert res.json()["success"] is True
+    res = client.get("/auth/github/callback?code=abc123&state=test_state_123", follow_redirects=False)
+    assert res.status_code == 302
+    assert "github=success" in res.headers["location"]
+    assert "uploadId" in res.headers["location"]
     mock_save_token.assert_called_once()
     call_args = mock_save_token.call_args[0]
     assert call_args[1] == 1
@@ -81,9 +105,10 @@ def test_github_callback_invalid_state(client, seed_conn):
     _create_test_upload(seed_conn, 1)
     with patch("src.services.github_service._find_upload_by_oauth_state") as mock_find:
         mock_find.return_value = None
-        res = client.get("/auth/github/callback?code=abc123&state=invalid")
-        assert res.status_code == 400
-        assert "Invalid OAuth state" in res.json()["detail"]
+        res = client.get("/auth/github/callback?code=abc123&state=invalid", follow_redirects=False)
+    assert res.status_code == 302
+    assert "github=error" in res.headers["location"]
+    assert "Invalid OAuth state" in res.headers["location"] or "message=" in res.headers["location"]
 
 @patch("src.services.github_service.get_github_token")
 @patch("src.services.github_service.list_user_repos")


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

This PR works off PR #616, so the base branch needs to be changed to main once that PR is merged. I did this because the UI is changed so much in that PR that I did not want to work on the soon-to-be old UI.

Improves and fixes the GitHub integration flow on the upload setup page: OAuth, repo selection, and token handling.

As discussed via Discord, you can either create your own GitHub project for OAuth or you can update the .env files to reflect the required GitHub variables. If you do not want to set up your own project, please contact me and I will send you the information required to connect to GitHub (e.g., the secret), I'll likely reply quite quickly.

### Changes
**OAuth flow**
- Connect GitHub opens a new tab only when the backend returns an auth URL (no pre-opened blank tab).
- After authorization, the popup closes automatically and posts a message to the opener tab to refresh.
- Removed the fallback "Open GitHub Authorization" link and simplified the flow.

**UI**
- Step-based flow: Step 1 Connect, Step 2 Load repos, Step 3 Select & link.
- Only the relevant buttons are shown for each step, with clearer primary/secondary styling.
- Repo dropdown uses a portal so it isn’t clipped by parents and opens above the input with correct arrow direction.
- Dropdown arrow is clickable and shows a pointer cursor.
- Added loading circle when loading repositories, so the screen does not appear frozen
- Scroll inside the repo dropdown no longer closes it; only outside click/scroll closes it.

**Bug fixes**
- Token validation: backend verifies the stored GitHub token before trusting it; invalid tokens are revoked and the user is prompted to re-authorize.
- Repos loading spinner no longer stays visible forever (effect dependency cleanup).

**Refactor**
- New components: `RepoSearchDropdown`, `GitHubIntegrationSection`.
- New hook: `useGitHubOAuthCallback` for OAuth callback handling.
- `CodeSetupSection` simplified to compose the new components.

**Documentation**
- Updated `github_integration.md` (token validation), `API.md` (Start GitHub Connection), `README.md` (FRONTEND_BASE_URL, OAuth setup, callback redirect).


**Closes:** #624 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [x] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- Manual: OAuth flow (popup + direct navigation), Connect/Skip/Load repos, repo search and selection, Link repository, popup-blocked message
- Ran `pytest` from main root folder, all tests pass
- Ran `npm run test:run` from frontend folder, all are passing
- Automated (specific tests checked): `RepoSearchDropdown` (filtering, onSelect, disabled, no-match), `GitHubIntegrationSection` (steps, loading, buttons, messages), `test_github_api_endpoints` (already connected, stale token revoke)

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

First steps shown upon GitHub Integration:
<img width="800" height="271" alt="image" src="https://github.com/user-attachments/assets/5e5884e6-10eb-46f4-8e78-ee42ffb4692f" />

After clicking Connect GitHub and repos are done loading:
<img width="787" height="277" alt="image" src="https://github.com/user-attachments/assets/47753d5e-8a4d-494e-b46c-55596ec48db5" />

After choosing and linking a repo:
<img width="829" height="343" alt="image" src="https://github.com/user-attachments/assets/8cf65130-3375-4be9-8d69-95d7ecdc4fff" />

</details>