### PR TITLE
Project Heatmap Bug

### DIFF
--- a/frontend/src/components/insights/tabs/Projects/ProjectSkillHeatmapTab.tsx
+++ b/frontend/src/components/insights/tabs/Projects/ProjectSkillHeatmapTab.tsx
@@ -74,7 +74,8 @@ export default function ProjectSkillHeatmapTab() {
 
   if (!data) return null;
 
-  const maxVal = data.matrix.length > 0 ? Math.max(...data.matrix.flat(), 1) : 1;
+  // Use min 4 so that 1 project = light shade, not dark (when max is 1, value/max would be 100%)
+  const maxVal = data.matrix.length > 0 ? Math.max(...data.matrix.flat(), 4) : 4;
   const hasData = data.matrix.length > 0 && data.col_labels.length > 0;
 
   const gridTemplate = `${LABEL_COL} repeat(${data.col_labels.length}, ${CELL_SIZE})`;


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

The base branch needs to be changed to main once PR #616 is merged.

Bug fix: The Project Heatmap was showing the darkest color for cells where only one project contributed.

Root cause: Color intensity was value / maxVal. When every cell had at most one project, maxVal was 1, so 1/1 = 100% and single-project cells were painted with the darkest shade.

Change: Set a minimum maxVal of 4 so that:

1 project → light shade (25%)
2 projects → medium-light (50%)
3 projects → medium (75%)
4+ projects → darkest shade
If the real max is above 4, the relative scaling stays the same; the fix only affects cases where the max is 1–3.

**Closes:** #643 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- Ran `pytest tests`, all are passing
- Ran frontend tests, all  are passing
- Manually checked heatmap now properly changes cell colours as more and less projects contribute

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

<img width="1147" height="465" alt="image" src="https://github.com/user-attachments/assets/2dc8e83d-6c23-4a4f-8dd0-ad5f7be2fb79" />

</details>